### PR TITLE
JSONSerialization: Improve number parsing for JSON

### DIFF
--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -398,11 +398,15 @@
 		B910957B1EEF237800A71930 /* NSString-UTF16-BE-data.txt in Resources */ = {isa = PBXBuildFile; fileRef = B91095791EEF237800A71930 /* NSString-UTF16-BE-data.txt */; };
 		B91161AA2429860900BD2907 /* DataURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91161A82429857D00BD2907 /* DataURLProtocol.swift */; };
 		B91161AD242A363900BD2907 /* TestDataURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91161AB242A350D00BD2907 /* TestDataURLProtocol.swift */; };
+		B9292465258E75DD00E24DA5 /* JSONNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9292464258E75DD00E24DA5 /* JSONNumber.swift */; };
+		B929246F258E772B00E24DA5 /* CMakeLists.txt in Resources */ = {isa = PBXBuildFile; fileRef = B929246E258E772B00E24DA5 /* CMakeLists.txt */; };
 		B933A79E1F3055F700FE6846 /* NSString-UTF32-BE-data.txt in Resources */ = {isa = PBXBuildFile; fileRef = B933A79C1F3055F600FE6846 /* NSString-UTF32-BE-data.txt */; };
 		B933A79F1F3055F700FE6846 /* NSString-UTF32-LE-data.txt in Resources */ = {isa = PBXBuildFile; fileRef = B933A79D1F3055F600FE6846 /* NSString-UTF32-LE-data.txt */; };
 		B940492D223B146800FB4384 /* TestProgressFraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B940492C223B146800FB4384 /* TestProgressFraction.swift */; };
 		B94B063C23FDE2BD00B244E8 /* SwiftFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5D885D1BBC938800234F36 /* SwiftFoundation.framework */; };
 		B951B5EC1F4E2A2000D8B332 /* TestNSLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B951B5EB1F4E2A2000D8B332 /* TestNSLock.swift */; };
+		B959016E25970BE300CACAE3 /* TestJSONNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = B959016D25970BE300CACAE3 /* TestJSONNumber.swift */; };
+		B95901922597102000CACAE3 /* CMakeLists.txt in Resources */ = {isa = PBXBuildFile; fileRef = B95901912597102000CACAE3 /* CMakeLists.txt */; };
 		B95FC97622B84B0A005DEA0A /* TestNSSortDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152EF3932283457B001E1269 /* TestNSSortDescriptor.swift */; };
 		B96C10F625BA1EFD00985A32 /* NSURLComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96C10F525BA1EFD00985A32 /* NSURLComponents.swift */; };
 		B96C110025BA20A600985A32 /* NSURLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96C10FF25BA20A600985A32 /* NSURLQueryItem.swift */; };
@@ -1109,10 +1113,14 @@
 		B91095791EEF237800A71930 /* NSString-UTF16-BE-data.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "NSString-UTF16-BE-data.txt"; sourceTree = "<group>"; };
 		B91161A82429857D00BD2907 /* DataURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataURLProtocol.swift; sourceTree = "<group>"; };
 		B91161AB242A350D00BD2907 /* TestDataURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDataURLProtocol.swift; sourceTree = "<group>"; };
+		B9292464258E75DD00E24DA5 /* JSONNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONNumber.swift; sourceTree = "<group>"; };
+		B929246E258E772B00E24DA5 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		B933A79C1F3055F600FE6846 /* NSString-UTF32-BE-data.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "NSString-UTF32-BE-data.txt"; sourceTree = "<group>"; };
 		B933A79D1F3055F600FE6846 /* NSString-UTF32-LE-data.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "NSString-UTF32-LE-data.txt"; sourceTree = "<group>"; };
 		B940492C223B146800FB4384 /* TestProgressFraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProgressFraction.swift; sourceTree = "<group>"; };
 		B951B5EB1F4E2A2000D8B332 /* TestNSLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNSLock.swift; sourceTree = "<group>"; };
+		B959016D25970BE300CACAE3 /* TestJSONNumber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestJSONNumber.swift; sourceTree = "<group>"; };
+		B95901912597102000CACAE3 /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		B95FC97222AF0050005DEA0A /* SwiftXCTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftXCTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B95FC97422AF051B005DEA0A /* xcode-build.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = "xcode-build.sh"; sourceTree = "<group>"; };
 		B96C10F525BA1EFD00985A32 /* NSURLComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSURLComponents.swift; sourceTree = "<group>"; };
@@ -1777,6 +1785,7 @@
 		F023071023F0976B0023DBEC /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				B95901912597102000CACAE3 /* CMakeLists.txt */,
 				155D3BBB22401D1100B0D38E /* FixtureValues.swift */,
 				616068F2225DE5C2004FCC54 /* FTPServer.swift */,
 				1520469A1D8AEABE00D02E36 /* HTTPServer.swift */,
@@ -1819,6 +1828,7 @@
 				EA66F63E1BF1619600136161 /* TestIndexSet.swift */,
 				63DCE9D31EAA432400E9CB02 /* TestISO8601DateFormatter.swift */,
 				3EA9D66F1EF0532D00B362D6 /* TestJSONEncoder.swift */,
+				B959016D25970BE300CACAE3 /* TestJSONNumber.swift */,
 				5EB6A15C1C188FC40037DCB8 /* TestJSONSerialization.swift */,
 				BD8042151E09857800487EB8 /* TestLengthFormatter.swift */,
 				A058C2011E529CF100B07AA1 /* TestMassFormatter.swift */,
@@ -2042,6 +2052,7 @@
 		F023072323F0A6E50023DBEC /* Foundation */ = {
 			isa = PBXGroup;
 			children = (
+				B929246E258E772B00E24DA5 /* CMakeLists.txt */,
 				F023072523F0B4890023DBEC /* Headers */,
 				F023072423F0B4140023DBEC /* Resources */,
 				EADE0B4D1BD09E0800C49C64 /* AffineTransform.swift */,
@@ -2081,6 +2092,7 @@
 				5B8BA1611D0B773A00938C27 /* IndexSet.swift */,
 				63DCE9D11EAA430100E9CB02 /* ISO8601DateFormatter.swift */,
 				3EDCE5091EF04D8100C2EC04 /* JSONEncoder.swift */,
+				B9292464258E75DD00E24DA5 /* JSONNumber.swift */,
 				EADE0B641BD15DFF00C49C64 /* JSONSerialization.swift */,
 				49D55FA025E84FE5007BD3B3 /* JSONSerialization+Parser.swift */,
 				EADE0B661BD15DFF00C49C64 /* LengthFormatter.swift */,
@@ -2100,6 +2112,7 @@
 				5BDC3FCD1BCF17D300ED97BB /* NSCFDictionary.swift */,
 				5BDC3FCF1BCF17E600ED97BB /* NSCFSet.swift */,
 				5BDC3FCB1BCF177E00ED97BB /* NSCFString.swift */,
+				15CA750924F8336A007DF6C1 /* NSCFTypeShims.swift */,
 				5BDC3F311BCC5DCB00ED97BB /* NSCharacterSet.swift */,
 				5BDC3F321BCC5DCB00ED97BB /* NSCoder.swift */,
 				EADE0B551BD15DFF00C49C64 /* NSComparisonPredicate.swift */,
@@ -2122,7 +2135,6 @@
 				D3BCEB9F1C2F6DDB00295652 /* NSKeyedCoderOldStyleArray.swift */,
 				D39A14001C2D6E0A00295652 /* NSKeyedUnarchiver.swift */,
 				5BDC3F3B1BCC5DCB00ED97BB /* NSLocale.swift */,
-				15CA750924F8336A007DF6C1 /* NSCFTypeShims.swift */,
 				5BDC3F3C1BCC5DCB00ED97BB /* NSLock.swift */,
 				D3BCEB9D1C2EDED800295652 /* NSLog.swift */,
 				5BECBA391D1CAE9A00B39B1F /* NSMeasurement.swift */,
@@ -2713,6 +2725,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B929246F258E772B00E24DA5 /* CMakeLists.txt in Resources */,
 				F023072623F0B4890023DBEC /* Headers in Resources */,
 				B983E32C23F0C69600D9C402 /* Docs in Resources */,
 				B983E32E23F0C6E200D9C402 /* CONTRIBUTING.md in Resources */,
@@ -2743,6 +2756,7 @@
 				D3A597F71C3415CC00295652 /* NSKeyedUnarchiver-ArrayTest.plist in Resources */,
 				CE19A88C1C23AA2300B4CB6A /* NSStringTestData.txt in Resources */,
 				E1A03F361C4828650023AF4D /* PropertyList-1.0.dtd in Resources */,
+				B95901922597102000CACAE3 /* CMakeLists.txt in Resources */,
 				E1A3726F1C31EBFB0023AF4D /* NSXMLDocumentTestData.xml in Resources */,
 				E1A03F381C482C730023AF4D /* NSXMLDTDTestData.xml in Resources */,
 				D3A598041C349E6A00295652 /* NSKeyedUnarchiver-OrderedSetTest.plist in Resources */,
@@ -2888,6 +2902,7 @@
 				5BF7AEC01BCD51F9008F214A /* NSUUID.swift in Sources */,
 				5BF7AEB01BCD51F9008F214A /* NSLocale.swift in Sources */,
 				EADE0BA31BD15E0000C49C64 /* NSKeyedArchiver.swift in Sources */,
+				B9292465258E75DD00E24DA5 /* JSONNumber.swift in Sources */,
 				5BF7AEAD1BCD51F9008F214A /* NSError.swift in Sources */,
 				EADE0BB61BD15E0000C49C64 /* NSSortDescriptor.swift in Sources */,
 				5BF7AEA41BCD51F9008F214A /* Bundle.swift in Sources */,
@@ -3104,6 +3119,7 @@
 				90E645DF1E4C89A400D0D47C /* TestNSCache.swift in Sources */,
 				5B13B34A1C582D4C00651CE2 /* TestURL.swift in Sources */,
 				EA54A6FB1DB16D53009E0809 /* TestObjCRuntime.swift in Sources */,
+				B959016E25970BE300CACAE3 /* TestJSONNumber.swift in Sources */,
 				BB3D7558208A1E500085CFDC /* Imports.swift in Sources */,
 				5B13B34D1C582D4C00651CE2 /* TestNSUUID.swift in Sources */,
 				15F10CDC218909BF00D88114 /* TestNSCalendar.swift in Sources */,

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(Foundation
   IndexSet.swift
   ISO8601DateFormatter.swift
   JSONEncoder.swift
+  JSONNumber.swift
   JSONSerialization.swift
   JSONSerialization+Parser.swift
   LengthFormatter.swift

--- a/Sources/Foundation/JSONNumber.swift
+++ b/Sources/Foundation/JSONNumber.swift
@@ -1,0 +1,668 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+// _JSONNumber - value type storing a parsed and validated JSON Number
+// _NSJSONNumber - internal subclass of NSNumber wrap _JSONNumber
+
+// The underlying problem with parsing numbers in JSON is that a numeric type
+// (Int64, UInt64, Double or Decimal) is chosen by JSONSerialization at parse
+// time to store in an NSNumber or NSDecimalNumber. However if later on the
+// value is extracted as a different type by JSONDecoder via bridging, then this
+// can lead to an incorrect value.
+//
+// This occurs because of loss of accuracy when converting a Decimal to a Double
+// and vice-versa, eg:
+//
+// let double = NSNumber(value: Double("46.984765")!)
+// print(double.doubleValue)        -> 46.984765
+// print(double.decimalValue)       -> 46.98476500000001024
+//
+// let nsdecimal = NSDecimalNumber(decimal: Decimal(string: "46.984765")!)
+// print(nsdecimal.decimalValue)    -> 46.984765
+// print(nsdecimal.doubleValue)     -> 46.984764999999996
+//
+// The method used by _JSONNumber is to hold the value as a String and delay
+// parsing until the value is needed. At this point it is known if the value
+// should be parsed as a Decimal or a Double/Float. Although the parsing step is
+// repeated if the value is required again, in general JSONDecoder will only
+// require the value once when it converts it into the decoded struct.
+//
+// Parsing
+// -------
+//
+// The initialisation step does the usual JSON number validation according to
+// the specification on http://json.org.
+//
+// As part of the validation the digits are parsed into a UInt64 as integer
+// parsing is a simpler case then floating point parsing.
+// This allows determining if the input is an integer and also allow parsing of
+// integer values expressed with an exponent eg "1e3" (1000) or "0.12e6" (120000).
+// This is to match the previous behaviour where although Int.init() would not
+// parse these values, they would still bridge to integer types because the input
+// would be parsed by the Double or Decimal parser.
+//
+// Integers
+// --------
+//
+// The integer value is stored in a property to avoid reparsing it and allowing
+// faster results for the computed properties that return an integer. This also
+// allows determining if the original input is an integer.
+//
+// Only two properties are stored:
+// jsonString: String
+//
+// - Stores the original (validated) input that can be reparsed for different
+//   floating point types as required.
+//
+// _integerMagnitude: UInt64
+//
+// - Stores the integer magnitude if the parsed input is an integer.
+//   The sign is held in the first character of jsonString if the value is negative.
+//   Positive JSON numbers do not store a sign.
+//
+//   If the input is not an integer then _integerMagnitude == 0. The integer magnitude
+//   zero is special cased where _integerMagnitude == 0 and jsonString == "0" or "-0".
+//
+//   _integerMagnitude is not stored as a UInt64? as the extra byte for the optional flag
+//   makes the size of the properties increase from 40 to 41 bytes. However because the class
+//   is allocated on the heap and malloc() usually uses a minium multiple of 8 bytes for memory
+//   regions, the allocated size would be 48 bytes. This helps reduce the memory usage.
+//
+// Bridging
+// --------
+//
+// Currently bridging from NSNumber to a number type eg Int uses the Int.init?(exactly:)
+// initialiser as below:
+//
+// public init?(exactly number: NSNumber) {
+//    let value = number.intValue
+//    guard NSNumber(value: value) == number else { return nil }
+//    self = value
+// }
+//
+// The problem with this is that .intValue never fails even if the underlying value will
+// not fit into an Int type eg 1.2. This means that a second NSNumber must be created
+// just so that an equality check can be performed against the original input.
+// Both of these operations involve overhead including a heap allocation for the NSNumber.
+//
+// _NSJSONNumber provides extra properties to help with bridging, named exactlyInt?,
+// exactlyDouble? etc which return either the JSON number value as that type or nil
+// if the type will not hold it exactly.
+// Integers & Boolean are computed from the _integerMagnitude and isNegative properties.
+// Floating point and Decimal are parsed using the type's initialiser which returns nil
+// if the value will not fit into that type. nil is also returned for parsed values that
+// are not finite. This allows the initialiser to be simplified to:
+//
+// internal init?(exactly number: _NSJSONNumber) {
+//     guard let value = number.exactlyInt else { return nil }
+//         self = value
+//     }
+// }
+//
+
+internal struct _JSONNumber: Equatable, CustomStringConvertible, CustomDebugStringConvertible {
+
+    fileprivate let jsonString: String
+    fileprivate let _integerMagnitude: UInt64
+    // Magnitude of integer value, the sign is held in the first character of jsonString (if negative)
+    // nil == not an integer
+    fileprivate var integerMagnitude: UInt64? {
+        if _integerMagnitude > 0 { return _integerMagnitude }
+        if jsonString == "0" || jsonString == "-0" { return 0 }
+        return nil
+    }
+
+    fileprivate var isNegative: Bool { jsonString.first! == "-" }
+
+    var description: String { jsonString }
+    var debugDescription: String { jsonString }
+
+    internal init(jsonString: String, integerMagnitude: UInt64?, exponent: Int) {
+        precondition(jsonString.count > 0)
+
+        guard var integerMagnitude = integerMagnitude else {
+            self.jsonString = jsonString
+            self._integerMagnitude = 0
+            return
+        }
+
+        if integerMagnitude == 0 {
+            let isNegative = jsonString.first! == "-"
+            self.jsonString = isNegative ? "-0" : "0"
+        } else {
+            self.jsonString = jsonString
+            // Normalise the exponent
+            switch exponent {
+                case 0: break
+                case -19...19:
+                    let multiplier = (1...exponent.magnitude).reduce(into: UInt64(1)) { (result, _) in
+                        result = result &* 10   // exponent has already been range checked to avoid overflow.
+                    }
+
+                    if exponent > 0 {
+                        let (newValue, overflow) = integerMagnitude.multipliedReportingOverflow(by: multiplier)
+                        integerMagnitude = overflow ? 0 : newValue
+                    } else {
+                        let (quotent, remainder) = multiplier.dividingFullWidth((0, integerMagnitude))
+                        integerMagnitude = (remainder == 0) ? quotent : 0
+                    }
+                default:
+                // The exponent is too large or small for the parsed integer to be stored in a UInt64.
+                integerMagnitude = 0
+            }
+        }
+        self._integerMagnitude = integerMagnitude
+
+    }
+
+    fileprivate init(jsonString: String, _integerMagnitude: UInt64) {
+        self.jsonString = jsonString
+        self._integerMagnitude = _integerMagnitude
+    }
+
+    // Extra methods used for bridging. By returning only exact values or nil otherwise, bridging can be
+    // simplified without an intermediate NSNumber needing to be created for an equality check.
+
+    internal var exactlyDecimal: Decimal? {
+        if let magnitude = integerMagnitude {
+            var d = Decimal(magnitude)
+            if isNegative {
+                d.negate()
+            }
+            return d
+        }
+        return Decimal(string: jsonString)
+    }
+
+    // 0 = false, 1 = true, all else is nil
+    internal var exactlyBool: Bool? {
+        switch self.exactlyUInt {
+            case 0: return false
+            case 1: return true
+            default: return nil
+        }
+    }
+
+#if !os(macOS)
+    internal var exactlyFloat16: Float16? {
+        guard let _floatValue = Float16(jsonString), _floatValue.isFinite else { return nil }
+        return _floatValue
+    }
+#endif
+
+    internal var exactlyFloat: Float? {
+        guard let _floatValue = Float(jsonString), _floatValue.isFinite else { return nil }
+        return _floatValue
+    }
+
+    internal var exactlyDouble: Double? {
+        if let value = Double(jsonString), value.isFinite {
+            return value
+        } else {
+            return nil
+        }
+    }
+
+#if arch(x86_64) || arch(i386)
+    internal var exactlyFloat80: Float80? {
+        guard let _floatValue = Float80(jsonString), _floatValue.isFinite else { return nil }
+        return _floatValue
+    }
+#endif
+
+    internal var exactlyUInt64: UInt64? {
+        guard let _integerMagnitude = self.integerMagnitude else { return nil }
+        if isNegative && _integerMagnitude > 0 { return nil }  // Allow -0 to return 0
+        return _integerMagnitude
+    }
+
+    internal var exactlyUInt: UInt? {
+        if let uint64Value = exactlyUInt64, uint64Value <= UInt64(UInt.max) {
+            return UInt(uint64Value)
+        } else {
+            return nil
+        }
+    }
+
+    internal var exactlyUInt32: UInt32? {
+        if let uint64Value = exactlyUInt64, uint64Value <= UInt64(UInt32.max) {
+            return UInt32(uint64Value)
+        } else {
+            return nil
+        }
+    }
+
+    internal var exactlyUInt16: UInt16? {
+        if let uint64Value = exactlyUInt64, uint64Value <= UInt64(UInt16.max) {
+            return UInt16(uint64Value)
+        } else {
+            return nil
+        }
+    }
+
+    internal var exactlyUInt8: UInt8? {
+        if let uint64Value = exactlyUInt64, uint64Value <= UInt64(UInt8.max) {
+            return UInt8(uint64Value)
+        } else {
+            return nil
+        }
+    }
+
+    internal var exactlyInt64: Int64? {
+        guard let _integerMagnitude = self.integerMagnitude else { return nil }
+        if isNegative {
+            if _integerMagnitude == Int64.min.magnitude { return Int64.min }
+            if _integerMagnitude < Int64.min.magnitude { return -1 * Int64(_integerMagnitude) }
+        } else {
+            if _integerMagnitude <= Int64.max.magnitude { return Int64(_integerMagnitude) }
+        }
+        return nil
+    }
+
+    internal var exactlyInt: Int? {
+        guard let _integerMagnitude = self.integerMagnitude else { return nil }
+        if isNegative {
+            if _integerMagnitude == UInt64(Int.min.magnitude) { return Int.min }
+            if _integerMagnitude < UInt64(Int.min.magnitude) { return -1 * Int(_integerMagnitude) }
+        } else {
+            if _integerMagnitude <= UInt64(Int.max.magnitude) { return Int(_integerMagnitude) }
+        }
+        return nil
+    }
+
+    internal var exactlyInt32: Int32? {
+        guard let _integerMagnitude = self.integerMagnitude else { return nil }
+        if isNegative {
+            if _integerMagnitude == UInt64(Int32.min.magnitude) { return Int32.min }
+            if _integerMagnitude < UInt64(Int32.min.magnitude) { return -1 * Int32(_integerMagnitude) }
+        } else {
+            if _integerMagnitude <= UInt64(Int32.max.magnitude) { return Int32(_integerMagnitude) }
+        }
+        return nil
+    }
+
+    internal var exactlyInt16: Int16? {
+        guard let _integerMagnitude = self.integerMagnitude else { return nil }
+        if isNegative {
+            if _integerMagnitude == UInt64(Int16.min.magnitude) { return Int16.min }
+            if _integerMagnitude < UInt64(Int16.min.magnitude) { return -1 * Int16(_integerMagnitude) }
+        } else {
+            if _integerMagnitude <= UInt64(Int16.max.magnitude) { return Int16(_integerMagnitude) }
+        }
+        return nil
+    }
+
+    internal var exactlyInt8: Int8? {
+        guard let _integerMagnitude = self.integerMagnitude else { return nil }
+        if isNegative {
+            if _integerMagnitude == UInt64(Int8.min.magnitude) { return Int8.min }
+            if _integerMagnitude < UInt64(Int8.min.magnitude) { return -1 * Int8(_integerMagnitude) }
+        } else {
+            if _integerMagnitude <= UInt64(Int8.max.magnitude) { return Int8(_integerMagnitude) }
+        }
+        return nil
+    }
+}
+
+internal final class _NSJSONNumber: NSNumber {
+    internal let jsonNumber: _JSONNumber
+    override var description: String { return jsonNumber.jsonString }
+    override var stringValue: String { return jsonNumber.jsonString }
+
+    init(jsonNumber: _JSONNumber) {
+        self.jsonNumber = jsonNumber
+    }
+
+    internal required convenience init(bytes buffer: UnsafeRawPointer, objCType: UnsafePointer<Int8>) {
+        fatalError("init(bytes:objCType:) has not been implemented")
+    }
+
+    internal required convenience init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    internal required convenience init(booleanLiteral value: Bool) {
+        self.init(value: value)
+    }
+
+    internal required convenience init(floatLiteral value: Double) {
+        self.init(value: value)
+    }
+
+    internal required convenience init(integerLiteral value: Int) {
+        self.init(value: value)
+    }
+
+    internal init(value: Bool) {
+        self.jsonNumber = _JSONNumber(jsonString: value ? "1" : "0", _integerMagnitude: value ? 1 : 0)
+    }
+
+#if !os(macOS)
+    internal init(value: Float16) {
+        precondition(value.isFinite)
+
+        let jsonString: String
+        let _integerMagnitude: UInt64
+
+        if value.isZero {
+            _integerMagnitude = 0
+            jsonString = (value.sign == .plus) ? "0" : "-0"
+        } else {
+            let u = UInt64(value.magnitude)
+            if Float16(u) == value {
+                _integerMagnitude = u
+            } else {
+                _integerMagnitude = 0
+            }
+            jsonString = value.description
+        }
+        self.jsonNumber = _JSONNumber(jsonString: jsonString, _integerMagnitude: _integerMagnitude)
+    }
+#endif
+
+    internal init(value: Float) {
+        precondition(value.isFinite)
+
+        let jsonString: String
+        let _integerMagnitude: UInt64
+
+        if value.isZero {
+            _integerMagnitude = 0
+            jsonString = (value.sign == .plus) ? "0" : "-0"
+        } else {
+            let u = UInt64(value.magnitude)
+            if Float(u) == value {
+                _integerMagnitude = u
+            } else {
+                _integerMagnitude = 0
+            }
+            jsonString = value.description
+        }
+        self.jsonNumber = _JSONNumber(jsonString: jsonString, _integerMagnitude: _integerMagnitude)
+    }
+
+    internal init(value: Double) {
+        precondition(value.isFinite)
+
+        let jsonString: String
+        let _integerMagnitude: UInt64
+        if value.isZero {
+            _integerMagnitude = 0
+            jsonString = (value.sign == .plus) ? "0" : "-0"
+        } else {
+            let u = UInt64(value.magnitude)
+            if Double(u) == value {
+                _integerMagnitude = u
+            } else {
+                _integerMagnitude = 0
+            }
+            jsonString = value.description
+        }
+        self.jsonNumber = _JSONNumber(jsonString: jsonString, _integerMagnitude: _integerMagnitude)
+    }
+
+#if arch(x86_64) || arch(i386)
+    internal init(value: Float80) {
+        precondition(value.isFinite)
+
+        let jsonString: String
+        let _integerMagnitude: UInt64
+
+        if value.isZero {
+            _integerMagnitude = 0
+            jsonString = (value.sign == .plus) ? "0" : "-0"
+        } else {
+            let u = UInt64(value.magnitude)
+            if Float80(u) == value {
+                _integerMagnitude = u
+            } else {
+                _integerMagnitude = 0
+            }
+            jsonString = value.description
+        }
+        self.jsonNumber = _JSONNumber(jsonString: jsonString, _integerMagnitude: _integerMagnitude)
+    }
+#endif
+
+    internal init(value: Int8) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    internal init(value: Int16) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    internal init(value: Int32) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+    internal init(value: Int64) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    internal init(value: Int) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    internal init(value: UInt8) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    internal init(value: UInt16) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    internal init(value: UInt32) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    internal init(value: UInt64) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    internal init(value: UInt) {
+        self.jsonNumber = _JSONNumber(jsonString: value.description, _integerMagnitude: UInt64(value.magnitude))
+    }
+
+    // 0, -0 is false, everything else is true
+    override var boolValue: Bool {
+        if let i = jsonNumber.integerMagnitude, i == 0 {
+            return false
+        }
+        return true
+    }
+
+    override var floatValue: Float {
+        return Float(jsonNumber.jsonString) ?? Float.nan
+    }
+
+    override var doubleValue: Double {
+        return Double(jsonNumber.jsonString) ?? Double.nan
+    }
+
+    override var intValue: Int {
+        guard let _integerMagnitude = jsonNumber.integerMagnitude else { return 0 }
+        let i = Int(truncatingIfNeeded: _integerMagnitude)
+        if !jsonNumber.isNegative || i < 0 { return i }
+        return -1 * i
+    }
+
+    override var int8Value: Int8 {
+        return Int8(truncatingIfNeeded: intValue)
+    }
+
+    override var int16Value: Int16 {
+        return Int16(truncatingIfNeeded: intValue)
+    }
+
+    override var int32Value: Int32 {
+        return Int32(truncatingIfNeeded: intValue)
+    }
+
+    override var int64Value: Int64 {
+        guard let _integerMagnitude = jsonNumber.integerMagnitude else { return 0 }
+        let i = Int64(truncatingIfNeeded: _integerMagnitude)
+        if !jsonNumber.isNegative || i < 0 { return i }
+        return -1 * i
+    }
+
+    override var uintValue: UInt {
+        guard !jsonNumber.isNegative, let _integerMagnitude = jsonNumber.integerMagnitude else { return 0 }
+        return UInt(truncatingIfNeeded: _integerMagnitude)
+    }
+
+    override var uint8Value: UInt8 {
+        guard !jsonNumber.isNegative, let _integerMagnitude = jsonNumber.integerMagnitude else { return 0 }
+        return UInt8(truncatingIfNeeded: _integerMagnitude)
+    }
+
+    override var uint16Value: UInt16 {
+        guard !jsonNumber.isNegative, let _integerMagnitude = jsonNumber.integerMagnitude else { return 0 }
+        return UInt16(truncatingIfNeeded: _integerMagnitude)
+    }
+
+    override var uint32Value: UInt32 {
+        guard !jsonNumber.isNegative, let _integerMagnitude = jsonNumber.integerMagnitude else { return 0 }
+        return UInt32(truncatingIfNeeded: _integerMagnitude)
+    }
+
+    override var uint64Value: UInt64 {
+        guard !jsonNumber.isNegative, let _integerMagnitude = jsonNumber.integerMagnitude else { return 0 }
+        return _integerMagnitude
+    }
+
+    override internal var int128Value: CFSInt128Struct {
+        guard let _integerMagnitude = jsonNumber.integerMagnitude else {
+            return CFSInt128Struct(high: Int64.max, low: UInt64.max)
+        }
+
+        if !jsonNumber.isNegative {
+            return CFSInt128Struct(high: 0, low: _integerMagnitude)
+        } else {
+            // 2's complement a UInt64 into a S128 - flip the bits and add 1
+            let low = ~_integerMagnitude
+            let (newValue, overflow) = low.addingReportingOverflow(1)
+            let high: Int64 = overflow ? 0 : -1
+
+            return CFSInt128Struct(high: high, low: newValue)
+        }
+    }
+
+    internal var decimal: Decimal {
+        return jsonNumber.exactlyDecimal ?? Decimal.nan
+    }
+}
+
+extension Bool {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyBool else { return nil }
+        self = value
+    }
+}
+
+#if !os(macOS)
+extension Float16 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyFloat16 else { return nil }
+        self = value
+    }
+}
+#endif
+
+extension Float {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyFloat else { return nil }
+        self = value
+    }
+}
+
+extension Double {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyDouble else { return nil }
+        self = value
+    }
+}
+
+#if arch(x86_64) || arch(i386)
+extension Float80 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyFloat80 else { return nil }
+        self = value
+    }
+}
+#endif
+
+extension Int8 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyInt8 else { return nil }
+        self = value
+    }
+}
+
+extension UInt8 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyUInt8 else { return nil }
+        self = value
+    }
+}
+
+extension Int16 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyInt16 else { return nil }
+        self = value
+    }
+}
+
+extension UInt16 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyUInt16 else { return nil }
+        self = value
+    }
+}
+
+extension Int32 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyInt32 else { return nil }
+        self = value
+    }
+}
+
+extension UInt32 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyUInt32 else { return nil }
+        self = value
+    }
+}
+
+extension Int64 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyInt64 else { return nil }
+        self = value
+    }
+}
+
+extension UInt64 {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyUInt64 else { return nil }
+        self = value
+    }
+}
+
+extension Int {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyInt else { return nil }
+        self = value
+    }
+}
+
+extension UInt {
+    internal init?(exactly number: _NSJSONNumber) {
+        guard let value = number.jsonNumber.exactlyUInt else { return nil }
+        self = value
+    }
+}

--- a/Sources/Foundation/NSDecimalNumber.swift
+++ b/Sources/Foundation/NSDecimalNumber.swift
@@ -515,10 +515,10 @@ extension NSNumber {
     public var decimalValue: Decimal {
         if let d = self as? NSDecimalNumber {
             return d.decimal
+        } else if let d = self as? _NSJSONNumber {
+            return d.decimal
         } else {
             return Decimal(self.doubleValue)
         }
     }
 }
-
-

--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -55,9 +55,12 @@ extension Int8 : _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int8?) -> Bool {
-        guard let value = Int8(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = Int8(exactly: jn)
+        } else {
+            result = Int8(exactly: x)
+        }
+        return result != nil
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int8 {
@@ -95,9 +98,12 @@ extension UInt8 : _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt8?) -> Bool {
-        guard let value = UInt8(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = UInt8(exactly: jn)
+        } else {
+            result = UInt8(exactly: x)
+        }
+        return result != nil
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt8 {
@@ -135,9 +141,12 @@ extension Int16 : _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int16?) -> Bool {
-        guard let value = Int16(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = Int16(exactly: jn)
+        } else {
+            result = Int16(exactly: x)
+        }
+        return result != nil
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int16 {
@@ -175,9 +184,12 @@ extension UInt16 : _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt16?) -> Bool {
-        guard let value = UInt16(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = UInt16(exactly: jn)
+        } else {
+            result = UInt16(exactly: x)
+        }
+        return result != nil
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt16 {
@@ -215,9 +227,12 @@ extension Int32 : _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int32?) -> Bool {
-        guard let value = Int32(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = Int32(exactly: jn)
+        } else {
+            result = Int32(exactly: x)
+        }
+        return result != nil
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int32 {
@@ -255,9 +270,12 @@ extension UInt32 : _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt32?) -> Bool {
-        guard let value = UInt32(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = UInt32(exactly: jn)
+        } else {
+            result = UInt32(exactly: x)
+        }
+        return result != nil
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt32 {
@@ -295,9 +313,12 @@ extension Int64 : _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int64?) -> Bool {
-        guard let value = Int64(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = Int64(exactly: jn)
+        } else {
+            result = Int64(exactly: x)
+        }
+        return result != nil
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int64 {
@@ -335,9 +356,12 @@ extension UInt64 : _ObjectiveCBridgeable {
     }
 
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt64?) -> Bool {
-        guard let value = UInt64(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = UInt64(exactly: jn)
+        } else {
+            result = UInt64(exactly: x)
+        }
+        return result != nil
     }
 
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt64 {
@@ -375,9 +399,12 @@ extension Int : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Int?) -> Bool {
-        guard let value = Int(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = Int(exactly: jn)
+        } else {
+            result = Int(exactly: x)
+        }
+        return result != nil
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Int {
@@ -415,9 +442,12 @@ extension UInt : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout UInt?) -> Bool {
-        guard let value = UInt(exactly: x) else { return false }
-        result = value
-        return true
+        if let jn = x as? _NSJSONNumber {
+            result = UInt(exactly: jn)
+        } else {
+            result = UInt(exactly: x)
+        }
+        return result != nil
     }
     
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> UInt {
@@ -463,11 +493,15 @@ extension Float : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Float?) -> Bool {
-        if x.floatValue.isNaN {
-            result = x.floatValue
-            return true
+        if let jn = x as? _NSJSONNumber {
+            result = Float(exactly: jn)
+        } else {
+            if x.floatValue.isNaN {
+                result = x.floatValue
+                return true
+            }
+            result = Float(exactly: x)
         }
-        result = Float(exactly: x)
         return result != nil
     }
     
@@ -516,11 +550,15 @@ extension Double : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Double?) -> Bool {
-        if x.doubleValue.isNaN {
-            result = x.doubleValue
-            return true
+        if let jn = x as? _NSJSONNumber {
+            result = Double(exactly: jn)
+        } else {
+            if x.doubleValue.isNaN {
+                result = x.doubleValue
+                return true
+            }
+            result = Double(exactly: x)
         }
-        result = Double(exactly: x)
         return result != nil
     }
     
@@ -563,18 +601,14 @@ extension Bool : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSNumber, result: inout Bool?) -> Bool {
-        if x === kCFBooleanTrue || NSNumber(value: 1) == x {
-            result = true
-            return true
-        } else if x === kCFBooleanFalse || NSNumber(value: 0) == x {
-            result = false
-            return true
+        if let jn = x as? _NSJSONNumber {
+            result = Bool(exactly: jn)
+        } else {
+            result = Bool(exactly: x)
         }
-
-        result = nil
-        return false
+        return result != nil
     }
-    
+
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSNumber?) -> Bool {
         var result: Bool?
         guard let src = source else { return false }
@@ -594,7 +628,7 @@ extension NSNumber : ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, Exp
 
 }
 
-private struct CFSInt128Struct {
+internal struct CFSInt128Struct {
     var high: Int64
     var low: UInt64
 }
@@ -903,7 +937,7 @@ open class NSNumber : NSValue {
         return .init(truncatingIfNeeded: value.low)
     }
 
-    private var int128Value: CFSInt128Struct {
+    internal var int128Value: CFSInt128Struct {
         var value = CFSInt128Struct(high: 0, low: 0)
         CFNumberGetValue(_cfObject, kCFNumberSInt128Type, &value)
         return value
@@ -1099,10 +1133,6 @@ open class NSNumber : NSValue {
         case kCFNumberSInt64Type:
             valuePtr.assumingMemoryBound(to: Int64.self).pointee = int64Value
         case kCFNumberSInt128Type:
-            struct CFSInt128Struct {
-                var high: Int64
-                var low: UInt64
-            }
             let val = int64Value
             valuePtr.assumingMemoryBound(to: CFSInt128Struct.self).pointee = CFSInt128Struct.init(high: (val < 0) ? -1 : 0, low: UInt64(bitPattern: val))
         case kCFNumberFloat32Type:

--- a/Tests/Foundation/CMakeLists.txt
+++ b/Tests/Foundation/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(TestFoundation PRIVATE
   Tests/TestIndexSet.swift
   Tests/TestISO8601DateFormatter.swift
   Tests/TestJSONEncoder.swift
+  Tests/TestJSONNumber.swift
   Tests/TestJSONSerialization.swift
   Tests/TestLengthFormatter.swift
   Tests/TestMassFormatter.swift

--- a/Tests/Foundation/Tests/TestCodable.swift
+++ b/Tests/Foundation/Tests/TestCodable.swift
@@ -546,6 +546,42 @@ class TestCodable : XCTestCase {
             }
         }
     }
+
+    func test_decimal_double() {
+        // SR-7054
+        struct DoubleItem : Codable {
+            var name: String
+            var price: Double
+        }
+
+        struct DecimalItem : Codable {
+            var name: String
+            var price: Decimal
+        }
+
+        let jsonString = """
+        { "name": "Gum ball", "price": 46.984765 }
+        """
+        let jsonData = jsonString.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        do {
+            let doubleItem = try decoder.decode(DoubleItem.self, from: jsonData)
+            print(doubleItem)
+            XCTAssertEqual(doubleItem.price.description, "46.984765")
+
+
+            let decimalItem = try decoder.decode(DecimalItem.self, from: jsonData)
+            print(decimalItem)
+            print(type(of: decimalItem.price))
+            XCTAssertEqual(decimalItem.price.description, "46.984765")
+            let jobj = try? JSONSerialization.jsonObject(with: jsonData)
+            print("jobj:", jobj ?? "nil")
+        }
+        catch {
+            XCTFail(error as! String)
+        }
+    }
 }
 
 extension TestCodable {
@@ -569,6 +605,7 @@ extension TestCodable {
             ("test_DateComponents_JSON", test_DateComponents_JSON),
             ("test_Measurement_JSON", test_Measurement_JSON),
             ("test_URLComponents_JSON", test_URLComponents_JSON),
+            ("test_decimal_double", test_decimal_double),
         ]
     }
 }

--- a/Tests/Foundation/Tests/TestJSONNumber.swift
+++ b/Tests/Foundation/Tests/TestJSONNumber.swift
@@ -1,0 +1,215 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
+
+class TestJSONNumber: XCTestCase {
+
+    #if !NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT    // _JSONNumber is an internal type
+    static let allTests: [(String, (TestJSONNumber) -> () throws -> Void)] = []
+    #else
+
+    private func initFromString(_ value: String, endIndex: Int? = nil) throws -> _JSONNumber {
+        var source = JSONParser(bytes: Array<UInt8>(value.utf8))
+        let jsonNumber = try source.reader.readNumber()
+        let index = source.reader.readerIndex
+        let _endIndex = endIndex ?? value.count
+        XCTAssertEqual(_endIndex, index, "endIndex of parsing \(value) should be \(_endIndex) not \(index)")
+        return jsonNumber
+    }
+
+    #if !os(macOS)
+    typealias _Float16 = Float16
+    #else
+    typealias _Float16 = Double
+    #endif
+
+    func testInit() throws {
+        func jsonFloat<T: BinaryFloatingPoint>(_ value: T?) -> T? {
+            if let value = value, !value.isNaN, value.isFinite {
+                return value
+            }
+            return nil
+        }
+
+        let testIntegers: [CustomStringConvertible] = [
+            "0", "-0", "1", "-1",
+            Int8.min, Int8.max, Int16.min, Int16.max, Int32.min, Int32.max, Int64.min, Int64.max, Int.min, Int.max,
+            Int64(Int8.min) - 2, Int64(Int8.min) - 1, Int64(Int8.min) + 1, Int64(Int8.min) + 2,
+            Int64(Int8.max) - 2, Int64(Int8.max) - 1, Int64(Int8.max) + 1, Int64(Int8.max) + 2,
+            Int64(Int16.min) - 2, Int64(Int16.min) - 1, Int64(Int16.min) + 1, Int64(Int16.min) + 2,
+            Int64(Int16.max) - 2, Int64(Int16.max) - 1, Int64(Int16.max) + 1, Int64(Int16.max) + 2,
+            Int64(Int32.min) - 2, Int64(Int32.min) - 1, Int64(Int32.min) + 1, Int64(Int32.min) + 2,
+            Int64(Int32.max) - 2, Int64(Int32.max) - 1, Int64(Int32.max) + 1, Int64(Int32.max) + 2,
+            "-9223372036854775810", "-9223372036854775809", Int64(Int64.min) + 1, Int64(Int64.min) + 2,
+            Int64(Int64.max) - 2, Int64(Int64.max) - 1, "9223372036854775808", "9223372036854775809",
+        ]
+
+        let testFloats: [CustomStringConvertible] = [
+            _Float16.leastNormalMagnitude, _Float16.leastNonzeroMagnitude, _Float16.greatestFiniteMagnitude,
+            Float.leastNormalMagnitude, Float.leastNonzeroMagnitude, Float.greatestFiniteMagnitude,
+            Double.leastNormalMagnitude, Double.leastNonzeroMagnitude, Double.greatestFiniteMagnitude,
+            "1e100", "1e200",
+        ]
+
+        for _testValue in testIntegers {
+            let testValue = _testValue.description
+
+            do {
+                let number = try initFromString(testValue)
+                let nsnumber = _NSJSONNumber(jsonNumber: number)
+                XCTAssertEqual(nsnumber.description, testValue, "'\(testValue)' .description")
+                XCTAssertEqual(nsnumber.stringValue, testValue, "'\(testValue)' .stringValue")
+
+                #if !os(macOS)
+                XCTAssertEqual(number.exactlyFloat16, jsonFloat(Float16(testValue)), "'\(testValue)' .exactlyFloat16")
+                #endif
+
+                XCTAssertEqual(number.exactlyFloat, jsonFloat(Float32(testValue)), "'\(testValue)' .exactlyFloat")
+                XCTAssertEqual(number.exactlyDouble, jsonFloat(Double(testValue)), "'\(testValue)' .exactlyDouble")
+
+                #if arch(x86_64) || arch(i386)
+                XCTAssertEqual(number.exactlyFloat80, jsonFloat(Float80(testValue)), "'\(testValue)' .exactlyFloat80")
+                #endif
+
+                XCTAssertEqual(number.exactlyInt8, Int8(testValue), "'\(testValue)' .exactlyInt8")
+                XCTAssertEqual(number.exactlyInt16, Int16(testValue), "'\(testValue)' .exactlIint16")
+                XCTAssertEqual(number.exactlyInt32, Int32(testValue), "'\(testValue)' .exactlyInt32")
+                XCTAssertEqual(number.exactlyInt64, Int64(testValue), "'\(testValue)' .exactlyInt64")
+                XCTAssertEqual(number.exactlyInt, Int(testValue), "'\(testValue)' .exactlyInt")
+
+                XCTAssertEqual(number.exactlyUInt8, UInt8(testValue), "'\(testValue)' .exactlyUint8")
+                XCTAssertEqual(number.exactlyUInt16, UInt16(testValue), "'\(testValue)' .exactlyUint16")
+                XCTAssertEqual(number.exactlyUInt32, UInt32(testValue), "'\(testValue)' .exactlyUint32")
+                XCTAssertEqual(number.exactlyUInt64, UInt64(testValue), "'\(testValue)' .exactlyUint64")
+                XCTAssertEqual(number.exactlyUInt, UInt(testValue), "'\(testValue)' .exactlyUint")
+
+                let _decimal = Decimal(string: testValue)
+                let decimal =  _decimal?.isFinite == true ? _decimal : nil
+                XCTAssertEqual(number.exactlyDecimal, decimal, "'\(testValue)' .exactlyDecimal")
+            } catch {
+                XCTFail("Could not parse \(testValue): \(error)")
+            }
+        }
+    }
+
+    func testBool() throws {
+        // Bools can have different interpretations of true and false so test equivalence to NSNumber
+
+        XCTAssertTrue(NSNumber(value: true).boolValue)
+        XCTAssertTrue(_NSJSONNumber(value: true).boolValue)
+        XCTAssertEqual(_NSJSONNumber(value: true).jsonNumber.exactlyBool, true)
+
+        XCTAssertFalse(NSNumber(value: false).boolValue)
+        XCTAssertFalse(_NSJSONNumber(value: false).boolValue)
+        XCTAssertEqual(_NSJSONNumber(value: false).jsonNumber.exactlyBool, false)
+
+        let testValues: [(Double, Bool?)] = [ (-0.0, false), (0.0, false), (1.0, true), (-1.0, nil), (-2, nil), (1e6, nil)]
+        for value in testValues {
+            XCTAssertEqual(NSNumber(value: value.0) as? Bool, value.1, "\(value) as? Bool")
+            XCTAssertEqual(_NSJSONNumber(value: value.0) as? Bool, value.1, "\(value) as? Bool")
+            XCTAssertEqual(_NSJSONNumber(value: value.0).jsonNumber.exactlyBool, value.1, "\(value) .exactlyBool")
+        }
+
+        for value in -10...10 {
+            XCTAssertEqual(NSNumber(value: value), _NSJSONNumber(value: value), "value: \(value)")
+            XCTAssertEqual(NSNumber(value: value).boolValue, _NSJSONNumber(value: value).boolValue, "value: \(value)")
+            XCTAssertEqual(NSNumber(value: value) as? Bool, _NSJSONNumber(value: value) as? Bool, "value: \(value)")
+        }
+    }
+
+    func testIntegers() {
+        let testInputs = [
+            ("-0.000e100", 0),
+            ("-0", 0),
+            ("0.0e0", 0),
+            ("0.0000e+000", 0),
+            ("0.0E-0000", 0),
+            ("0.00012e5", 12),
+        ]
+
+        for (input, intValue) in testInputs {
+            do {
+                let number = try initFromString(input)
+                XCTAssertEqual(number.exactlyInt, intValue, "Testing \(input)")
+            } catch {
+                XCTFail("Cant parse: \(input), \(error)")
+            }
+        }
+
+        XCTAssertEqual(_NSJSONNumber(value: 0.0).uintValue, 0)
+        XCTAssertEqual(_NSJSONNumber(value: 0.0).intValue, 0)
+        XCTAssertEqual(_NSJSONNumber(value: -0.0).uintValue, 0)
+        XCTAssertEqual(_NSJSONNumber(value: -0.0).intValue, 0)
+    }
+
+    // A Number can end validly with non number characters
+    func testTrailingCharacters() {
+        let goodInputs = [
+            ("0}", "0"),
+            ("0.1 ", "0.1"),
+            ("0.12 ", "0.12"),
+            ("12.345e-12 ", "12.345e-12"),
+            ("0.1e-3]", "0.1e-3"),
+            ("-0 }", "-0")
+        ]
+
+        for (input, description) in goodInputs {
+            do {
+                let number = _NSJSONNumber(jsonNumber: try initFromString(input, endIndex: description.count))
+                XCTAssertEqual(number.description, description)
+            } catch {
+                XCTFail("Cant parse \(input), \(error)")
+            }
+        }
+    }
+
+    func testInvalidNumbers() {
+        let badInputs = [
+            ("0.e-000", JSONError.unexpectedCharacter(ascii: 101, characterIndex: 2)),
+          //  (" 1", JSONError.numberWithLeadingZero(index: 1)),
+          //  (".23", JSONError.numberWithLeadingZero(index: 1)),
+            ("01.2", JSONError.numberWithLeadingZero(index: 1)),
+            ("0.", JSONError.unexpectedEndOfFile),
+          //  ("+1", JSONError.numberWithLeadingZero(index: 1)),
+            ("00", JSONError.numberWithLeadingZero(index: 1)),
+            ("0e", JSONError.unexpectedEndOfFile),
+            ("0eE", JSONError.unexpectedCharacter(ascii: 69, characterIndex: 2)),
+            ("0ex1", JSONError.unexpectedCharacter(ascii: 120, characterIndex: 2)),
+            ("0E+", JSONError.unexpectedEndOfFile),
+            ("0e-", JSONError.unexpectedEndOfFile),
+        ]
+
+        for (badInput, expectedError) in badInputs {
+            XCTAssertThrowsError(try initFromString(badInput), "Parsing \(badInput)") {
+                let msg = "Testing \(badInput)"
+                guard let jsonError = $0 as? JSONError else {
+                    XCTFail("Expected a JSONError \(msg)")
+                    return
+                }
+                XCTAssertEqual(jsonError, expectedError, "with input \(badInput)")
+            }
+        }
+    }
+
+    static let allTests: [(String, (TestJSONNumber) -> () throws -> Void)] = [
+        ("testInit", testInit),
+        ("testBool", testBool),
+        ("testIntegers", testIntegers),
+        ("testTrailingCharacters", testTrailingCharacters),
+        ("testInvalidNumbers", testInvalidNumbers),
+    ]
+    #endif  // NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+}

--- a/Tests/Foundation/main.swift
+++ b/Tests/Foundation/main.swift
@@ -55,6 +55,7 @@ var allTestCases = [
     testCase(TestIndexSet.allTests),
     testCase(TestISO8601DateFormatter.allTests),
     testCase(TestJSONSerialization.allTests),
+    testCase(TestJSONNumber.allTests),
     testCase(TestNSKeyedArchiver.allTests),
     testCase(TestNSKeyedUnarchiver.allTests),
     testCase(TestLengthFormatter.allTests),


### PR DESCRIPTION
This is a potential solution for SR-7054 and SR-12244 involving parsing JSON numbers and then later bridging them to `Decimal` or a floating point type and losing accuray compared to the original input. It will need to be updated after #2966 is merge but that will be minimal changes. The bridging should also be marginally faster as it doesnt need to create a 2nd `NSNumber` for the equality check.

- Add _NSJSONNumber, an internal subclass of NSNumber to provide lazy
  parsing of numbers at time of use. This avoids parsing numbers as
  Decimal when later bridged to Double/Float and vice-versa which
  has accuracy issues if converted from one to the other.

- Add test cases for SR-7054 and SR-12244

