### PR TITLE
Store the hostname in _names for Host.current()

### DIFF
--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -118,7 +118,7 @@ open class Host: NSObject {
         return addresses.firstIndex { aHost.addresses.contains($0) } != nil
     }
     
-    internal func _resolveCurrent() {
+    internal func _resolveCurrent(withInfo info: String) {
 #if os(Windows)
         var szAddress: [WCHAR] =
             Array<WCHAR>(repeating: 0, count: Int(NI_MAXHOST))
@@ -165,6 +165,7 @@ open class Host: NSObject {
 
           pAdapter = pAdapter!.pointee.Next
         }
+        _names = [info]
         _resolved = true
 #else
         var ifaddr: UnsafeMutablePointer<ifaddrs>? = nil
@@ -189,6 +190,7 @@ open class Host: NSObject {
             }
             ifa = ifaValue.ifa_next
         }
+        _names = [info]
         _resolved = true
 #endif
     }
@@ -197,7 +199,7 @@ open class Host: NSObject {
         guard _resolved == false else { return }
 #if os(Windows)
         if let info = _info {
-          if _type == .current { return _resolveCurrent() }
+          if _type == .current { return _resolveCurrent(withInfo: info) }
 
           var hints: ADDRINFOW = ADDRINFOW()
           memset(&hints, 0, MemoryLayout<ADDRINFOW>.size)
@@ -266,7 +268,7 @@ open class Host: NSObject {
             case .address:
                 flags = AI_PASSIVE | AI_CANONNAME | AI_NUMERICHOST
             case .current:
-                _resolveCurrent()
+                _resolveCurrent(withInfo: info)
                 return
             }
             var hints = addrinfo()

--- a/Tests/Foundation/Tests/TestHost.swift
+++ b/Tests/Foundation/Tests/TestHost.swift
@@ -12,7 +12,8 @@ class TestHost: XCTestCase {
     static var allTests: [(String, (TestHost) -> () throws -> Void)] {
         return [
             ("test_addressesDoNotGrow", test_addressesDoNotGrow),
-            ("test_isEqual", test_isEqual)
+            ("test_isEqual", test_isEqual),
+            ("test_localNamesNonEmpty", test_localNamesNonEmpty),
         ]
     }
     
@@ -48,6 +49,15 @@ class TestHost: XCTestCase {
 
         let google = Host(name: "google.com")
         XCTAssertFalse(swift0.isEqual(to: google))
+    }
+
+    // SR-14197
+    func test_localNamesNonEmpty() {
+        let local = Host.current()
+        XCTAssertTrue(local.names.count > 0)
+
+        let swift = Host(name: "localhost")
+        XCTAssertTrue(swift.names.count > 0)
     }
 }
 


### PR DESCRIPTION
Host.current() looks up the hostname for its _info field, but then never
gives it to the user. As a result, .names is always empty for
Host.current().

This patch is a minimal-effort workaround: it simply throws the value of
gethostname() (or its Windows equivalent) into _names. We could probably
do better than that, but for now this is good enough.

Resolves SR-14197.