### PR TITLE
[5.4] Judge executables with API on Windows

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -709,9 +709,10 @@ extension FileManager {
     }
 
     internal func _isExecutableFile(atPath path: String) -> Bool {
-        var isDirectory: ObjCBool = false
-        guard fileExists(atPath: path, isDirectory: &isDirectory) else { return false }
-        return !isDirectory.boolValue && _isReadableFile(atPath: path)
+        var binaryType = DWORD(0)
+        return path.withCString(encodedAs: UTF16.self) {
+            GetBinaryTypeW($0, &binaryType)
+        }
     }
 
     internal func _isDeletableFile(atPath path: String) -> Bool {


### PR DESCRIPTION
- Use `GetBinaryTypeW` to identify if the file is an executable file.

(cherry picked from commit 8a87b13)