### PR TITLE
macOS: Dont import CFXMLInterface as @_implementationOnly as this breaks

### DIFF
--- a/Sources/FoundationXML/XMLNode.swift
+++ b/Sources/FoundationXML/XMLNode.swift
@@ -10,11 +10,12 @@
 //import libxml2
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import SwiftFoundation
+import CFXMLInterface
 #else
 import Foundation
+@_implementationOnly import CFXMLInterface
 #endif
 @_implementationOnly import CoreFoundation
-@_implementationOnly import CFXMLInterface
 
 // initWithKind options
 //  NSXMLNodeOptionsNone

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -9,11 +9,12 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import SwiftFoundation
+import CFXMLInterface
 #else
 import Foundation
+@_implementationOnly import CFXMLInterface
 #endif
 @_implementationOnly import CoreFoundation
-@_implementationOnly import CFXMLInterface
 
 extension XMLParser {
     public enum ExternalEntityResolvingPolicy : UInt {


### PR DESCRIPTION
- This doesnt work on macOS for some reason, so just import it as a
  normal import. This was breaking testing on macOS.

- This doesnt affect any other platform where it is actually required
  to @_implementationOnly import.

This reverts #2979 on macOS