### PR TITLE
Make firstRange and lastRange mirror macOS Foundation more

### DIFF
--- a/Sources/Foundation/DataProtocol.swift
+++ b/Sources/Foundation/DataProtocol.swift
@@ -137,6 +137,9 @@ extension DataProtocol {
     }
     
     public func firstRange<D: DataProtocol, R: RangeExpression>(of data: D, in range: R) -> Range<Index>? where R.Bound == Index {
+        guard !data.isEmpty else {
+            return nil
+        }
         let r = range.relative(to: self)
         let rangeCount = distance(from: r.lowerBound, to: r.upperBound)
         if rangeCount < data.count {
@@ -166,6 +169,9 @@ extension DataProtocol {
     }
     
     public func lastRange<D: DataProtocol, R: RangeExpression>(of data: D, in range: R) -> Range<Index>? where R.Bound == Index {
+        guard !data.isEmpty else {
+            return nil
+        }
         let r = range.relative(to: self)
         let rangeCount = distance(from: r.lowerBound, to: r.upperBound)
         if rangeCount < data.count {

--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -212,6 +212,8 @@ class TestNSData: LoopbackServerTest {
             ("testCopyBytes", testCopyBytes),
             ("testCustomDeallocator", testCustomDeallocator),
             ("testDataInSet", testDataInSet),
+            ("testFirstRangeEmptyData", testFirstRangeEmptyData),
+            ("testLastRangeEmptyData", testLastRangeEmptyData),
             ("testEquality", testEquality),
             ("testGenericAlgorithms", testGenericAlgorithms),
             ("testInitializationWithArray", testInitializationWithArray),
@@ -1192,6 +1194,16 @@ extension TestNSData {
         s.insert(d3)
         
         XCTAssertEqual(s.count, 2, "Expected only two entries in the Set")
+    }
+    
+    func testFirstRangeEmptyData() {
+        let d = Data([1, 2, 3])
+        XCTAssertNil(d.firstRange(of: Data()))
+    }
+    
+    func testLastRangeEmptyData() {
+        let d = Data([1, 2, 3])
+        XCTAssertNil(d.lastRange(of: Data()))
     }
     
     func testReplaceSubrange() {


### PR DESCRIPTION
When the searched Data is empty, on macOS `nil` is returned, on Linux an empty Range is returned.
This PR fixes the discrepancy.