### PR TITLE
Fix firstRange and lastRange implementation in DataProtocol

### DIFF
--- a/Sources/Foundation/DataProtocol.swift
+++ b/Sources/Foundation/DataProtocol.swift
@@ -143,8 +143,9 @@ extension DataProtocol {
             return nil
         }
         var haystackIndex = r.lowerBound
-        let haystackEnd = index(r.upperBound, offsetBy: -data.count + 1)
-        while haystackIndex < haystackEnd {
+        let haystackEnd = r.upperBound
+        let haystackSearchEnd = index(r.upperBound, offsetBy: -data.count)
+        while haystackIndex <= haystackSearchEnd {
             var compareIndex = haystackIndex
             var needleIndex = data.startIndex
             let needleEnd = data.endIndex
@@ -172,13 +173,14 @@ extension DataProtocol {
             return nil
         }
         var haystackIndex = r.upperBound
-        let haystackStart = index(r.lowerBound, offsetBy: data.count - 1)
-        while haystackIndex > haystackStart {
+        let haystackStart = r.lowerBound
+        let haystackSearchStart = index(r.lowerBound, offsetBy: data.count)
+        while haystackIndex >= haystackSearchStart {
             var compareIndex = haystackIndex
             var needleIndex = data.endIndex
             let needleStart = data.startIndex
             var matched = true
-            while compareIndex > haystackStart && needleIndex > needleStart {
+            while compareIndex >= haystackStart && needleIndex > needleStart {
                 needleIndex = data.index(before: needleIndex)
                 compareIndex = index(before: compareIndex)
                 if self[compareIndex] != data[needleIndex] {

--- a/Sources/Foundation/DataProtocol.swift
+++ b/Sources/Foundation/DataProtocol.swift
@@ -143,7 +143,7 @@ extension DataProtocol {
             return nil
         }
         var haystackIndex = r.lowerBound
-        let haystackEnd = index(r.upperBound, offsetBy: -data.count)
+        let haystackEnd = index(r.upperBound, offsetBy: -data.count + 1)
         while haystackIndex < haystackEnd {
             var compareIndex = haystackIndex
             var needleIndex = data.startIndex
@@ -172,19 +172,19 @@ extension DataProtocol {
             return nil
         }
         var haystackIndex = r.upperBound
-        let haystackStart = index(r.lowerBound, offsetBy: data.count)
+        let haystackStart = index(r.lowerBound, offsetBy: data.count - 1)
         while haystackIndex > haystackStart {
             var compareIndex = haystackIndex
             var needleIndex = data.endIndex
             let needleStart = data.startIndex
             var matched = true
             while compareIndex > haystackStart && needleIndex > needleStart {
+                needleIndex = data.index(before: needleIndex)
+                compareIndex = index(before: compareIndex)
                 if self[compareIndex] != data[needleIndex] {
                     matched = false
                     break
                 }
-                needleIndex = data.index(before: needleIndex)
-                compareIndex = index(before: compareIndex)
             }
             if matched {
                 return compareIndex..<haystackIndex

--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -1190,6 +1190,7 @@ extension TestNSData {
         XCTAssertEqual(d.firstRange(of: Data([3])), 2..<3)
         XCTAssertEqual(d.firstRange(of: Data([0])), 6..<7)
         XCTAssertEqual(d.firstRange(of: Data([2, 3, 0])), 4..<7)
+        XCTAssertEqual(d.firstRange(of: Data([3, 1, 2])), 2..<5)
         XCTAssertEqual(d.firstRange(of: Data([1, 2, 3, 1, 2, 3, 0])), 0..<7)
     }
     

--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -213,6 +213,8 @@ class TestNSData: LoopbackServerTest {
             ("testCustomDeallocator", testCustomDeallocator),
             ("testDataInSet", testDataInSet),
             ("testEquality", testEquality),
+            ("testFirstRange", testFirstRange),
+            ("testLastRange", testLastRange),
             ("testGenericAlgorithms", testGenericAlgorithms),
             ("testInitializationWithArray", testInitializationWithArray),
             ("testInsertData", testInsertData),
@@ -1179,6 +1181,22 @@ extension TestNSData {
         
         // Use == explicitly here to make sure we're calling the right methods
         XCTAssertTrue(d1 == d2, "Data should be equal")
+    }
+    
+    func testFirstRange() {
+        let d = Data([1, 2, 3, 1, 2, 3, 0])
+        XCTAssertEqual(d.firstRange(of: Data([1])), 0..<1)
+        XCTAssertEqual(d.firstRange(of: Data([2])), 1..<2)
+        XCTAssertEqual(d.firstRange(of: Data([3])), 2..<3)
+        XCTAssertEqual(d.firstRange(of: Data([0])), 6..<7)
+    }
+    
+    func testLastRange() {
+        let d = Data([0, 1, 2, 3, 1, 2, 3])
+        XCTAssertEqual(d.lastRange(of: Data([1])), 4..<5)
+        XCTAssertEqual(d.lastRange(of: Data([2])), 5..<6)
+        XCTAssertEqual(d.lastRange(of: Data([3])), 6..<7)
+        XCTAssertEqual(d.lastRange(of: Data([0])), 0..<1)
     }
     
     func testDataInSet() {

--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -1189,6 +1189,8 @@ extension TestNSData {
         XCTAssertEqual(d.firstRange(of: Data([2])), 1..<2)
         XCTAssertEqual(d.firstRange(of: Data([3])), 2..<3)
         XCTAssertEqual(d.firstRange(of: Data([0])), 6..<7)
+        XCTAssertEqual(d.firstRange(of: Data([2, 3, 0])), 4..<7)
+        XCTAssertEqual(d.firstRange(of: Data([1, 2, 3, 1, 2, 3, 0])), 0..<7)
     }
     
     func testLastRange() {
@@ -1197,6 +1199,9 @@ extension TestNSData {
         XCTAssertEqual(d.lastRange(of: Data([2])), 5..<6)
         XCTAssertEqual(d.lastRange(of: Data([3])), 6..<7)
         XCTAssertEqual(d.lastRange(of: Data([0])), 0..<1)
+        XCTAssertEqual(d.lastRange(of: Data([0, 1, 2])), 0..<3)
+        XCTAssertEqual(d.lastRange(of: Data([1, 2, 3])), 4..<7)
+        XCTAssertEqual(d.lastRange(of: Data([0, 1, 2, 3, 1, 2, 3])), 0..<7)
     }
     
     func testDataInSet() {


### PR DESCRIPTION
`firstRange` did not find needle if at last index of haystack.
`lastRange` was fully broken and crashed.