### PR TITLE
Fix autolink mechanism for static libraries on Linux

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -160,6 +160,19 @@ set_target_properties(Foundation PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
+if(NOT BUILD_SHARED_LIBS)
+  # TODO(katei): Comment out after swift-frontend implementation
+  # https://github.com/apple/swift/pull/35936
+  # target_compile_options(Foundation
+  #   PRIVATE
+  #     "SHELL:-public-autolink-library icui18n")
+
+  # Merge private dependencies into single static objects archive
+  set_property(TARGET Foundation PROPERTY STATIC_LIBRARY_OPTIONS
+    $<TARGET_OBJECTS:CoreFoundation>
+    $<TARGET_OBJECTS:uuid>)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   # NOTE: workaround for CMake which doesn't link in OBJECT libraries properly
   add_dependencies(Foundation CoreFoundationResources)

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -161,11 +161,10 @@ set_target_properties(Foundation PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
 if(NOT BUILD_SHARED_LIBS)
-  # TODO(katei): Comment out after swift-frontend implementation
-  # https://github.com/apple/swift/pull/35936
-  # target_compile_options(Foundation
-  #   PRIVATE
-  #     "SHELL:-public-autolink-library icui18n")
+  target_compile_options(Foundation
+    PRIVATE
+      "SHELL:-Xfrontend -public-autolink-library -Xfrontend icui18n
+             -Xfrontend -public-autolink-library -Xfrontend BlocksRuntime")
 
   # Merge private dependencies into single static objects archive
   set_property(TARGET Foundation PROPERTY STATIC_LIBRARY_OPTIONS

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -64,6 +64,19 @@ target_link_libraries(FoundationNetworking
     CFURLSessionInterface
   PUBLIC
     Foundation)
+
+if(NOT BUILD_SHARED_LIBS)
+  # TODO(katei): Comment out after swift-frontend implementation
+  # https://github.com/apple/swift/pull/35936
+  # target_compile_options(FoundationNetworking
+  #   PRIVATE
+  #     "SHELL:-public-autolink-library curl")
+
+  # Merge private dependencies into single static objects archive
+  set_property(TARGET FoundationNetworking PROPERTY STATIC_LIBRARY_OPTIONS
+    $<TARGET_OBJECTS:CFURLSessionInterface>)
+endif()
+
 set_target_properties(FoundationNetworking PROPERTIES
   INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -66,11 +66,9 @@ target_link_libraries(FoundationNetworking
     Foundation)
 
 if(NOT BUILD_SHARED_LIBS)
-  # TODO(katei): Comment out after swift-frontend implementation
-  # https://github.com/apple/swift/pull/35936
-  # target_compile_options(FoundationNetworking
-  #   PRIVATE
-  #     "SHELL:-public-autolink-library curl")
+  target_compile_options(FoundationNetworking
+    PRIVATE
+      "SHELL:-Xfrontend -public-autolink-library -Xfrontend curl")
 
   # Merge private dependencies into single static objects archive
   set_property(TARGET FoundationNetworking PROPERTY STATIC_LIBRARY_OPTIONS

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -18,11 +18,9 @@ target_link_libraries(FoundationXML
     Foundation)
 
 if(NOT BUILD_SHARED_LIBS)
-  # TODO(katei): Comment out after swift-frontend implementation
-  # https://github.com/apple/swift/pull/35936
-  # target_compile_options(FoundationXML
-  #   PRIVATE
-  #     "SHELL:-public-autolink-library xml2")
+  target_compile_options(FoundationXML
+    PRIVATE
+      "SHELL:-Xfrontend -public-autolink-library -Xfrontend xml2")
 
   # Merge private dependencies into single static objects archive
   set_property(TARGET FoundationXML PROPERTY STATIC_LIBRARY_OPTIONS

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -16,6 +16,19 @@ target_link_libraries(FoundationXML
     CFXMLInterface
   PUBLIC
     Foundation)
+
+if(NOT BUILD_SHARED_LIBS)
+  # TODO(katei): Comment out after swift-frontend implementation
+  # https://github.com/apple/swift/pull/35936
+  # target_compile_options(FoundationXML
+  #   PRIVATE
+  #     "SHELL:-public-autolink-library xml2")
+
+  # Merge private dependencies into single static objects archive
+  set_property(TARGET FoundationXML PROPERTY STATIC_LIBRARY_OPTIONS
+    $<TARGET_OBJECTS:CFXMLInterface>)
+endif()
+
 set_target_properties(FoundationXML PROPERTIES
   INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift


### PR DESCRIPTION
Resolve: [[SR-14536] Importing FoundationNetworking with -static-stdlib is broken with missing symbols on Linux - Swift](https://bugs.swift.org/browse/SR-14536)

Discussion: [Autolinking behavior of @_implementationOnly with static linking - Development / Core Libraries - Swift Forums](https://forums.swift.org/t/autolinking-behavior-of-implementationonly-with-static-linking/44393)

~~Blocked by [[Frontend] Add -public-autolink-library option by kateinoigakukun · Pull Request #35936 · apple/swift](https://github.com/apple/swift/pull/35936)~~

## Overview

`Foundation` imports `CoreFoundation` with `@_implementationOnly` as a private dependency, and it doesn't emit `IMPORTED_MODULE` in swiftmodule.
Users of Foundation can link `libCoreFoundation.so` automatically when using dynamic linking because it's already linked into `libFoundation.so`.
However, this automatic linking doesn't work when static linking, so users need to link CoreFoundation and dependent libraries of CoreFoundation explicitly by adding `-lCoreFoundation -lBlocksRuntime -licui18n`.

To avoid forcing users to link private dependencies explicitly, this patch changed to merge the dependencies into libFoundation.a. And also to avoid forcing to link dependent libs of CoreFoundation like `curl` or `icui18n`, add `LINK_LIBRARY` entry in Foundation.swiftmodule using `-public-autolink-library` which is introduced by https://github.com/apple/swift/pull/35936

