### PR TITLE
[SR-14496] - When Base64 encoding, only add line separators if there …

### DIFF
--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -900,12 +900,14 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             // anyway.
             buffer.baseAddress!.advanced(by: outputIndex).copyMemory(from: &outputBytes, byteCount: 4)
             outputIndex += 4
+            bytesLeft = dataBuffer.count - inputIndex
+            
             if lineLength != 0 {
                 // Add required EOL markers.
                 currentLineCount += 4
                 assert(currentLineCount <= lineLength)
 
-                if currentLineCount == lineLength {
+                if currentLineCount == lineLength && bytesLeft > 0 {
                     buffer[outputIndex] = separatorByte1
                     outputIndex += 1
 
@@ -916,7 +918,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
                     currentLineCount = 0
                 }
             }
-            bytesLeft = dataBuffer.count - inputIndex
         }
 
         // Return the number of ASCII bytes written to the buffer

--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -244,6 +244,8 @@ class TestNSData: LoopbackServerTest {
             ("test_base64EncodedDataWithOptionToInsertCarriageReturnContainsCarriageReturn", test_base64EncodedDataWithOptionToInsertCarriageReturnContainsCarriageReturn),
             ("test_base64EncodedDataWithOptionToInsertLineFeedsContainsLineFeed", test_base64EncodedDataWithOptionToInsertLineFeedsContainsLineFeed),
             ("test_base64EncodedDataWithOptionToInsertCarriageReturnAndLineFeedContainsBoth", test_base64EncodedDataWithOptionToInsertCarriageReturnAndLineFeedContainsBoth),
+            ("test_base64EncodeDoesNotAddLineSeparatorsWhenStringFitsInLine", test_base64EncodeDoesNotAddLineSeparatorsWhenStringFitsInLine),
+            ("test_base64EncodeAddsLineSeparatorsWhenStringDoesNotFitInLine", test_base64EncodeAddsLineSeparatorsWhenStringDoesNotFitInLine),
             ("test_base64EncodedStringGetsEncodedText", test_base64EncodedStringGetsEncodedText),
             ("test_initializeWithBase64EncodedStringGetsDecodedData", test_initializeWithBase64EncodedStringGetsDecodedData),
             ("test_base64DecodeWithPadding1", test_base64DecodeWithPadding1),
@@ -812,6 +814,36 @@ class TestNSData: LoopbackServerTest {
             return
         }
         XCTAssertEqual(encodedTextResult, encodedText)
+    }
+    
+    func test_base64EncodeDoesNotAddLineSeparatorsWhenStringFitsInLine() {
+        
+        XCTAssertEqual(
+            Data(repeating: 0, count: 48).base64EncodedString(options: .lineLength64Characters),
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "each 3 byte is converted into 4 characterss. 48 / 3 * 4 <= 64, therefore result should not have line separator."
+        )
+        
+        XCTAssertEqual(
+            Data(repeating: 0, count: 57).base64EncodedString(options: .lineLength76Characters),
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "each 3 byte is converted into 4 characterss. 57 / 3 * 4 <= 76, therefore result should not have line separator."
+        )
+    }
+    
+    func test_base64EncodeAddsLineSeparatorsWhenStringDoesNotFitInLine() {
+        
+        XCTAssertEqual(
+            Data(repeating: 0, count: 49).base64EncodedString(options: .lineLength64Characters),
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\r\nAA==",
+            "each 3 byte is converted into 4 characterss. 49 / 3 * 4 > 64, therefore result should have lines with separator."
+        )
+        
+        XCTAssertEqual(
+            Data(repeating: 0, count: 58).base64EncodedString(options: .lineLength76Characters),
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\r\nAA==",
+            "each 3 byte is converted into 4 characterss. 58 / 3 * 4 > 76, therefore result should have lines with separator."
+        )
     }
     
     func test_base64EncodedStringGetsEncodedText() {


### PR DESCRIPTION
Line separators were added at the end of base64 encoded string even though the result was fitting in the given max-line length limit.

Adjusted base64 encoding to match Darwin's behaviour - now we will only add separators if there are more bytes to parse.

Resolves https://bugs.swift.org/browse/SR-14496