### PR TITLE
[CMake] fix plutil runpath for ELF platforms

### DIFF
--- a/Sources/Tools/plutil/CMakeLists.txt
+++ b/Sources/Tools/plutil/CMakeLists.txt
@@ -2,6 +2,31 @@ add_executable(plutil
   main.swift)
 target_link_libraries(plutil PRIVATE
   Foundation)
+
+# On ELF platforms, remove the absolute rpath to the host toolchain's stdlib,
+# then add it back temporarily as a BUILD_RPATH just for the tests.
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  target_link_options(plutil PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
+
+  string(REPLACE " " ";" ARGS_LIST ${CMAKE_Swift_FLAGS})
+  execute_process(
+    COMMAND ${CMAKE_Swift_COMPILER} ${ARGS_LIST} -print-target-info
+    OUTPUT_VARIABLE output
+    ERROR_VARIABLE error_output
+    RESULT_VARIABLE result
+  )
+  if(NOT ${result} EQUAL 0)
+    message(FATAL_ERROR "Error getting target info with\n"
+      "  `${CMAKE_Swift_COMPILER} ${CMAKE_Swift_FLAGS} -print-target-info`\n"
+      "Error:\n"
+      "  ${error_output}")
+  endif()
+
+  string(REGEX MATCH "\"runtimeLibraryPaths\": \\[\n\ +\"([^\"]+)\""
+           path ${output})
+  set_target_properties(plutil PROPERTIES BUILD_RPATH ${CMAKE_MATCH_1})
+endif()
+
 set_target_properties(plutil PROPERTIES
   INSTALL_RPATH "$ORIGIN/../lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
 


### PR DESCRIPTION
Remove the absolute path to the host toolchain's stdlib from plutil, and add it as a CMake `BUILD_PATH`, so that it's removed upon installation.

The problem is that plutil on linux currently has this rpath:
```
> readelf -d swift-DEVELOPMENT-SNAPSHOT-2021-05-05-a-centos8/usr/bin/plutil |ag runpath
 0x000000000000001d (RUNPATH)            Library runpath: [/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux]
```
I submitted this as part of #2783 earlier, but had to remove it because the linux CMake was too old and didn't support `BUILD_RPATH` then. With apple/swift#37517 updating the linux CMake, this should work now.