### PR TITLE
Set `isRunning` of `Process` to `false` before calling the termination handler

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -830,6 +830,9 @@ open class Process: NSObject {
                 process._terminationReason = .exit
             }
             
+            // Set the running flag to false
+            process.isRunning = false
+
             // If a termination handler has been set, invoke it on a background thread
             
             if let terminationHandler = process.terminationHandler {
@@ -839,9 +842,6 @@ open class Process: NSObject {
                 thread.start()
             }
             
-            // Set the running flag to false
-            process.isRunning = false
-
             // Invalidate the source and wake up the run loop, if it's available
             
             CFRunLoopSourceInvalidate(process.runLoopSource)


### PR DESCRIPTION
Otherwise, we end up in a race condition where `isRunning` might still be `true` when accessed from inside the `terminationHandler`. If this is the case, accessing `terminationReason` or `terminationStatus` inside the termination handler crashes because their precondition that the task has finished are not satisfied.

We are experiencing this flaky behavior in [SourceKit-LSP’s](https://github.com/apple/sourcekit-lsp) crash recovery tests on Linux.

Fixes rdar://78035044