### PR TITLE
[5.4] Fix temporary filename coda going above the maximum path length in some cases

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -489,11 +489,15 @@ class TestFileManager : XCTestCase {
             try fm.createDirectory(atPath: basePath, withIntermediateDirectories: false, attributes: nil)
             try fm.createDirectory(atPath: basePath2, withIntermediateDirectories: false, attributes: nil)
 
-            let _ = fm.createFile(atPath: itemPath, contents: Data(count: 123), attributes: nil)
-            let _ = fm.createFile(atPath: itemPath2, contents: Data(count: 456), attributes: nil)
-
+            if !fm.createFile(atPath: itemPath, contents: Data(count: 123), attributes: nil) {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            if !fm.createFile(atPath: itemPath2, contents: Data(count: 456), attributes: nil) {
+                throw CocoaError(.fileWriteUnknown)
+            }
         } catch {
-            XCTFail()
+            XCTFail("Failed with error while creating temporary files: \(error)")
+            return
         }
 
         var item1FileAttributes: [FileAttributeKey: Any]!


### PR DESCRIPTION
This fixes an issue that would occur if the filename for a temporary file plus the .tmp.<coda> suffix was beyond the maximum path limit, but would be fine without it. This limits the temp filename to a maximum of 31 characters.

There will be follow-ups for other situations where long paths have similar issues, but this one specifically is also going to be nominated for 5.4.x and 5.5.

Fixes <https://bugs.swift.org/browse/SR-14823>. This is a candidate PR cherry-pick of <https://github.com/apple/swift-corelibs-foundation/pull/3005>