### PR TITLE
[5.5] SR-14108: Implement `copy()` in `DateFormatter`.

### DIFF
--- a/Sources/Foundation/DateFormatter.swift
+++ b/Sources/Foundation/DateFormatter.swift
@@ -36,6 +36,51 @@ open class DateFormatter : Formatter {
         super.init(coder: coder)
     }
 
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copied = DateFormatter()
+
+        func __copy<T>(_ keyPath: ReferenceWritableKeyPath<DateFormatter, T>) {
+            copied[keyPath: keyPath] = self[keyPath: keyPath]
+        }
+
+        __copy(\.formattingContext)
+        __copy(\.dateStyle)
+        __copy(\.timeStyle)
+        __copy(\._locale)
+        __copy(\.generatesCalendarDates)
+        __copy(\._timeZone)
+        __copy(\._calendar)
+        __copy(\.isLenient)
+        __copy(\._twoDigitStartDate)
+        __copy(\._eraSymbols)
+        __copy(\._monthSymbols)
+        __copy(\._shortMonthSymbols)
+        __copy(\._weekdaySymbols)
+        __copy(\._shortWeekdaySymbols)
+        __copy(\._amSymbol)
+        __copy(\._pmSymbol)
+        __copy(\._longEraSymbols)
+        __copy(\._veryShortMonthSymbols)
+        __copy(\._standaloneMonthSymbols)
+        __copy(\._shortStandaloneMonthSymbols)
+        __copy(\._veryShortStandaloneMonthSymbols)
+        __copy(\._veryShortWeekdaySymbols)
+        __copy(\._standaloneWeekdaySymbols)
+        __copy(\._shortStandaloneWeekdaySymbols)
+        __copy(\._veryShortStandaloneWeekdaySymbols)
+        __copy(\._quarterSymbols)
+        __copy(\._shortQuarterSymbols)
+        __copy(\._standaloneQuarterSymbols)
+        __copy(\._shortStandaloneQuarterSymbols)
+        __copy(\._gregorianStartDate)
+        __copy(\.doesRelativeDateFormatting)
+
+        // The last is `_dateFormat` because setting `dateStyle` and `timeStyle` make it `nil`.
+        __copy(\._dateFormat)
+
+        return copied
+    }
+
     open var formattingContext: Context = .unknown // default is NSFormattingContextUnknown
 
     @available(*, unavailable, renamed: "date(from:)")


### PR DESCRIPTION
This PR contains cherry-picks from #3008 for Swift 5.5 branch.

> DateFormatter.copy() returns the same instance not a copied one so far.
>This PR adds an implementation of copy() in DateFormatter to behave expectedly(i.e. The same behavior with DarwinFoundation).
> 
> Resolves SR-14108.