### PR TITLE
Partially fix Decimal.ulp to return a valid representation.

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -209,7 +209,7 @@ class TestDecimal : XCTestCase {
         
         let ulp = explicit.ulp
         XCTAssertEqual(0x7f, ulp.exponent)
-        XCTAssertEqual(8, ulp._length)
+        XCTAssertEqual(1, ulp._length)
         XCTAssertEqual(0, ulp._isNegative)
         XCTAssertEqual(1, ulp._isCompact)
         XCTAssertEqual(0, ulp._reserved)
@@ -587,6 +587,11 @@ class TestDecimal : XCTestCase {
                 XCTAssertEqual(.orderedSame, NSDecimalCompare(&expected, &result), "\(expected._mantissa.0) == \(i) * \(j)");
             }
         }
+    }
+    
+    func test_ULP() {
+        let x = 0.1 as Decimal
+        XCTAssertFalse(x.ulp > x)
     }
 
     func test_unconditionallyBridgeFromObjectiveC() {

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -503,7 +503,7 @@ extension Decimal {
     public var ulp: Decimal {
         if !self.isFinite { return Decimal.nan }
         return Decimal(
-            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
             _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
 

--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -731,7 +731,7 @@ extension Decimal {
     public var ulp: Decimal {
         if !self.isFinite { return Decimal.nan }
         return Decimal(
-            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
             _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
 

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -271,7 +271,7 @@ class TestDecimal: XCTestCase {
 
         let ulp = explicit.ulp
         XCTAssertEqual(0x7f, ulp.exponent)
-        XCTAssertEqual(8, ulp._length)
+        XCTAssertEqual(1, ulp._length)
         XCTAssertEqual(0, ulp._isNegative)
         XCTAssertEqual(1, ulp._isCompact)
         XCTAssertEqual(0, ulp._reserved)
@@ -850,6 +850,11 @@ class TestDecimal: XCTestCase {
         XCTAssertTrue(number.boolValue, "Should have received true")
 
         XCTAssertEqual(100,number.objCType.pointee, "ObjC type for NSDecimalNumber is 'd'")
+    }
+    
+    func test_ULP() {
+        let x = 0.1 as Decimal
+        XCTAssertFalse(x.ulp > x)
     }
 
     func test_ZeroPower() {
@@ -1457,6 +1462,7 @@ class TestDecimal: XCTestCase {
             ("test_ScanDecimal", test_ScanDecimal),
             ("test_SimpleMultiplication", test_SimpleMultiplication),
             ("test_SmallerNumbers", test_SmallerNumbers),
+            ("test_ULP", test_ULP),
             ("test_ZeroPower", test_ZeroPower),
             ("test_parseDouble", test_parseDouble),
             ("test_doubleValue", test_doubleValue),


### PR DESCRIPTION
Unfortunately, `Decimal.ulp` has never actually worked correctly. To make it short, users currently get an _invalid representation_ of an _incorrect result_—

1. The incorrect result: The implementation has never actually returned the "unit in the last place" as an IEEE floating-point type would. For instance, `print((0.1 as Decimal).ulp)` gives `0.1`, but it's obvious that the type has enough precision to be able to represent values between `0.1` and `0.2`. This is somewhat forgivable, though, because `Foundation.Decimal` isn't an IEEE decimal type.

2. The invalid representation: The implementation constructs a `Decimal` value explicitly with `_length` set to `8` but using a mantissa of only length `1`. This breaks `Foundation.Decimal` invariants and is not normalized by `NSDecimalNormalize`. Consequently, all sorts of weirdness happens when one tries to compare this invalid representation to valid ones. For instance, `(0.1 as Decimal).ulp == 0.1` evaluates to `false`, which is untenable because, as we just noted above, `print((0.1 as Decimal).ulp)` gives `0.1`.

This PR defers addressing (1), since it should be done in concert with addressing the implementation of `nextUp` and `nextDown`, and we'd need to consider whether that's a straightforward bugfix or whether it would break too much existing code that relies on the current behavior of these properties. What this PR does do is address (2) by changing the explicitly set `_length` to `1`; corresponding tests are added and adjusted as appropriate.