### PR TITLE
[5.5] Partially fix Decimal.ulp to return a valid representation.

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -209,7 +209,7 @@ class TestDecimal : XCTestCase {
         
         let ulp = explicit.ulp
         XCTAssertEqual(0x7f, ulp.exponent)
-        XCTAssertEqual(8, ulp._length)
+        XCTAssertEqual(1, ulp._length)
         XCTAssertEqual(0, ulp._isNegative)
         XCTAssertEqual(1, ulp._isCompact)
         XCTAssertEqual(0, ulp._reserved)
@@ -587,6 +587,11 @@ class TestDecimal : XCTestCase {
                 XCTAssertEqual(.orderedSame, NSDecimalCompare(&expected, &result), "\(expected._mantissa.0) == \(i) * \(j)");
             }
         }
+    }
+    
+    func test_ULP() {
+        let x = 0.1 as Decimal
+        XCTAssertFalse(x.ulp > x)
     }
 
     func test_unconditionallyBridgeFromObjectiveC() {

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -503,7 +503,7 @@ extension Decimal {
     public var ulp: Decimal {
         if !self.isFinite { return Decimal.nan }
         return Decimal(
-            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
             _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
 

--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -731,7 +731,7 @@ extension Decimal {
     public var ulp: Decimal {
         if !self.isFinite { return Decimal.nan }
         return Decimal(
-            _exponent: _exponent, _length: 8, _isNegative: 0, _isCompact: 1,
+            _exponent: _exponent, _length: 1, _isNegative: 0, _isCompact: 1,
             _reserved: 0, _mantissa: (0x0001, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000))
     }
 

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -271,7 +271,7 @@ class TestDecimal: XCTestCase {
 
         let ulp = explicit.ulp
         XCTAssertEqual(0x7f, ulp.exponent)
-        XCTAssertEqual(8, ulp._length)
+        XCTAssertEqual(1, ulp._length)
         XCTAssertEqual(0, ulp._isNegative)
         XCTAssertEqual(1, ulp._isCompact)
         XCTAssertEqual(0, ulp._reserved)
@@ -850,6 +850,11 @@ class TestDecimal: XCTestCase {
         XCTAssertTrue(number.boolValue, "Should have received true")
 
         XCTAssertEqual(100,number.objCType.pointee, "ObjC type for NSDecimalNumber is 'd'")
+    }
+    
+    func test_ULP() {
+        let x = 0.1 as Decimal
+        XCTAssertFalse(x.ulp > x)
     }
 
     func test_ZeroPower() {
@@ -1457,6 +1462,7 @@ class TestDecimal: XCTestCase {
             ("test_ScanDecimal", test_ScanDecimal),
             ("test_SimpleMultiplication", test_SimpleMultiplication),
             ("test_SmallerNumbers", test_SmallerNumbers),
+            ("test_ULP", test_ULP),
             ("test_ZeroPower", test_ZeroPower),
             ("test_parseDouble", test_parseDouble),
             ("test_doubleValue", test_doubleValue),


### PR DESCRIPTION
This PR cherry-picks #3014 for the release/5.5 branch.