### PR TITLE
asprintf exists on linux

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1472,7 +1472,7 @@ void _CF_dispatch_once(dispatch_once_t *predicate, void (^block)(void)) {
 #pragma mark -
 #pragma mark Windows and Linux Helpers
 
-#if TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_WIN32
 
 #include <stdio.h>
 

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -414,7 +414,7 @@ CF_INLINE int popcountll(long long x) {
 #define CF_TEST_PRIVATE CF_PRIVATE
 #endif
 
-#if TARGET_OS_LINUX || TARGET_OS_WIN32
+#if TARGET_OS_WIN32
 
 #include <stdarg.h>
 


### PR DESCRIPTION
asprintf exists on linux for quite a while, 2015 at least. do use it.

fixes https://bugs.swift.org/browse/SR-14935
