### PR TITLE
Add `|| TARGET_OS_WASI` to ifdef in `uuid.c`

### DIFF
--- a/Sources/UUID/uuid.c
+++ b/Sources/UUID/uuid.c
@@ -61,7 +61,7 @@ static inline void nanotime(struct timespec *tv) {
     tv->tv_nsec = now - (tv->tv_sec * 1000000000);
 }
 
-#elif TARGET_OS_LINUX || TARGET_OS_BSD
+#elif TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include <time.h>
 
 static inline void nanotime(struct timespec *tv) {


### PR DESCRIPTION
This makes `nanotime` implementation available for Wasm/WASI.