### PR TITLE
Allow disabling Dispatch and Networking in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,14 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 option(BUILD_SHARED_LIBS "build shared libraries" ON)
+option(HAS_LIBDISPATCH_API "has libdispatch API" ON)
+option(BUILD_NETWORKING "build FoundationNetworking module" ON)
+option(BUILD_TOOLS "build tools" ON)
 option(NS_CURL_ASSUME_FEATURES_MISSING "Assume that optional libcurl features are missing rather than test the library's version, for build debugging" NO)
 
-find_package(dispatch CONFIG REQUIRED)
+if(HAS_LIBDISPATCH_API)
+  find_package(dispatch CONFIG REQUIRED)
+endif()
 
 include(SwiftSupport)
 include(GNUInstallDirs)
@@ -52,6 +57,12 @@ set(SAVED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS NO)
 add_subdirectory(CoreFoundation EXCLUDE_FROM_ALL)
 set(BUILD_SHARED_LIBS ${SAVED_BUILD_SHARED_LIBS})
+
+# BlocksRuntime is already in libdispatch so it is only needed if libdispatch is
+# NOT being used
+if(NOT HAS_LIBDISPATCH_API)
+  add_subdirectory(Sources/BlocksRuntime)
+endif()
 
 # Setup include paths for uuid/uuid.h
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/uuid-headers/uuid/uuid.h
@@ -74,9 +85,22 @@ endif()
 
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS
-    CoreFoundation CFXMLInterface CFURLSessionInterface)
-  install(TARGETS CoreFoundation CFXMLInterface CFURLSessionInterface
+    CoreFoundation CFXMLInterface)
+
+  if(NOT HAS_LIBDISPATCH_API)
+    set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS
+      BlocksRuntime)
+  endif()
+
+  install(TARGETS CoreFoundation CFXMLInterface
     DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
+
+  if(BUILD_NETWORKING)
+    set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS
+      CFURLSessionInterface)
+    install(TARGETS CFURLSessionInterface
+      DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
+  endif()
 endif()
 
 set(swift_lib_dir "lib/swift")


### PR DESCRIPTION
Dispatch and Networking aren't available for Wasm and WASI. We should make these parts configurable to make it possible to turn them off when building for that platform.