### PR TITLE
Add support for WASI in `CFUtilities.c`

### DIFF
--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -18,13 +18,17 @@
 #include <CoreFoundation/CFPriv.h>
 #include "CFInternal.h"
 #include "CFLocaleInternal.h"
+#if !TARGET_OS_WASI
 #include "CFBundle_Internal.h"
+#endif
 #include <CoreFoundation/CFPriv.h>
 #if TARGET_OS_MAC || TARGET_OS_WIN32
 #include <CoreFoundation/CFBundle.h>
 #endif
 #include <CoreFoundation/CFURLAccess.h>
+#if !TARGET_OS_WASI
 #include <CoreFoundation/CFPropertyList.h>
+#endif
 #if TARGET_OS_WIN32
 #include <process.h>
 #endif
@@ -65,7 +69,7 @@
 #include <os/lock.h>
 #endif
 
-#if TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include <string.h>
 #include <sys/mman.h>
 #endif
@@ -354,6 +358,7 @@ static CFDictionaryRef _CFCopyVersionDictionary(CFStringRef path) {
     return (CFDictionaryRef)plist;
 }
 
+#if !TARGET_OS_WASI
 CFStringRef _CFCopySystemVersionDictionaryValue(CFStringRef key) {
     CFStringRef versionString;
     CFDictionaryRef dict = _CFCopyServerVersionDictionary();
@@ -462,14 +467,12 @@ CONST_STRING_DECL(_kCFSystemVersionProductUserVisibleVersionKey, "ProductUserVis
 CONST_STRING_DECL(_kCFSystemVersionBuildVersionKey, "ProductBuildVersion")
 CONST_STRING_DECL(_kCFSystemVersionProductVersionStringKey, "Version")
 CONST_STRING_DECL(_kCFSystemVersionBuildStringKey, "Build")
+#endif
 
 
 CF_EXPORT Boolean _CFExecutableLinkedOnOrAfter(CFSystemVersion version) {
     return true;
 }
-
-
-
 
 #if TARGET_OS_OSX
 CF_PRIVATE void *__CFLookupCarbonCoreFunction(const char *name) {
@@ -637,7 +640,8 @@ CF_INLINE BOOL _CFCanChangeEUIDs(void) {
     return true;
 #endif
 }
-    
+
+#if !TARGET_OS_WASI
 typedef struct _ugids {
     uid_t _euid;
     uid_t _egid;
@@ -690,6 +694,7 @@ CF_EXPORT uid_t _CFGetEGID(void) {
     __CFGetUGIDs(NULL, &egid);
     return egid;
 }
+#endif // !TARGET_OS_WASI
 
 const char *_CFPrintForDebugger(const void *obj) {
 	static char *result = NULL;
@@ -900,6 +905,9 @@ static void _populateBanner(char **banner, char **time, char **thread, int *bann
 #elif TARGET_OS_WIN32
     bannerLen = asprintf(banner, "%04d-%02d-%02d %02d:%02d:%02d.%03d %s[%d:%lx] ", year, month, day, hour, minute, second, ms, *_CFGetProgname(), getpid(), GetCurrentThreadId());
     asprintf(thread, "%lx", GetCurrentThreadId());
+#elif TARGET_OS_WASI
+    bannerLen = asprintf(banner, "%04d-%02d-%02d %02d:%02d:%02d.%03d [%x] ", year, month, day, hour, minute, second, ms, (unsigned int)pthread_self());
+    asprintf(thread, "%lx", pthread_self());
 #else
     bannerLen = asprintf(banner, "%04d-%02d-%02d %02d:%02d:%02d.%03d %s[%d:%x] ", year, month, day, hour, minute, second, ms, *_CFGetProgname(), getpid(), (unsigned int)pthread_self());
     asprintf(thread, "%lx", pthread_self());
@@ -1080,8 +1088,12 @@ CF_PRIVATE void _CFLogSimple(int32_t lev, char *format, ...) {
 
 void CFLog(int32_t lev, CFStringRef format, ...) {
     va_list args;
-    va_start(args, format); 
+    va_start(args, format);
+#if TARGET_OS_WASI
+    _CFLogvEx3(NULL, NULL, NULL, NULL, lev, format, args, NULL);
+#else
     _CFLogvEx3(NULL, NULL, NULL, NULL, lev, format, args, __builtin_return_address(0));
+#endif
     va_end(args);
 }
     
@@ -1333,7 +1345,7 @@ CF_PRIVATE Boolean _CFReadMappedFromFile(CFStringRef path, Boolean map, Boolean 
     if (0LL == statBuf.st_size) {
         bytes = malloc(8); // don't return constant string -- it's freed!
 	length = 0;
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
     } else if (map) {
         if((void *)-1 == (bytes = mmap(0, (size_t)statBuf.st_size, PROT_READ, MAP_PRIVATE, fd, 0))) {
 	    int32_t savederrno = errno;
@@ -1628,7 +1640,7 @@ CF_EXPORT Boolean _CFExtensionIsValidToAppend(CFStringRef extension) {
 }
 
 
-#if DEPLOYMENT_RUNTIME_SWIFT
+#if DEPLOYMENT_RUNTIME_SWIFT && !TARGET_OS_WASI
 
 CFDictionaryRef __CFGetEnvironment() {
     static dispatch_once_t once = 0L;
@@ -1689,4 +1701,4 @@ int32_t __CFGetPid() {
     return getpid();
 }
 
-#endif
+#endif // DEPLOYMENT_RUNTIME_SWIFT && !TARGET_OS_WASI


### PR DESCRIPTION
Processes, file access, platform info, and bundles aren't available on WASI, so these have to be disabled when compiling for that platform.