### PR TITLE
Add `CMakeLists.txt` to `Sources/BlocksRuntime`

### DIFF
--- a/Sources/BlocksRuntime/CMakeLists.txt
+++ b/Sources/BlocksRuntime/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(BlocksRuntime
+  data.c
+  runtime.c)
+
+target_include_directories(BlocksRuntime PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR})
+
+set_target_properties(BlocksRuntime PROPERTIES
+  POSITION_INDEPENDENT_CODE FALSE)
+
+add_library(BlocksRuntime::BlocksRuntime ALIAS BlocksRuntime)
+
+install(TARGETS BlocksRuntime
+  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)


### PR DESCRIPTION
Sources in this directory are unused on most platforms, since Blocks are already included in libdispatch. Platforms, such as WASI, that don't have multi-threading support need to build BlocksRuntime bundled with Foundation.