### PR TITLE
Revert "Fix autolink mechanism for static libraries on Linux"

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -160,18 +160,6 @@ set_target_properties(Foundation PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
-if(NOT BUILD_SHARED_LIBS)
-  target_compile_options(Foundation
-    PRIVATE
-      "SHELL:-Xfrontend -public-autolink-library -Xfrontend icui18n
-             -Xfrontend -public-autolink-library -Xfrontend BlocksRuntime")
-
-  # Merge private dependencies into single static objects archive
-  set_property(TARGET Foundation PROPERTY STATIC_LIBRARY_OPTIONS
-    $<TARGET_OBJECTS:CoreFoundation>
-    $<TARGET_OBJECTS:uuid>)
-endif()
-
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   # NOTE: workaround for CMake which doesn't link in OBJECT libraries properly
   add_dependencies(Foundation CoreFoundationResources)

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -64,17 +64,6 @@ target_link_libraries(FoundationNetworking
     CFURLSessionInterface
   PUBLIC
     Foundation)
-
-if(NOT BUILD_SHARED_LIBS)
-  target_compile_options(FoundationNetworking
-    PRIVATE
-      "SHELL:-Xfrontend -public-autolink-library -Xfrontend curl")
-
-  # Merge private dependencies into single static objects archive
-  set_property(TARGET FoundationNetworking PROPERTY STATIC_LIBRARY_OPTIONS
-    $<TARGET_OBJECTS:CFURLSessionInterface>)
-endif()
-
 set_target_properties(FoundationNetworking PROPERTIES
   INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -16,17 +16,6 @@ target_link_libraries(FoundationXML
     CFXMLInterface
   PUBLIC
     Foundation)
-
-if(NOT BUILD_SHARED_LIBS)
-  target_compile_options(FoundationXML
-    PRIVATE
-      "SHELL:-Xfrontend -public-autolink-library -Xfrontend xml2")
-
-  # Merge private dependencies into single static objects archive
-  set_property(TARGET FoundationXML PROPERTY STATIC_LIBRARY_OPTIONS
-    $<TARGET_OBJECTS:CFXMLInterface>)
-endif()
-
 set_target_properties(FoundationXML PROPERTIES
   INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift


### PR DESCRIPTION
Reverts apple/swift-corelibs-foundation#2996

The icui18n library that is linked against is not necessarily the same as the one used to build Foundation and Swift, so this is causing builds to fail.