### PR TITLE
Add support for CF data structures/utils on WASI

### DIFF
--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -48,6 +48,11 @@ CF_INLINE unsigned long __CFPageSize() {
 CF_INLINE unsigned long __CFPageSize() {
     return (unsigned long)getpagesize();
 }
+#elif TARGET_OS_WASI
+CF_INLINE unsigned long __CFPageSize() {
+    // WebAssembly linear memory pages are always 64KiB in size
+    return 65536;
+}
 #endif
 
 #define INLINE_BYTES_THRESHOLD ((4 * __CFPageSize()) - sizeof(struct __CFData) - 15)

--- a/CoreFoundation/Locale.subproj/CFLocale.c
+++ b/CoreFoundation/Locale.subproj/CFLocale.c
@@ -15,12 +15,16 @@
 #include <CoreFoundation/CFString.h>
 #include <CoreFoundation/CFArray.h>
 #include <CoreFoundation/CFDictionary.h>
-#include <CoreFoundation/CFPreferences.h>
 #include <CoreFoundation/CFCalendar.h>
 #include <CoreFoundation/CFNumber.h>
 #include "CFInternal.h"
 #include "CFRuntime_Internal.h"
+#if !TARGET_OS_WASI
+#include <CoreFoundation/CFPreferences.h>
 #include "CFBundle_Internal.h"
+#else
+#include "CFBase.h"
+#endif
 #include "CFLocaleInternal.h"
 #include <stdatomic.h>
 #if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_BSD

--- a/CoreFoundation/Locale.subproj/CFLocaleKeys.c
+++ b/CoreFoundation/Locale.subproj/CFLocaleKeys.c
@@ -132,7 +132,7 @@ CONST_STRING_DECL(kCFCalendarIdentifierEthiopicAmeteMihret, "ethiopic");
 CONST_STRING_DECL(kCFCalendarIdentifierEthiopicAmeteAlem, "ethiopic-amete-alem");
 
 // Aliases for other platforms.
-#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WIN32
+#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WIN32 || TARGET_OS_WASI
 
 CF_EXPORT CFStringRef const kCFBuddhistCalendar __attribute__((alias ("kCFCalendarIdentifierBuddhist")));
 CF_EXPORT CFStringRef const kCFChineseCalendar __attribute__((alias ("kCFCalendarIdentifierChinese")));

--- a/CoreFoundation/NumberDate.subproj/CFNumber.c
+++ b/CoreFoundation/NumberDate.subproj/CFNumber.c
@@ -178,7 +178,7 @@ static const Float64Bits doubleOneBits = {.floatValue = 1.0f};
 #define BITSFORDOUBLEZERO doubleZeroBits.bits
 #define BITSFORDOUBLEONE  doubleOneBits.bits
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #define FLOAT_POSITIVE_2_TO_THE_64	0x1.0p+64L
 #define FLOAT_NEGATIVE_2_TO_THE_127	-0x1.0p+127L
 #define FLOAT_POSITIVE_2_TO_THE_127	0x1.0p+127L

--- a/CoreFoundation/NumberDate.subproj/CFTimeZone.c
+++ b/CoreFoundation/NumberDate.subproj/CFTimeZone.c
@@ -25,11 +25,13 @@
 #include <unicode/udat.h>
 #include <unicode/ustring.h>
 #include <CoreFoundation/CFDateFormatter.h>
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include <dirent.h>
 #include <unistd.h>
-#if !TARGET_OS_ANDROID
+#if !TARGET_OS_ANDROID && !TARGET_OS_WASI
 #include <sys/fcntl.h>
+#elif TARGET_OS_WASI
+#include <fcntl.h>
 #else
 #include <sys/endian.h>
 #endif
@@ -47,7 +49,7 @@
 #include <tzfile.h>
 #define MACOS_TZDIR1 "/usr/share/zoneinfo/"          // 10.12 and earlier
 #define MACOS_TZDIR2 "/var/db/timezone/zoneinfo/"    // 10.13 onwards
-#elif TARGET_OS_LINUX || TARGET_OS_BSD
+#elif TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #ifndef TZDIR
 #define TZDIR	"/usr/share/zoneinfo/" /* Time zone object file directory */
 #endif /* !defined TZDIR */
@@ -57,7 +59,7 @@
 #endif /* !defined TZDEFAULT */
 #endif
 
-#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WIN32
+#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WIN32 || TARGET_OS_WASI
 struct tzhead {
     char	tzh_magic[4];		/* TZ_MAGIC */
     char	tzh_reserved[16];	/* reserved for future use */
@@ -351,7 +353,7 @@ static CFMutableArrayRef __CFCopyAndroidTimeZoneList() {
     return result;
 }
 
-#elif TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#elif TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 static CFMutableArrayRef __CFCopyRecursiveDirectoryList() {
     CFMutableArrayRef result = CFArrayCreateMutable(kCFAllocatorSystemDefault, 0, &kCFTypeArrayCallBacks);
 #if !TARGET_OS_ANDROID
@@ -810,7 +812,7 @@ static void __InitTZStrings(void) {
 
 #elif TARGET_OS_ANDROID
 // Nothing
-#elif TARGET_OS_LINUX || TARGET_OS_BSD
+#elif TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 static void __InitTZStrings(void) {
     __tzZoneInfo = CFSTR(TZDIR);
     __tzDir = TZDIR "zone.tab";
@@ -863,7 +865,7 @@ static CFTimeZoneRef __CFTimeZoneCreateSystem(void) {
         if (result) return result;
     }
 
-#if !TARGET_OS_ANDROID
+#if !TARGET_OS_ANDROID && !TARGET_OS_WASI
     if (!__tzZoneInfo) __InitTZStrings();
     ret = readlink(TZDEFAULT, linkbuf, sizeof(linkbuf));
     // The link can be relative, we treat this the same as if there was no link
@@ -880,9 +882,11 @@ static CFTimeZoneRef __CFTimeZoneCreateSystem(void) {
     } else
 #endif
     {
+        #if !TARGET_OS_WASI
         // TODO: This can still fail on Linux if the time zone is not recognized by ICU later
         // Try localtime
         tzset();
+        #endif
         time_t t = time(NULL);
         struct tm lt = {0};
         localtime_r(&t, &lt);
@@ -1348,7 +1352,8 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
 
     return FALSE;
 #else
-#if !TARGET_OS_ANDROID
+#if !TARGET_OS_ANDROID && !TARGET_OS_WASI
+
     if (!__tzZoneInfo) __InitTZStrings();
     if (!__tzZoneInfo) return NULL;
     baseURL = CFURLCreateWithFileSystemPath(kCFAllocatorSystemDefault, __tzZoneInfo, kCFURLPOSIXPathStyle, true);
@@ -1367,7 +1372,7 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
         if (mapping) {
             name = mapping;
         }
-#if !TARGET_OS_ANDROID
+#if !TARGET_OS_ANDROID && !TARGET_OS_WASI
         else if (CFStringHasPrefix(name, __tzZoneInfo)) {
             CFMutableStringRef unprefixed = CFStringCreateMutableCopy(kCFAllocatorSystemDefault, CFStringGetLength(name), name);
             CFStringDelete(unprefixed, CFRangeMake(0, CFStringGetLength(__tzZoneInfo)));
@@ -1383,7 +1388,7 @@ Boolean _CFTimeZoneInit(CFTimeZoneRef timeZone, CFStringRef name, CFDataRef data
             return false;
         }
     }
-    if (NULL == data) {
+    if (NULL == data && NULL != baseURL) {
         tzName = name;
         data = _CFTimeZoneDataCreate(baseURL, tzName);
     }

--- a/CoreFoundation/Parsing.subproj/CFBinaryPList.c
+++ b/CoreFoundation/Parsing.subproj/CFBinaryPList.c
@@ -29,7 +29,10 @@
 #include <string.h>
 #include "CFInternal.h"
 #include "CFRuntime_Internal.h"
+
+#if !TARGET_OS_WASI
 #include <CoreFoundation/CFStream.h>
+#endif
 
 enum {
 	CF_NO_ERROR = 0,
@@ -130,6 +133,7 @@ uint32_t _CFKeyedArchiverUIDGetValue(CFKeyedArchiverUIDRef uid) {
 
 CF_PRIVATE CFErrorRef __CFPropertyListCreateError(CFIndex code, CFStringRef debugString, ...);
 
+#if !TARGET_OS_WASI
 typedef struct {
     CFTypeRef stream;
     void *databytes;
@@ -691,6 +695,7 @@ CF_PRIVATE CFDataRef __CFBinaryPlistCreateDataUsingExternalBufferAllocator(CFPro
     }
     return result;
 }
+#endif
 
 #pragma mark -
 #pragma mark Reading

--- a/CoreFoundation/Parsing.subproj/CFPropertyList.c
+++ b/CoreFoundation/Parsing.subproj/CFPropertyList.c
@@ -23,7 +23,9 @@
 #include "CFRuntime_Internal.h"
 #include <CoreFoundation/CFBurstTrie.h>
 #include <CoreFoundation/CFString.h>
+#if !TARGET_OS_WASI
 #include <CoreFoundation/CFStream.h>
+#endif
 #include <CoreFoundation/CFCalendar.h>
 #include "CFLocaleInternal.h"
 #include <limits.h>
@@ -2850,7 +2852,6 @@ CFSetRef _CFPropertyListCopyTopLevelKeys(CFAllocatorRef allocator, CFDataRef dat
 }
 
 
-
 // Legacy
 CFTypeRef _CFPropertyListCreateFromXMLData(CFAllocatorRef allocator, CFDataRef xmlData, CFOptionFlags option, CFStringRef *errorString, Boolean allowNewTypes, CFPropertyListFormat *format) {
     CFTypeRef out = NULL;
@@ -2883,6 +2884,7 @@ CFPropertyListRef CFPropertyListCreateFromXMLData(CFAllocatorRef allocator, CFDa
     return result;
 }
 
+#if !TARGET_OS_WASI
 CFDataRef CFPropertyListCreateData(CFAllocatorRef allocator, CFPropertyListRef propertyList, CFPropertyListFormat format, CFOptionFlags options, CFErrorRef *error) {
     CFAssert1(format != kCFPropertyListOpenStepFormat, __kCFLogAssertion, "%s(): kCFPropertyListOpenStepFormat not supported for writing", __PRETTY_FUNCTION__);
     CFAssert2(format == kCFPropertyListXMLFormat_v1_0 || format == kCFPropertyListBinaryFormat_v1_0, __kCFLogAssertion, "%s(): Unrecognized option %ld", __PRETTY_FUNCTION__, format);
@@ -3136,6 +3138,7 @@ bool _CFPropertyListValidateData(CFDataRef data, CFTypeID *outTopLevelTypeID) {
     return result;
 }
 
+#endif
 
 #pragma mark -
 #pragma mark Property List Copies

--- a/CoreFoundation/Parsing.subproj/CFPropertyList.h
+++ b/CoreFoundation/Parsing.subproj/CFPropertyList.h
@@ -14,7 +14,10 @@
 #include <CoreFoundation/CFData.h>
 #include <CoreFoundation/CFString.h>
 #include <CoreFoundation/CFError.h>
+
+#if !TARGET_OS_WASI
 #include <CoreFoundation/CFStream.h>
+#endif
 
 CF_IMPLICIT_BRIDGING_ENABLED
 CF_EXTERN_C_BEGIN
@@ -82,6 +85,7 @@ Boolean CFPropertyListIsValid(CFPropertyListRef plist, CFPropertyListFormat form
 
 CF_IMPLICIT_BRIDGING_DISABLED
 
+#if !TARGET_OS_WASI
 /* Writes the bytes of a plist serialization out to the stream.  The
  * stream must be opened and configured -- the function simply writes
  * a bunch of bytes to the stream. The output plist format can be chosen.
@@ -113,6 +117,7 @@ CFPropertyListRef CFPropertyListCreateFromStream(CFAllocatorRef allocator, CFRea
 CF_IMPLICIT_BRIDGING_ENABLED
 
 CF_IMPLICIT_BRIDGING_DISABLED
+#endif
 
 CF_ENUM(CFIndex) {
     kCFPropertyListReadCorruptError = 3840,              // Error parsing a property list
@@ -126,6 +131,7 @@ CF_ENUM(CFIndex) {
 CF_EXPORT
 CFPropertyListRef CFPropertyListCreateWithData(CFAllocatorRef allocator, CFDataRef data, CFOptionFlags options, CFPropertyListFormat *format, CFErrorRef *error) API_AVAILABLE(macos(10.6), ios(4.0), watchos(2.0), tvos(9.0));
 
+#if !TARGET_OS_WASI
 /* Create and return a property list with a CFReadStream input. If the format parameter is non-NULL, it will be set to the format of the data after parsing is complete. The options parameter is used to specify CFPropertyListMutabilityOptions. The streamLength parameter specifies the number of bytes to read from the stream. Set streamLength to 0 to read until the end of the stream is detected. If an error occurs while parsing the data, the return value will be NULL. Additionally, if an error occurs and the error parameter is non-NULL, the error parameter will be set to a CFError describing the problem, which the caller must release. If the parse succeeds, the returned value is a reference to the new property list. It is the responsibility of the caller to release this value.
  */
 CF_EXPORT
@@ -135,6 +141,7 @@ CFPropertyListRef CFPropertyListCreateWithStream(CFAllocatorRef allocator, CFRea
  */
 CF_EXPORT
 CFIndex CFPropertyListWrite(CFPropertyListRef propertyList, CFWriteStreamRef stream, CFPropertyListFormat format, CFOptionFlags options, CFErrorRef *error) API_AVAILABLE(macos(10.6), ios(4.0), watchos(2.0), tvos(9.0));
+#endif
 
 /* Create a CFData with the bytes of a serialized property list. The format of the property list can be chosen with the format parameter. The options parameter is currently unused and should be set to 0. If an error occurs while parsing the data, the return value will be NULL. Additionally, if an error occurs and the error parameter is non-NULL, the error parameter will be set to a CFError describing the problem, which the caller must release. If the conversion succeeds, the returned value is a reference to the created data. It is the responsibility of the caller to release this value.
  */
@@ -145,6 +152,5 @@ CF_IMPLICIT_BRIDGING_ENABLED
 
 CF_EXTERN_C_END
 CF_IMPLICIT_BRIDGING_DISABLED
-
 #endif /* ! __COREFOUNDATION_CFPROPERTYLIST__ */
 

--- a/CoreFoundation/String.subproj/CFBurstTrie.c
+++ b/CoreFoundation/String.subproj/CFBurstTrie.c
@@ -18,7 +18,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <limits.h>
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include <unistd.h>
 #include <sys/param.h>
 #include <sys/mman.h>

--- a/CoreFoundation/String.subproj/CFCharacterSet.c
+++ b/CoreFoundation/String.subproj/CFCharacterSet.c
@@ -731,7 +731,7 @@ static void __CFCSetAddNonBMPPlanesInRange(CFMutableCharacterSetRef cset, CFRang
     int firstChar = (range.location & 0xFFFF);
     int maxChar = range.location + range.length;
     int idx = range.location >> 16; // first plane
-    int maxPlane = MIN((maxChar - 1) >> 16, MAX_ANNEX_PLANE); // last plane
+    int maxPlane = __CFMin((maxChar - 1) >> 16, MAX_ANNEX_PLANE); // last plane
     CFRange planeRange;
     CFMutableCharacterSetRef annexPlane;
 
@@ -775,7 +775,7 @@ static void __CFCSetRemoveNonBMPPlanesInRange(CFMutableCharacterSetRef cset, CFR
     int firstChar = (range.location & 0xFFFF);
     int maxChar = range.location + range.length;
     int idx = range.location >> 16; // first plane
-    int maxPlane = MIN((maxChar - 1) >> 16, MAX_ANNEX_PLANE); // last plane
+    int maxPlane = __CFMin((maxChar - 1) >> 16, MAX_ANNEX_PLANE); // last plane
     CFRange planeRange;
     CFMutableCharacterSetRef annexPlane;
 

--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -426,7 +426,7 @@ CFStringEncoding __CFDefaultEightBitStringEncoding = kCFStringEncodingInvalidId;
 
 #if TARGET_OS_MAC
 #define __defaultEncoding kCFStringEncodingMacRoman
-#elif TARGET_OS_LINUX
+#elif TARGET_OS_LINUX || TARGET_OS_WASI
 #define __defaultEncoding kCFStringEncodingUTF8
 #elif TARGET_OS_WIN32
 #define __defaultEncoding kCFStringEncodingWindowsLatin1

--- a/CoreFoundation/String.subproj/CFStringEncodings.c
+++ b/CoreFoundation/String.subproj/CFStringEncodings.c
@@ -656,7 +656,7 @@ CFIndex __CFStringEncodeByteStream(CFStringRef string, CFIndex rangeLoc, CFIndex
                     return numCharsProcessed;
                 }
 		
-                CFIndex uninterestingTailLen = buffer ? (rangeLen - MIN(max, rangeLen)) : 0;
+                CFIndex uninterestingTailLen = buffer ? (rangeLen - __CFMin(max, rangeLen)) : 0;
                 while (*ptr < 0x80 && rangeLen > uninterestingTailLen) {
                     ++ptr;
                     --rangeLen;

--- a/CoreFoundation/String.subproj/CFStringUtilities.c
+++ b/CoreFoundation/String.subproj/CFStringUtilities.c
@@ -640,7 +640,7 @@ CF_PRIVATE CFComparisonResult _CFCompareStringsWithLocale(CFStringInlineBuffer *
         } else
 #endif
         {
-            compResult = ((memcmp(characters1, characters2, sizeof(UniChar) * MIN(range1.length, range2.length)) < 0) ? kCFCompareLessThan : kCFCompareGreaterThan);
+            compResult = ((memcmp(characters1, characters2, sizeof(UniChar) * __CFMin(range1.length, range2.length)) < 0) ? kCFCompareLessThan : kCFCompareGreaterThan);
         }
     } else {
         UniChar *buffer1 = NULL;

--- a/CoreFoundation/StringEncodings.subproj/CFUniChar.c
+++ b/CoreFoundation/StringEncodings.subproj/CFUniChar.c
@@ -10,12 +10,13 @@
 
 #include <CoreFoundation/CFBase.h>
 #include <CoreFoundation/CFByteOrder.h>
+#include "CFBase.h"
 #include "CFInternal.h"
 #include "CFUniChar.h" 
 #include "CFStringEncodingConverterExt.h"
 #include "CFUnicodeDecomposition.h"
 #include "CFUniCharPriv.h"
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -34,7 +35,7 @@ extern void _CFGetFrameworkPath(wchar_t *path, int maxLength);
 
 #if TARGET_OS_MAC
 #define __kCFCharacterSetDir "/System/Library/CoreServices"
-#elif TARGET_OS_LINUX || TARGET_OS_BSD
+#elif TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #define __kCFCharacterSetDir "/usr/local/share/CoreFoundation"
 #elif TARGET_OS_WIN32
 #define __kCFCharacterSetDir "\\Windows\\CoreFoundation"
@@ -42,7 +43,7 @@ extern void _CFGetFrameworkPath(wchar_t *path, int maxLength);
 
 #if TARGET_OS_MAC
 #define USE_MACHO_SEGMENT 1
-#elif DEPLOYMENT_RUNTIME_SWIFT && (TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WIN32)
+#elif DEPLOYMENT_RUNTIME_SWIFT && (TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WIN32 || TARGET_OS_WASI)
 #define USE_RAW_SYMBOL 1
 #endif
 
@@ -107,7 +108,7 @@ static const void *__CFGetSectDataPtr(const char *segname, const char *sectname,
 
 // Memory map the file
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 CF_INLINE void __CFUniCharCharacterSetPath(char *cpath) {
 #elif TARGET_OS_WIN32
 CF_INLINE void __CFUniCharCharacterSetPath(wchar_t *wpath) {
@@ -171,7 +172,7 @@ void __AddBitmapStateForName(const wchar_t *bitmapName) {
 }
 #endif
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 static bool __CFUniCharLoadBytesFromFile(const char *fileName, const void **bytes, int64_t *fileSize) {
 #elif TARGET_OS_WIN32
 static bool __CFUniCharLoadBytesFromFile(const wchar_t *fileName, const void **bytes, int64_t *fileSize) {
@@ -238,7 +239,7 @@ static bool __CFUniCharLoadBytesFromFile(const wchar_t *fileName, const void **b
 #endif // USE_MACHO_SEGMENT
 
     
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #if !defined(CF_UNICHAR_BITMAP_FILE)
 #if USE_MACHO_SEGMENT
 #define CF_UNICHAR_BITMAP_FILE "__csbitmaps"
@@ -254,7 +255,7 @@ static bool __CFUniCharLoadBytesFromFile(const wchar_t *fileName, const void **b
 #error Unknown or unspecified DEPLOYMENT_TARGET
 #endif
     
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #if __CF_BIG_ENDIAN__
 #if USE_MACHO_SEGMENT
 #define MAPPING_TABLE_FILE "__data"
@@ -286,7 +287,7 @@ static bool __CFUniCharLoadBytesFromFile(const wchar_t *fileName, const void **b
 #error Unknown or unspecified DEPLOYMENT_TARGET
 #endif
     
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #if USE_MACHO_SEGMENT
 #define PROP_DB_FILE "__properties"
 #else
@@ -308,7 +309,7 @@ static bool __CFUniCharLoadBytesFromFile(const wchar_t *fileName, const void **b
 #define CF_UNICODE_DATA_SYM __CFUnicodeDataL
 #endif
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 static bool __CFUniCharLoadFile(const char *bitmapName, const void **bytes, int64_t *fileSize) {
 #if USE_MACHO_SEGMENT
     *bytes = __CFGetSectDataPtr("__UNICODE", bitmapName, NULL);
@@ -1227,7 +1228,7 @@ static __CFUniCharBitmapData *__CFUniCharUnicodePropertyTable = NULL;
 static int __CFUniCharUnicodePropertyTableCount = 0;
 
 const void *CFUniCharGetUnicodePropertyDataForPlane(uint32_t propertyType, uint32_t plane) {
-    static dispatch_once_t once = 0L;
+    static dispatch_once_t once = 0;
     dispatch_once(&once, ^{
         __CFUniCharBitmapData *table;
         const void *bytes;

--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -53,7 +53,9 @@ static CFStringRef WindowsPathToURLPath(CFStringRef path, CFAllocatorRef alloc, 
 static CFStringRef POSIXPathToURLPath(CFStringRef path, CFAllocatorRef alloc, Boolean isDirectory, Boolean isAbsolute, Boolean *posixAndUrlPathsMatch) CF_RETURNS_RETAINED;
 static CFStringRef CreateStringFromFileSystemRepresentationByAddingPercentEscapes(CFAllocatorRef alloc, const UInt8 *bytes, CFIndex numBytes, Boolean isDirectory, Boolean isAbsolute, Boolean windowsPath, Boolean *addedPercentEncoding) CF_RETURNS_RETAINED;
 CFStringRef CFURLCreateStringWithFileSystemPath(CFAllocatorRef allocator, CFURLRef anURL, CFURLPathStyle fsType, Boolean resolveAgainstBase) CF_RETURNS_RETAINED;
+#if !TARGET_OS_WASI
 CF_EXPORT CFURLRef _CFURLCreateCurrentDirectoryURL(CFAllocatorRef allocator) CF_RETURNS_RETAINED;
+#endif
 #if TARGET_OS_MAC
 static Boolean _CFURLHasFileURLScheme(CFURLRef url, Boolean *hasScheme);
 #endif
@@ -2187,11 +2189,13 @@ static CFURLRef _CFURLCreateWithFileSystemPath(CFAllocatorRef allocator, CFStrin
                 // if fileSystemPath is an absolute path, ignore baseURL (if provided)
                 baseURL = NULL;
             }
+#if !TARGET_OS_WASI
             else if ( baseURL == NULL ) {
                 // if fileSystemPath is a relative path and no baseURL is provided, use the current working directory
                 baseURL = _CFURLCreateCurrentDirectoryURL(allocator);
                 releaseBaseURL = true;
             }
+#endif
             
             // override isDirectory if the path is to root
             if ( !isDirectory && (len == 1) && (CFStringGetCharacterAtIndex(urlString, 0) == '/') ) {
@@ -2289,11 +2293,13 @@ static CFURLRef _CFURLCreateWithFileSystemRepresentation(CFAllocatorRef allocato
             baseURL = NULL;
             isFileReferencePath = _fileSystemRepresentationHasFileIDPrefix(buffer, bufLen);
         }
+#if !TARGET_OS_WASI
         else if ( baseURL == NULL ) {
             // if buffer contains a relative path and no baseURL is provided, use the current working directory
             baseURL = _CFURLCreateCurrentDirectoryURL(allocator);
             releaseBaseURL = true;
         }
+#endif
         CFStringRef urlString = CreateStringFromFileSystemRepresentationByAddingPercentEscapes(allocator, buffer, bufLen, isDirectory, isAbsolute, false /*windowsPath*/, &addedPercentEncoding);
         if ( urlString ) {
             // allocate the URL object with the appropriate number of ranges
@@ -4035,7 +4041,7 @@ static CFStringRef URLPathToPOSIXPath(CFStringRef path, CFAllocatorRef allocator
     return result;
 }
 
-#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 static Boolean CanonicalFileURLStringToFileSystemRepresentation(CFStringRef str, UInt8 *inBuffer, CFIndex inBufferLen)
 {
     size_t fileURLPrefixLength;
@@ -4290,6 +4296,7 @@ static CFStringRef _resolveFileSystemPaths(CFStringRef relativePath, CFStringRef
     return _resolvedPath(buf, buf + baseLen + relLen, pathDelimiter, false, true, alloc);
 }
 
+#if !TARGET_OS_WASI
 CFURLRef _CFURLCreateCurrentDirectoryURL(CFAllocatorRef allocator) {
     CFURLRef url = NULL;
     // CFMaxPathSize is OK here since we're getting the path from the file system
@@ -4299,6 +4306,7 @@ CFURLRef _CFURLCreateCurrentDirectoryURL(CFAllocatorRef allocator) {
     }
     return url;
 }
+#endif
 
 CFURLRef CFURLCreateWithFileSystemPath(CFAllocatorRef allocator, CFStringRef filePath, CFURLPathStyle fsType, Boolean isDirectory) {
     CFURLRef result;

--- a/CoreFoundation/URL.subproj/CFURLAccess.c
+++ b/CoreFoundation/URL.subproj/CFURLAccess.c
@@ -24,13 +24,15 @@ CFData read/write routines
 #include <CoreFoundation/CFNumber.h>
 #include <string.h>
 #include <ctype.h>
-#if TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include <stdlib.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#if !TARGET_OS_WASI
 #include <pwd.h>
+#endif
 #include <fcntl.h>
 #elif TARGET_OS_WIN32
 #include <io.h>
@@ -200,6 +202,7 @@ static CFDictionaryRef _CFFileURLCreatePropertiesFromResource(CFAllocatorRef all
     return propertyDict;
 }
 
+#if !TARGET_OS_WASI
 static Boolean _CFFileURLWritePropertiesToResource(CFURLRef url, CFDictionaryRef propertyDict, SInt32 *errorCode) {
     CFTypeRef buffer[16];
     CFTypeRef *keys;
@@ -233,7 +236,7 @@ static Boolean _CFFileURLWritePropertiesToResource(CFURLRef url, CFDictionaryRef
                 CFNumberRef modeNum = (CFNumberRef)value;
                 CFNumberGetValue(modeNum, kCFNumberSInt32Type, &mode);
             } else {
-#if TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_OSX || TARGET_OS_IOS || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #define MODE_TYPE mode_t
 #elif TARGET_OS_WIN32
 #define MODE_TYPE uint16_t
@@ -255,6 +258,7 @@ static Boolean _CFFileURLWritePropertiesToResource(CFURLRef url, CFDictionaryRef
     if (errorCode) *errorCode = result ? 0 : kCFURLUnknownError;
     return result;
 }
+#endif
 
 static Boolean _CFFileURLCreateDataAndPropertiesFromResource(CFAllocatorRef alloc, CFURLRef url, CFDataRef *fetchedData, CFArrayRef desiredProperties, CFDictionaryRef *fetchedProperties, SInt32 *errorCode) {
     Boolean success = true;
@@ -774,11 +778,13 @@ Boolean CFURLWriteDataAndPropertiesToResource(CFURLRef url, CFDataRef data, CFDi
                 if (!success && errorCode) *errorCode = kCFURLUnknownError;
             }
         }
+#if !TARGET_OS_WASI
         if (propertyDict) {
             if (!_CFFileURLWritePropertiesToResource(url, propertyDict, errorCode))
                 success = false;
         }
         return success;
+#endif
     } else {
         CFRelease(scheme);
 #if TARGET_OS_MAC


### PR DESCRIPTION
A lot of data structures, like strings, characters, data, locales, plists just need a proper check for `|| TARGET_OS_WASI` to be enabled on that platform and to use a suitable implementation. Some code related to filesystem access had to be disabled on WASI though.