### PR TITLE
tests: explicitly flush `stderr` on exit

### DIFF
--- a/Tests/Foundation/main.swift
+++ b/Tests/Foundation/main.swift
@@ -13,6 +13,8 @@
     import Darwin
 #elseif canImport(Glibc)
     import Glibc
+#elseif canImport(CRT)
+    import CRT
 #endif
 
 #if !os(Windows)
@@ -131,4 +133,8 @@ allTestCases.append(contentsOf: [
 ])
 #endif
 
+atexit({
+    fflush(stdout)
+    fflush(stderr)
+})
 XCTMain(allTestCases)


### PR DESCRIPTION
It has been observed in CI that the stderr output is sometimes truncated
on failure.  Explicitly flush the output to ensure that we can see the
error messages.  This has been observed on Windows which does not do a
courtesy flush unlike Linux.