### PR TITLE
CoreFoundation: add `US/Pacific` TimeZone mapping for Windows

### DIFF
--- a/CoreFoundation/OlsonWindowsMapping.plist
+++ b/CoreFoundation/OlsonWindowsMapping.plist
@@ -734,5 +734,7 @@
     <string>Line Islands Standard Time</string>
     <key>Etc/GMT-14</key>
     <string>Line Islands Standard Time</string>
+    <key>US/Pacific</key>
+    <string>Pacific Standard Time</string>
   </dict>
 </plist>


### PR DESCRIPTION
Windows does not have the same timezone information available as the
other platforms.  We import a subset of the CLDR (due to duplicate
mappings) into Foundation to provide the translation.
`TestCalendar/test_nextDate` usees `US/Pacific` for a test case.
Explicitly add this to the Olson -> Windows mapping.  We cannot provide
a Windows -> Olson mapping entry for this value as that would have
multiple values for the canonical `America/Los_Angeles` key.  This
repairs the `TestCalendar/test_nextDate` test case on Windows.