### PR TITLE
tests: repair `TestNSData/test_writeToURLSpecialFile`

### DIFF
--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -625,7 +625,11 @@ class TestNSData: LoopbackServerTest {
     }
 
     func test_writeToURLSpecialFile() {
+#if os(Windows)
+        let url = URL(fileURLWithPath: "CON")
+#else
         let url = URL(fileURLWithPath: "/dev/stdout")
+#endif
         XCTAssertNoThrow(try Data("Output to STDOUT\n".utf8).write(to: url))
     }
 


### PR DESCRIPTION
This test was added recently and regressed the test suite on Windows.
Windows does not have a devfs mounted at `/dev`.  Use the `CON` special
file which is roughly equivalent to `/dev/stdout` to emulate the desired
test behaviour.