### PR TITLE
FileHandle: improve the compatibility of `synchronize`

### DIFF
--- a/Tests/Foundation/Tests/TestFileHandle.swift
+++ b/Tests/Foundation/Tests/TestFileHandle.swift
@@ -615,7 +615,11 @@ class TestFileHandle : XCTestCase {
 
     func testSynchronizeOnSpecialFile() throws {
         // .synchronize() on a special file shouldnt fail
+#if os(Windows)
+        let fh = try XCTUnwrap(FileHandle(forWritingAtPath: "CON"))
+#else
         let fh = try XCTUnwrap(FileHandle(forWritingAtPath: "/dev/stdout"))
+#endif
         XCTAssertNoThrow(try fh.synchronize())
     }
 


### PR DESCRIPTION
TestFileHandle/test_synchronizeOnSpecialFile introduced a failure in the
Windows test suite.  The underlying problem here is that
`FlushFileBuffers` is not permitted on unbuffered file handles (such as
consoles).  Ensure that we do not treat errors on character devices as
flush errors.