### PR TITLE
Tests: make test_mountedVoumeURLs more robust

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -1080,8 +1080,14 @@ class TestFileManager : XCTestCase {
         }
         XCTAssertNotEqual(0, volumes.count)
 #if os(Windows)
-        let url = URL(fileURLWithPath: String(NSTemporaryDirectory().prefix(3)))
-        XCTAssertTrue(volumes.contains(url))
+        guard let url: URL = FileManager.default.urls(for: .applicationSupportDirectory, in: .localDomainMask).first else {
+            XCTFail("unable to query a system directory")
+            return
+        }
+        let root: String = url.withUnsafeFileSystemRepresentation {
+            String(String(cString: $0!).prefix(3))
+        }
+        XCTAssertTrue(volumes.contains(URL(fileURLWithPath: root)))
 #else
         XCTAssertTrue(volumes.contains(URL(fileURLWithPath: "/")))
 #endif


### PR DESCRIPTION
Rather than creating a temporary directory, locate the application
support directory.  The temporary directory may be created under a
root that that is not an actual volume, but rather an aliased
mountpoint.  This is the case on the CI hosts where `T:` is a path
substitution rather than an actual disk volume.