### PR TITLE
FileManager: correct API misuse on Windows

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -269,6 +269,11 @@ extension FileManager {
                 throw _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [path])
             }
 
+            let hr: HRESULT = PathCchStripToRoot(&szVolumePath, szVolumePath.count)
+            guard hr == S_OK || hr == S_FALSE else {
+                throw _NSErrorWithWindowsError(DWORD(hr & 0xffff), reading: true, paths: [path])
+            }
+
             var volumeSerialNumber: DWORD = 0
             guard GetVolumeInformationW(&szVolumePath, nil, 0, &volumeSerialNumber, nil, nil, nil, 0) else {
                 throw _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [path])


### PR DESCRIPTION
`GetVolumeInformationW` is documented as taking the root directory of
the volume to describe as `lpRootPathName`. We attempt to compute the
location by determining the volume mount point where the specified
path is mounted. However, `GetVolumePathNameW` does always return the
path to the volume mount point, which is the root of the volume where
the specified path.  With a path substitution that is not rooted at a
volume root, the volume root with a relative path. As we need to get
to the root, force the stripping to the root via `PathCchStripToRoot`.

This should repair the
TestFoundation.TestFileManager/test_filesystemAttributes on Windows.