### PR TITLE
Enable String, URL and XML-related types for WASI

### DIFF
--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -25,7 +25,11 @@ func NSLocalizedString(_ key: String,
                        bundle: Bundle = Bundle.main,
                        value: String = "",
                        comment: String) -> String {
+#if os(WASI)
+    return key
+#else
     return bundle.localizedString(forKey: key, value: value, table: tableName)
+#endif
 }
 
 internal let kCFStringEncodingMacRoman =  CFStringBuiltInEncodings.macRoman.rawValue

--- a/Sources/Foundation/NSSwiftRuntime.swift
+++ b/Sources/Foundation/NSSwiftRuntime.swift
@@ -16,11 +16,15 @@
 @_exported import Darwin
 #elseif os(Linux) || os(Android) || CYGWIN || os(OpenBSD)
 @_exported import Glibc
+#elseif os(WASI)
+@_exported import WASILibc
 #elseif os(Windows)
 @_exported import CRT
 #endif
 
+#if !os(WASI)
 @_exported import Dispatch
+#endif
 
 #if os(Windows)
 import WinSDK
@@ -257,8 +261,10 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSMutableString.appendString = _CFSwiftStringAppend
     __CFSwiftBridge.NSMutableString.appendCharacters = _CFSwiftStringAppendCharacters
     __CFSwiftBridge.NSMutableString._cfAppendCString = _CFSwiftStringAppendCString
-    
+
+#if !os(WASI)    
     __CFSwiftBridge.NSRunLoop._new = _NSRunLoopNew
+#endif
     
     __CFSwiftBridge.NSCharacterSet._expandedCFCharacterSet = _CFSwiftCharacterSetExpandedCFCharacterSet
     __CFSwiftBridge.NSCharacterSet._retainedBitmapRepresentation = _CFSwiftCharacterSetRetainedBitmapRepresentation
@@ -304,6 +310,7 @@ internal func __CFInitializeSwift() {
     
 //    __CFDefaultEightBitStringEncoding = UInt32(kCFStringEncodingUTF8)
     
+#if !os(WASI)
     __CFSwiftBridge.NSURL.copyResourcePropertyForKey = _CFSwiftURLCopyResourcePropertyForKey
     __CFSwiftBridge.NSURL.copyResourcePropertiesForKeys = _CFSwiftURLCopyResourcePropertiesForKeys
     __CFSwiftBridge.NSURL.setResourcePropertyForKey = _CFSwiftURLSetResourcePropertyForKey
@@ -312,6 +319,7 @@ internal func __CFInitializeSwift() {
     __CFSwiftBridge.NSURL.clearResourcePropertyCache = _CFSwiftURLClearResourcePropertyCache
     __CFSwiftBridge.NSURL.setTemporaryResourceValueForKey = _CFSwiftSetTemporaryResourceValueForKey
     __CFSwiftBridge.NSURL.resourceIsReachable = _CFSwiftURLResourceIsReachable
+#endif
 }
 
 public func === (lhs: AnyClass, rhs: AnyClass) -> Bool {

--- a/Sources/Foundation/PropertyListSerialization.swift
+++ b/Sources/Foundation/PropertyListSerialization.swift
@@ -74,6 +74,7 @@ open class PropertyListSerialization : NSObject {
         }
     }
     
+#if !os(WASI)
     internal class func propertyList(with stream: CFReadStream, options opt: ReadOptions, format: UnsafeMutablePointer <PropertyListFormat>?) throws -> Any {
         var fmt = kCFPropertyListBinaryFormat_v1_0
         var error: Unmanaged<CFError>? = nil
@@ -93,4 +94,5 @@ open class PropertyListSerialization : NSObject {
     open class func propertyList(with stream: InputStream, options opt: ReadOptions = [], format: UnsafeMutablePointer<PropertyListFormat>?) throws -> Any {
         return try propertyList(with: stream._stream, options: opt, format: format)
     }
+#endif
 }

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -396,7 +396,9 @@ internal func _structuredErrorFunc(_ interface: _CFXMLInterface, error: _CFXMLIn
 
 open class XMLParser : NSObject {
     private var _handler: _CFXMLInterfaceSAXHandler
+#if !os(WASI)
     internal var _stream: InputStream?
+#endif
     internal var _data: Data?
 
     internal var _chunkSize = Int(4096 * 32) // a suitably large number for a decent chunk size
@@ -410,6 +412,9 @@ open class XMLParser : NSObject {
     
     // initializes the parser with the specified URL.
     public convenience init?(contentsOf url: URL) {
+#if os(WASI)
+        return nil
+#else
         setupXMLParsing()
         if url.isFileURL {
             if let stream = InputStream(url: url) {
@@ -427,6 +432,7 @@ open class XMLParser : NSObject {
                 return nil
             }
         }
+#endif
     }
     
     // create the parser from data
@@ -442,6 +448,7 @@ open class XMLParser : NSObject {
         _CFXMLInterfaceDestroyContext(_parserContext)
     }
     
+#if !os(WASI)
     //create a parser that incrementally pulls data from the specified stream and parses it.
     public init(stream: InputStream) {
         setupXMLParsing()
@@ -449,6 +456,7 @@ open class XMLParser : NSObject {
         _handler = _CFXMLInterfaceCreateSAXHandler()
         _parserContext = nil
     }
+#endif
     
     open weak var delegate: XMLParserDelegate?
     
@@ -460,20 +468,32 @@ open class XMLParser : NSObject {
     
     open var allowedExternalEntityURLs: Set<URL>?
     
+#if os(WASI)
+    private static var _currentParser: XMLParser?
+#endif
+
     internal static func currentParser() -> XMLParser? {
+#if os(WASI)
+        return _currentParser
+#else
         if let current = Thread.current.threadDictionary["__CurrentNSXMLParser"] {
             return current as? XMLParser
         } else {
             return nil
         }
+#endif
     }
     
     internal static func setCurrentParser(_ parser: XMLParser?) {
+#if os(WASI)
+        _currentParser = parser
+#else
         if let p = parser {
             Thread.current.threadDictionary["__CurrentNSXMLParser"] = p
         } else {
             Thread.current.threadDictionary.removeObject(forKey: "__CurrentNSXMLParser")
         }
+#endif
     }
     
     internal func _handleParseResult(_ parseResult: Int32) -> Bool {
@@ -547,6 +567,7 @@ open class XMLParser : NSObject {
         return result
     }
 
+#if !os(WASI)
     internal func parseFrom(_ stream : InputStream) -> Bool {
         var result = true
 
@@ -575,9 +596,29 @@ open class XMLParser : NSObject {
 
         return result
     }
-    
+#else
+    internal func parse(from data: Data) -> Bool {
+        var result = true
+        var chunkStart = 0
+        var chunkEnd = min(_chunkSize, data.count)
+        while result {
+            if chunkStart >= data.count || chunkEnd >= data.count {
+                break
+            }
+            let chunk = data[chunkStart..<chunkEnd]
+            result = parseData(chunk)
+            chunkStart = chunkEnd
+            chunkEnd = min(chunkEnd + _chunkSize, data.count)
+        }
+        return result
+    }
+#endif
+
     // called to start the event-driven parse. Returns YES in the event of a successful parse, and NO in case of error.
     open func parse() -> Bool {
+#if os(WASI)
+        return _data.map { parse(from: $0) } ?? false
+#else
         XMLParser.setCurrentParser(self)
         defer { XMLParser.setCurrentParser(nil) }
 
@@ -588,6 +629,7 @@ open class XMLParser : NSObject {
         }
 
         return false
+#endif
     }
     
     // called by the delegate to stop the parse. The delegate will get an error message sent to it.


### PR DESCRIPTION
APIs related to file access (i.e. those depending on `NSCoding`) and multi-threading (those that require `NSRunLoop`) had to be disabled for WASI/Wasm to make this work.