### PR TITLE
Revert "Revert "Fix autolink mechanism for static libraries on Linux""

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ if(HAS_LIBDISPATCH_API)
   find_package(dispatch CONFIG REQUIRED)
 endif()
 
+find_package(ICU COMPONENTS uc i18n REQUIRED)
+
 include(SwiftSupport)
 include(GNUInstallDirs)
 include(XCTest)

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -32,7 +32,6 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   else()
     find_package(CURL REQUIRED)
   endif()
-  find_package(ICU COMPONENTS uc i18n REQUIRED)
 endif()
 
 include(GNUInstallDirs)

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -160,6 +160,18 @@ set_target_properties(Foundation PROPERTIES
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_options(Foundation
+    PRIVATE
+      "SHELL:-Xfrontend -public-autolink-library -Xfrontend icui18n
+             -Xfrontend -public-autolink-library -Xfrontend BlocksRuntime")
+
+  # Merge private dependencies into single static objects archive
+  set_property(TARGET Foundation PROPERTY STATIC_LIBRARY_OPTIONS
+    $<TARGET_OBJECTS:CoreFoundation>
+    $<TARGET_OBJECTS:uuid>)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL Windows)
   # NOTE: workaround for CMake which doesn't link in OBJECT libraries properly
   add_dependencies(Foundation CoreFoundationResources)

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -161,10 +161,22 @@ set_target_properties(Foundation PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR}/swift)
 
 if(NOT BUILD_SHARED_LIBS)
+  # ICU_I18N_LIBRARY is set by find_package(ICU) in the top level CMakeLists.txt
+  # It's an absolute path to the found library file
+  get_target_property(icui18n_path ICU::i18n IMPORTED_LOCATION)
+  get_filename_component(icu_i18n_basename "${icui18n_path}" NAME_WE)
+  get_filename_component(icu_i18n_dir "${icui18n_path}" DIRECTORY)
+  string(REPLACE "lib" "" icu_i18n_basename "${icu_i18n_basename}")
+
   target_compile_options(Foundation
     PRIVATE
-      "SHELL:-Xfrontend -public-autolink-library -Xfrontend icui18n
+      "SHELL:-Xfrontend -public-autolink-library -Xfrontend ${icu_i18n_basename}
              -Xfrontend -public-autolink-library -Xfrontend BlocksRuntime")
+  # ICU libraries are linked by absolute library path in this project,
+  # but -public-autolink-library forces to resolve library path by
+  # library search path given by -L, so add a directory of icui18n
+  # in the search path
+  target_link_directories(Foundation PUBLIC "${icu_i18n_dir}")
 
   # Merge private dependencies into single static objects archive
   set_property(TARGET Foundation PROPERTY STATIC_LIBRARY_OPTIONS

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -64,6 +64,17 @@ target_link_libraries(FoundationNetworking
     CFURLSessionInterface
   PUBLIC
     Foundation)
+
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_options(FoundationNetworking
+    PRIVATE
+      "SHELL:-Xfrontend -public-autolink-library -Xfrontend curl")
+
+  # Merge private dependencies into single static objects archive
+  set_property(TARGET FoundationNetworking PROPERTY STATIC_LIBRARY_OPTIONS
+    $<TARGET_OBJECTS:CFURLSessionInterface>)
+endif()
+
 set_target_properties(FoundationNetworking PROPERTIES
   INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -16,6 +16,17 @@ target_link_libraries(FoundationXML
     CFXMLInterface
   PUBLIC
     Foundation)
+
+if(NOT BUILD_SHARED_LIBS)
+  target_compile_options(FoundationXML
+    PRIVATE
+      "SHELL:-Xfrontend -public-autolink-library -Xfrontend xml2")
+
+  # Merge private dependencies into single static objects archive
+  set_property(TARGET FoundationXML PROPERTY STATIC_LIBRARY_OPTIONS
+    $<TARGET_OBJECTS:CFXMLInterface>)
+endif()
+
 set_target_properties(FoundationXML PROPERTIES
   INSTALL_RPATH "$ORIGIN"
   Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift


### PR DESCRIPTION
Re-land https://github.com/apple/swift-corelibs-foundation/pull/2996

ICU i18n library name is now resolved based on CMake package finding system. It allows to use `swift` suffixed ICU libraries.