### PR TITLE
[5.4] Fix BlockOperation with multiple execution blocks

### DIFF
--- a/Sources/Foundation/Operation.swift
+++ b/Sources/Foundation/Operation.swift
@@ -668,22 +668,16 @@ open class BlockOperation : Operation {
         }
         _lock()
         defer { _unlock() }
-        if _block == nil && _executionBlocks == nil {
+        if _block == nil {
             _block = block
+        } else if _executionBlocks == nil {
+            _executionBlocks = [block]
         } else {
-            if _executionBlocks == nil {
-                if let existing = _block {
-                    _executionBlocks = [existing, block]
-                } else {
-                    _executionBlocks = [block]
-                }
-            } else {
-                _executionBlocks?.append(block)
-            }
+            _executionBlocks?.append(block)
         }
     }
     
-    open var executionBlocks: [@convention(block) () -> Void] {
+    open var executionBlocks: [() -> Void] {
         get {
             _lock()
             defer { _unlock() }

--- a/Tests/Foundation/Tests/TestOperationQueue.swift
+++ b/Tests/Foundation/Tests/TestOperationQueue.swift
@@ -42,6 +42,7 @@ class TestOperationQueue : XCTestCase {
             ("test_Lifecycle", test_Lifecycle),
             ("test_ConcurrentOperations", test_ConcurrentOperations),
             ("test_ConcurrentOperationsWithDependenciesAndCompletions", test_ConcurrentOperationsWithDependenciesAndCompletions),
+            ("test_BlockOperationAddExecutionBlock", test_BlockOperationAddExecutionBlock),
         ]
     }
     
@@ -753,6 +754,21 @@ class TestOperationQueue : XCTestCase {
         }
     }
 
+    func test_BlockOperationAddExecutionBlock() {
+        let block1Expectation = expectation(description: "Block 1 executed")
+        let block2Expectation = expectation(description: "Block 2 executed")
+        
+        let blockOperation = BlockOperation {
+            block1Expectation.fulfill()
+        }
+        blockOperation.addExecutionBlock {
+            block2Expectation.fulfill()
+        }
+        XCTAssert(blockOperation.executionBlocks.count == 2)
+        let queue = OperationQueue()
+        queue.addOperation(blockOperation)
+        waitForExpectations(timeout: 1.0)
+    }
 }
 
 class AsyncOperation: Operation {


### PR DESCRIPTION
This is cherry-picking of #2938, which I shamefully forgot to port from `main`.
Hope that 5.4.3 window is not closed yet.

#### Original description:
> This is rebased version of #2497. Original request seems abandoned, but changes are useful. All credit goes to @dannliu.
> 
> Latest Foundation still has this issue: BlockOperation stores first execution block into the internal array along with a second execution block. As the result:
> 
> unexpected value is returned by executionBlocks
> first block will be run twice.
> Also @convention(block) specifier in executionBlocks makes dynamic cast crash on return. Looks like it could be safely removed.