### PR TITLE
Introduce AttributedString

### DIFF
--- a/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/TargetConditionals.h
@@ -138,6 +138,12 @@
 #define TARGET_OS_MAC          TARGET_OS_DARWIN
 #define TARGET_OS_OSX          TARGET_OS_DARWIN
 
+// iOS, watchOS, and tvOS are not supported
+#define TARGET_OS_IPHONE        0
+#define TARGET_OS_IOS           0
+#define TARGET_OS_WATCH         0
+#define TARGET_OS_TV            0
+
 #if __x86_64__
 #define TARGET_CPU_PPC          0
 #define TARGET_CPU_PPC64        0

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -86,6 +86,18 @@
 		3EA9D6701EF0532D00B362D6 /* TestJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA9D66F1EF0532D00B362D6 /* TestJSONEncoder.swift */; };
 		3EDCE50C1EF04D8100C2EC04 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EDCE5051EF04D8100C2EC04 /* Codable.swift */; };
 		3EDCE5101EF04D8100C2EC04 /* JSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EDCE5091EF04D8100C2EC04 /* JSONEncoder.swift */; };
+		4704393226BDFF34000D213E /* TestAttributedStringPerformance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4704392E26BDFF33000D213E /* TestAttributedStringPerformance.swift */; };
+		4704393326BDFF34000D213E /* TestAttributedStringCOW.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4704392F26BDFF33000D213E /* TestAttributedStringCOW.swift */; };
+		4704393426BDFF34000D213E /* TestAttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4704393026BDFF33000D213E /* TestAttributedString.swift */; };
+		4704393526BDFF34000D213E /* TestAttributedStringSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4704393126BDFF34000D213E /* TestAttributedStringSupport.swift */; };
+		474E124D26BCD6D00016C28A /* AttributedString+Locking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 474E124C26BCD6D00016C28A /* AttributedString+Locking.swift */; };
+		476E415226BDAA150043E21E /* Morphology.swift in Sources */ = {isa = PBXBuildFile; fileRef = 476E415126BDAA150043E21E /* Morphology.swift */; };
+		4778104C26BC9F810071E8A1 /* FoundationAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4778104526BC9F810071E8A1 /* FoundationAttributes.swift */; };
+		4778104E26BC9F810071E8A1 /* AttributedStringRunCoalescing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4778104726BC9F810071E8A1 /* AttributedStringRunCoalescing.swift */; };
+		4778104F26BC9F810071E8A1 /* AttributedStringAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4778104826BC9F810071E8A1 /* AttributedStringAttribute.swift */; };
+		4778105026BC9F810071E8A1 /* AttributedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4778104926BC9F810071E8A1 /* AttributedString.swift */; };
+		4778105126BC9F810071E8A1 /* Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4778104A26BC9F810071E8A1 /* Conversion.swift */; };
+		4778105226BC9F810071E8A1 /* AttributedStringCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4778104B26BC9F810071E8A1 /* AttributedStringCodable.swift */; };
 		49D55FA125E84FE5007BD3B3 /* JSONSerialization+Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D55FA025E84FE5007BD3B3 /* JSONSerialization+Parser.swift */; };
 		528776141BF2629700CB0090 /* FoundationErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 522C253A1BF16E1600804FC6 /* FoundationErrors.swift */; };
 		528776191BF27D9500CB0090 /* Test.plist in Resources */ = {isa = PBXBuildFile; fileRef = 528776181BF27D9500CB0090 /* Test.plist */; };
@@ -807,6 +819,18 @@
 		3EDCE5051EF04D8100C2EC04 /* Codable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Codable.swift; sourceTree = "<group>"; };
 		3EDCE5091EF04D8100C2EC04 /* JSONEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONEncoder.swift; sourceTree = "<group>"; };
 		400E22641C1A4E58007C5933 /* TestProcessInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestProcessInfo.swift; sourceTree = "<group>"; };
+		4704392E26BDFF33000D213E /* TestAttributedStringPerformance.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAttributedStringPerformance.swift; sourceTree = "<group>"; };
+		4704392F26BDFF33000D213E /* TestAttributedStringCOW.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAttributedStringCOW.swift; sourceTree = "<group>"; };
+		4704393026BDFF33000D213E /* TestAttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAttributedString.swift; sourceTree = "<group>"; };
+		4704393126BDFF34000D213E /* TestAttributedStringSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAttributedStringSupport.swift; sourceTree = "<group>"; };
+		474E124C26BCD6D00016C28A /* AttributedString+Locking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AttributedString+Locking.swift"; sourceTree = "<group>"; };
+		476E415126BDAA150043E21E /* Morphology.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Morphology.swift; sourceTree = "<group>"; };
+		4778104526BC9F810071E8A1 /* FoundationAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationAttributes.swift; sourceTree = "<group>"; };
+		4778104726BC9F810071E8A1 /* AttributedStringRunCoalescing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringRunCoalescing.swift; sourceTree = "<group>"; };
+		4778104826BC9F810071E8A1 /* AttributedStringAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringAttribute.swift; sourceTree = "<group>"; };
+		4778104926BC9F810071E8A1 /* AttributedString.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedString.swift; sourceTree = "<group>"; };
+		4778104A26BC9F810071E8A1 /* Conversion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Conversion.swift; sourceTree = "<group>"; };
+		4778104B26BC9F810071E8A1 /* AttributedStringCodable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttributedStringCodable.swift; sourceTree = "<group>"; };
 		49D55FA025E84FE5007BD3B3 /* JSONSerialization+Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONSerialization+Parser.swift"; sourceTree = "<group>"; };
 		4AE109261C17CCBF007367B5 /* TestIndexPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestIndexPath.swift; sourceTree = "<group>"; };
 		4DC1D07F1C12EEEF00B5948A /* TestPipe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestPipe.swift; sourceTree = "<group>"; };
@@ -1385,6 +1409,20 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4778103D26BC9E320071E8A1 /* AttributedString */ = {
+			isa = PBXGroup;
+			children = (
+				4778104926BC9F810071E8A1 /* AttributedString.swift */,
+				4778104826BC9F810071E8A1 /* AttributedStringAttribute.swift */,
+				4778104B26BC9F810071E8A1 /* AttributedStringCodable.swift */,
+				4778104726BC9F810071E8A1 /* AttributedStringRunCoalescing.swift */,
+				4778104A26BC9F810071E8A1 /* Conversion.swift */,
+				4778104526BC9F810071E8A1 /* FoundationAttributes.swift */,
+				474E124C26BCD6D00016C28A /* AttributedString+Locking.swift */,
+			);
+			path = AttributedString;
+			sourceTree = "<group>";
+		};
 		5B5D88531BBC938800234F36 = {
 			isa = PBXGroup;
 			children = (
@@ -1797,6 +1835,10 @@
 			isa = PBXGroup;
 			children = (
 				C93559281C12C49F009FD6A9 /* TestAffineTransform.swift */,
+				4704393026BDFF33000D213E /* TestAttributedString.swift */,
+				4704392F26BDFF33000D213E /* TestAttributedStringCOW.swift */,
+				4704392E26BDFF33000D213E /* TestAttributedStringPerformance.swift */,
+				4704393126BDFF34000D213E /* TestAttributedStringSupport.swift */,
 				659FB6DD2405E5E200F5F63F /* TestBridging.swift */,
 				6E203B8C1C1303BB003B2576 /* TestBundle.swift */,
 				A5A34B551C18C85D00FD972B /* TestByteCountFormatter.swift */,
@@ -2049,6 +2091,7 @@
 				B98303F325F21389001F959E /* CMakeLists.txt */,
 				F023072523F0B4890023DBEC /* Headers */,
 				F023072423F0B4140023DBEC /* Resources */,
+				4778103D26BC9E320071E8A1 /* AttributedString */,
 				EADE0B4D1BD09E0800C49C64 /* AffineTransform.swift */,
 				5BD31D231D5CECC400563814 /* Array.swift */,
 				5B23AB861CE62D17000DB898 /* Boxing.swift */,
@@ -2189,6 +2232,7 @@
 				B96C110925BA215800985A32 /* URLResourceKey.swift */,
 				EADE0B871BD15DFF00C49C64 /* UserDefaults.swift */,
 				6EB768271D18C12C00D4B719 /* UUID.swift */,
+				476E415126BDAA150043E21E /* Morphology.swift */,
 			);
 			path = Foundation;
 			sourceTree = "<group>";
@@ -2861,6 +2905,7 @@
 				EADE0BBF1BD15E0000C49C64 /* NSURLError.swift in Sources */,
 				EADE0BAF1BD15E0000C49C64 /* PersonNameComponentsFormatter.swift in Sources */,
 				EADE0B941BD15DFF00C49C64 /* NSCompoundPredicate.swift in Sources */,
+				4778105026BC9F810071E8A1 /* AttributedString.swift in Sources */,
 				528776141BF2629700CB0090 /* FoundationErrors.swift in Sources */,
 				5B23AB8D1CE63228000DB898 /* URL.swift in Sources */,
 				EADE0BA91BD15E0000C49C64 /* NSNull.swift in Sources */,
@@ -2881,6 +2926,7 @@
 				49D55FA125E84FE5007BD3B3 /* JSONSerialization+Parser.swift in Sources */,
 				5BC1B9A821F275B000524D8C /* Collections+DataProtocol.swift in Sources */,
 				5BF7AEBE1BCD51F9008F214A /* NSTimeZone.swift in Sources */,
+				4778105226BC9F810071E8A1 /* AttributedStringCodable.swift in Sources */,
 				EADE0B951BD15DFF00C49C64 /* DateComponentsFormatter.swift in Sources */,
 				5BC1B9AE21F275E900524D8C /* Pointers+DataProtocol.swift in Sources */,
 				B96C10F625BA1EFD00985A32 /* NSURLComponents.swift in Sources */,
@@ -2954,6 +3000,7 @@
 				5BF7AEAF1BCD51F9008F214A /* Host.swift in Sources */,
 				EADE0B4E1BD09E0800C49C64 /* AffineTransform.swift in Sources */,
 				5BDC3FCE1BCF17D300ED97BB /* NSCFDictionary.swift in Sources */,
+				476E415226BDAA150043E21E /* Morphology.swift in Sources */,
 				EADE0BA81BD15E0000C49C64 /* NotificationQueue.swift in Sources */,
 				EA418C261D57257D005EAD0D /* NSKeyedArchiverHelpers.swift in Sources */,
 				EADE0B981BD15DFF00C49C64 /* NSDecimalNumber.swift in Sources */,
@@ -2963,6 +3010,7 @@
 				D3BCEBA01C2F6DDB00295652 /* NSKeyedCoderOldStyleArray.swift in Sources */,
 				5B8BA1621D0B773A00938C27 /* IndexSet.swift in Sources */,
 				EADE0BA71BD15E0000C49C64 /* NSNotification.swift in Sources */,
+				4778104E26BC9F810071E8A1 /* AttributedStringRunCoalescing.swift in Sources */,
 				B96C110A25BA215800985A32 /* URLResourceKey.swift in Sources */,
 				5BF7AEB41BCD51F9008F214A /* NSObject.swift in Sources */,
 				EADE0B521BD09F2F00C49C64 /* ByteCountFormatter.swift in Sources */,
@@ -2976,8 +3024,11 @@
 				5BECBA3A1D1CAE9A00B39B1F /* NSMeasurement.swift in Sources */,
 				5BF7AEB21BCD51F9008F214A /* NSNumber.swift in Sources */,
 				1513A8432044893F00539722 /* FileManager+XDG.swift in Sources */,
+				4778105126BC9F810071E8A1 /* Conversion.swift in Sources */,
 				91B668A52252B3E7001487A1 /* FileManager+Win32.swift in Sources */,
+				4778104F26BC9F810071E8A1 /* AttributedStringAttribute.swift in Sources */,
 				5BCD03821D3EE35C00E3FF9B /* TimeZone.swift in Sources */,
+				4778104C26BC9F810071E8A1 /* FoundationAttributes.swift in Sources */,
 				B96C112525BA2CE700985A32 /* URLQueryItem.swift in Sources */,
 				5BC1B9AC21F275D500524D8C /* NSData+DataProtocol.swift in Sources */,
 				5B4092121D1B30B40022B067 /* ExtraStringAPIs.swift in Sources */,
@@ -2989,6 +3040,7 @@
 				B98303EA25F2131D001F959E /* JSONDecoder.swift in Sources */,
 				5BDC3FCC1BCF177E00ED97BB /* NSCFString.swift in Sources */,
 				EADE0BAC1BD15E0000C49C64 /* NSOrderedSet.swift in Sources */,
+				474E124D26BCD6D00016C28A /* AttributedString+Locking.swift in Sources */,
 				5BC1B9A421F2757F00524D8C /* ContiguousBytes.swift in Sources */,
 				EADE0B971BD15DFF00C49C64 /* Decimal.swift in Sources */,
 				5B78185B1D6CB5D2004A01F2 /* CGFloat.swift in Sources */,
@@ -3101,6 +3153,7 @@
 				5FE52C951D147D1C00F7D270 /* TestNSTextCheckingResult.swift in Sources */,
 				5B13B3451C582D4C00651CE2 /* TestNSString.swift in Sources */,
 				1520469B1D8AEABE00D02E36 /* HTTPServer.swift in Sources */,
+				4704393326BDFF34000D213E /* TestAttributedStringCOW.swift in Sources */,
 				B90C57BC1EEEEA5A005208AE /* TestThread.swift in Sources */,
 				B90C57BB1EEEEA5A005208AE /* TestFileManager.swift in Sources */,
 				A058C2021E529CF100B07AA1 /* TestMassFormatter.swift in Sources */,
@@ -3144,6 +3197,7 @@
 				5B13B34E1C582D4C00651CE2 /* TestXMLDocument.swift in Sources */,
 				5B13B32B1C582D4C00651CE2 /* TestNSData.swift in Sources */,
 				5B13B34C1C582D4C00651CE2 /* TestURLResponse.swift in Sources */,
+				4704393526BDFF34000D213E /* TestAttributedStringSupport.swift in Sources */,
 				AA9E0E0D21FA6E0700963F4C /* TestPropertyListEncoder.swift in Sources */,
 				0383A1751D2E558A0052E5D1 /* TestStream.swift in Sources */,
 				5B13B3481C582D4C00651CE2 /* TestTimer.swift in Sources */,
@@ -3179,6 +3233,7 @@
 				5B13B3371C582D4C00651CE2 /* TestNotificationCenter.swift in Sources */,
 				5B13B3251C582D4700651CE2 /* main.swift in Sources */,
 				5B1FD9E31D6D17B80080E83C /* TestURLSession.swift in Sources */,
+				4704393226BDFF34000D213E /* TestAttributedStringPerformance.swift in Sources */,
 				3EA9D6701EF0532D00B362D6 /* TestJSONEncoder.swift in Sources */,
 				D512D17C1CD883F00032E6A5 /* TestFileHandle.swift in Sources */,
 				D4FE895B1D703D1100DA7986 /* TestURLRequest.swift in Sources */,
@@ -3189,6 +3244,7 @@
 				155B77AC22E63D2D00D901DE /* TestURLCredentialStorage.swift in Sources */,
 				B951B5EC1F4E2A2000D8B332 /* TestNSLock.swift in Sources */,
 				5B13B33A1C582D4C00651CE2 /* TestNSNumber.swift in Sources */,
+				4704393426BDFF34000D213E /* TestAttributedString.swift in Sources */,
 				5B13B3521C582D4C00651CE2 /* TestNSValue.swift in Sources */,
 				7D0DE86F211883F500540061 /* Utilities.swift in Sources */,
 				5B13B3311C582D4C00651CE2 /* TestIndexPath.swift in Sources */,

--- a/Sources/Foundation/AttributedString/AttributedString+Locking.swift
+++ b/Sources/Foundation/AttributedString/AttributedString+Locking.swift
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+extension UnsafeMutablePointer where Pointee == os_unfair_lock_s {
+    internal init() {
+        let l = UnsafeMutablePointer.allocate(capacity: 1)
+        l.initialize(to: os_unfair_lock())
+        self = l
+    }
+    
+    internal func cleanupLock() {
+        deinitialize(count: 1)
+        deallocate()
+    }
+    
+    internal func lock() {
+        os_unfair_lock_lock(self)
+    }
+    
+    internal func tryLock() -> Bool {
+        let result = os_unfair_lock_trylock(self)
+        return result
+    }
+    
+    internal func unlock() {
+        os_unfair_lock_unlock(self)
+    }
+}
+
+@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)
+typealias Lock = os_unfair_lock_t
+
+#else
+internal typealias Lock = NSLock
+
+extension NSLock {
+    // Stub to match the API of os_unfair_lock_t
+    func cleanupLock() { /* NOOP */ }
+}
+#endif

--- a/Sources/Foundation/AttributedString/AttributedString.swift
+++ b/Sources/Foundation/AttributedString/AttributedString.swift
@@ -1,0 +1,2092 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Reflection) import Swift
+
+@dynamicMemberLookup
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct AttributeContainer : Equatable, CustomStringConvertible {
+    public static func == (lhs: AttributeContainer, rhs: AttributeContainer) -> Bool {
+        guard lhs.contents.keys == rhs.contents.keys else { return false }
+        for (key, value) in lhs.contents {
+            if !__equalAttributes(value, rhs.contents[key]) {
+                return false
+            }
+        }
+        return true
+    }
+    
+    public var description : String {
+        contents._attrStrDescription
+    }
+    
+    internal var contents : [String : Any]
+
+    public subscript<T: AttributedStringKey>(_: T.Type) -> T.Value? {
+        get { contents[T.name] as? T.Value }
+        set { contents[T.name] = newValue }
+    }
+
+    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? {
+        get { self[K.self] }
+        set { self[K.self] = newValue }
+    }
+    
+    public subscript<S: AttributeScope>(dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>) -> ScopedAttributeContainer<S> {
+        get {
+            return ScopedAttributeContainer(contents)
+        }
+        _modify {
+            var container = ScopedAttributeContainer<S>()
+            defer {
+                if let removedKey = container.removedKey {
+                    contents[removedKey] = nil
+                } else {
+                    contents.merge(container.contents) { original, new in
+                        return new
+                    }
+                }
+            }
+            yield &container
+        }
+    }
+
+    public static subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> Builder<K> {
+        return Builder(container: AttributeContainer())
+    }
+
+    @_disfavoredOverload
+    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> Builder<K> {
+        return Builder(container: self)
+    }
+
+    public struct Builder<T: AttributedStringKey> {
+        var container : AttributeContainer
+
+        public func callAsFunction(_ value: T.Value) -> AttributeContainer {
+            var new = container
+            new[T.self] = value
+            return new
+        }
+    }
+
+    public init() {
+        contents = [:]
+    }
+    
+    internal init(_ contents: [String : Any]) {
+        self.contents = contents
+    }
+
+    public mutating func merge(_ other: AttributeContainer, mergePolicy: AttributedString.AttributeMergePolicy = .keepNew) {
+        self.contents.merge(other.contents, uniquingKeysWith: mergePolicy.combinerClosure)
+    }
+    
+    public func merging(_ other: AttributeContainer, mergePolicy:  AttributedString.AttributeMergePolicy = .keepNew) -> AttributeContainer {
+        var copy = self
+        copy.merge(other, mergePolicy:  mergePolicy)
+        return copy
+    }
+}
+
+internal extension Dictionary where Key == String, Value == Any {
+    var _attrStrDescription : String {
+        let keyvals = self.reduce(into: "") { (res, entry) in
+            res += "\t\(entry.key) = \(entry.value)" + "\n"
+        }
+        return "{\n\(keyvals)}"
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol AttributedStringAttributeMutation {
+    mutating func setAttributes(_ attributes: AttributeContainer)
+    mutating func mergeAttributes(_ attributes: AttributeContainer, mergePolicy:  AttributedString.AttributeMergePolicy)
+    mutating func replaceAttributes(_ attributes: AttributeContainer, with others: AttributeContainer)
+}
+
+@dynamicMemberLookup
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol AttributedStringProtocol : AttributedStringAttributeMutation, Hashable, CustomStringConvertible {
+    var startIndex : AttributedString.Index { get }
+    var endIndex : AttributedString.Index { get }
+    
+    var runs : AttributedString.Runs { get }
+    var characters : AttributedString.CharacterView { get }
+    var unicodeScalars : AttributedString.UnicodeScalarView { get }
+    
+    subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? { get set }
+    subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? { get set }
+    subscript<S: AttributeScope>(dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>) -> ScopedAttributeContainer<S> { get set }
+    
+    subscript<R: RangeExpression>(bounds: R) -> AttributedSubstring where R.Bound == AttributedString.Index { get }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString {
+    internal init<S:AttributedStringProtocol>(_ s: S) {
+        if let s = s as? AttributedString {
+            self = s
+        } else if let s = s as? AttributedSubstring {
+            self = AttributedString(s)
+        } else {
+            // !!!: We don't expect or want this to happen.
+            self = AttributedString(s.characters._guts)
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension AttributedStringProtocol {
+    func settingAttributes(_ attributes: AttributeContainer) -> AttributedString {
+        var new = AttributedString(self)
+        new.setAttributes(attributes)
+        return new
+    }
+    
+    func mergingAttributes(_ attributes: AttributeContainer, mergePolicy:  AttributedString.AttributeMergePolicy = .keepNew) -> AttributedString {
+        var new = AttributedString(self)
+        new.mergeAttributes(attributes, mergePolicy:  mergePolicy)
+        return new
+    }
+    
+    func replacingAttributes(_ attributes: AttributeContainer, with others: AttributeContainer) -> AttributedString {
+        var new = AttributedString(self)
+        new.replaceAttributes(attributes, with: others)
+        return new
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedStringProtocol {
+    internal var __guts : AttributedString.Guts {
+        if let s = self as? AttributedString {
+            return s._guts
+        } else if let s = self as? AttributedSubstring {
+            return s._guts
+        } else {
+            return self.characters._guts
+        }
+    }
+    
+    public var description : String {
+        var result = ""
+        self.__guts.enumerateRuns { run, loc, _, modified in
+            let range = self.__guts.index(startIndex, offsetByUTF8: loc) ..< self.__guts.index(startIndex, offsetByUTF8: loc + run.length)
+            result += (result.isEmpty ? "" : "\n") + "\(String(self.characters[range])) \(run.attributes)"
+            modified = .guaranteedNotModified
+        }
+        return result
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(__guts)
+    }
+
+    @_specialize(where Self == AttributedString, RHS == AttributedString)
+    @_specialize(where Self == AttributedString, RHS == AttributedSubstring)
+    @_specialize(where Self == AttributedSubstring, RHS == AttributedString)
+    @_specialize(where Self == AttributedSubstring, RHS == AttributedSubstring)
+    public static func == <RHS: AttributedStringProtocol>(lhs: Self, rhs: RHS) -> Bool {
+        // Manually slice the __guts.string (in case its an AttributedSubstring), the Runs type takes the range into account for AttributedSubstrings
+        let rangeLHS = Range(uncheckedBounds: (lower: lhs.startIndex, upper: lhs.endIndex))
+        let rangeRHS = Range(uncheckedBounds: (lower: rhs.startIndex, upper: rhs.endIndex))
+        return lhs.__guts.string[rangeLHS._stringRange] == rhs.__guts.string[rangeRHS._stringRange] && lhs.runs == rhs.runs
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension AttributedStringProtocol {
+    func index(afterCharacter i: AttributedString.Index) -> AttributedString.Index {
+        self.characters.index(after: i)
+    }
+    func index(beforeCharacter i: AttributedString.Index) -> AttributedString.Index {
+        self.characters.index(before: i)
+    }
+    func index(_ i: AttributedString.Index, offsetByCharacters distance: Int) -> AttributedString.Index {
+        self.characters.index(i, offsetBy: distance)
+    }
+
+    func index(afterUnicodeScalar i: AttributedString.Index) -> AttributedString.Index {
+        self.unicodeScalars.index(after: i)
+    }
+    func index(beforeUnicodeScalar i: AttributedString.Index) -> AttributedString.Index {
+        self.unicodeScalars.index(before: i)
+    }
+    func index(_ i: AttributedString.Index, offsetByUnicodeScalars distance: Int) -> AttributedString.Index {
+        self.unicodeScalars.index(i, offsetBy: distance)
+    }
+
+    func index(afterRun i: AttributedString.Index) -> AttributedString.Index {
+        self.runs._runs_index(after: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [])
+    }
+    func index(beforeRun i: AttributedString.Index) -> AttributedString.Index {
+        self.runs._runs_index(before: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [])
+    }
+    func index(_ i: AttributedString.Index, offsetByRuns distance: Int) -> AttributedString.Index {
+        var res = i
+        var remainingDistance = distance
+        while remainingDistance != 0 {
+            if remainingDistance > 0 {
+                res = self.runs._runs_index(after: res, startIndex: startIndex, endIndex: endIndex, attributeNames: [])
+                remainingDistance -= 1
+            } else {
+                res = self.runs._runs_index(before: res, startIndex: startIndex, endIndex: endIndex, attributeNames: [])
+                remainingDistance += 1
+            }
+        }
+        return res
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedStringProtocol {
+    public func range<T: StringProtocol>(of stringToFind: T, options: String.CompareOptions = [], locale: Locale? = nil) -> Range<AttributedString.Index>? {
+        // Since we have secret access to the String property, go ahead and use the full implementation given by Foundation rather than the limited reimplementation we needed for CharacterView.
+        return self.__guts.string.range(of: stringToFind, options: options, range: (startIndex..<endIndex)._stringRange, locale: locale)?._attributedStringRange
+    }
+}
+
+@dynamicMemberLookup
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct AttributedString : AttributedStringProtocol {
+    
+    public enum AttributeMergePolicy {
+        case keepNew
+        case keepCurrent
+        
+        internal var combinerClosure: (Any, Any) -> Any {
+            switch self {
+            case .keepNew: return { _, new in new }
+            case .keepCurrent: return { current, _ in current }
+            }
+        }
+    }
+    
+    public subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? {
+        get { _guts.getValue(in: startIndex ..< endIndex, key: K.name) as? K.Value }
+        set {
+            ensureUniqueReference()
+            if let v = newValue {
+                _guts.add(value: v, in: startIndex ..< endIndex, key: K.name)
+            } else {
+                _guts.remove(attribute: K.self, in: startIndex ..< endIndex)
+            }
+        }
+    }
+
+    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? {
+        get { self[K.self] }
+        set { self[K.self] = newValue }
+    }
+    
+    public subscript<S: AttributeScope>(dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>) -> ScopedAttributeContainer<S> {
+        get {
+            return ScopedAttributeContainer(_guts.getValues(in: startIndex ..< endIndex))
+        }
+        _modify {
+            ensureUniqueReference()
+            var container = ScopedAttributeContainer<S>()
+            defer {
+                if let removedKey = container.removedKey {
+                    _guts.remove(key: removedKey, in: startIndex ..< endIndex)
+                } else {
+                    _guts.add(attributes: AttributeContainer(container.contents), in: startIndex ..< endIndex)
+                }
+            }
+            yield &container
+        }
+    }
+    
+    public mutating func setAttributes(_ attributes: AttributeContainer) {
+        ensureUniqueReference()
+        _guts.set(attributes: attributes, in: startIndex ..< endIndex)
+    }
+    
+    public mutating func mergeAttributes(_ attributes: AttributeContainer, mergePolicy:  AttributeMergePolicy = .keepNew) {
+        ensureUniqueReference()
+        _guts.add(attributes: attributes, in: startIndex ..< endIndex, mergePolicy:  mergePolicy)
+    }
+    
+    public mutating func replaceAttributes(_ attributes: AttributeContainer, with others: AttributeContainer) {
+        guard attributes != others else {
+            return
+        }
+        ensureUniqueReference()
+        _guts.enumerateRuns { run, _, _, modified in
+            if _run(run, matches: attributes) {
+                for key in attributes.contents.keys {
+                    run.attributes.contents.removeValue(forKey: key)
+                }
+                run.attributes.mergeIn(others)
+                modified = .guaranteedModified
+            } else {
+                modified = .guaranteedNotModified
+            }
+        }
+    }
+    
+    internal func applyRemovals<K>(withOriginal orig: AttributedString.SingleAttributeTransformer<K>, andChanged changed: AttributedString.SingleAttributeTransformer<K>, to attrStr: inout AttributedString, key: K.Type) {
+        if orig.range != changed.range || orig.attrName != changed.attrName {
+            attrStr._guts.remove(attribute: K.self, in: orig.range) // If the range changed, we need to remove from the old range first.
+        }
+    }
+    
+    internal func applyChanges<K>(withOriginal orig: AttributedString.SingleAttributeTransformer<K>, andChanged changed: AttributedString.SingleAttributeTransformer<K>, to attrStr: inout AttributedString, key: K.Type) {
+        if orig.range != changed.range || orig.attrName != changed.attrName || !__equalAttributes(orig.attr, changed.attr) {
+            if let newVal = changed.attr { // Then if there's a new value, we add it in.
+                // Unfortunately, we can't use the attrStr[range].set() provided by the AttributedStringProtocol, because we *don't know* the new type statically!
+                attrStr._guts.add(value: newVal, in: changed.range, key: changed.attrName)
+            } else {
+                attrStr._guts.remove(attribute: K.self, in: changed.range) // ???: Is this right? Does changing the range of an attribute==nil run remove it from the new range?
+            }
+        }
+    }
+
+    public func transformingAttributes<K>(_ k:  K.Type, _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void) -> AttributedString {
+        let orig = AttributedString(_guts)
+        var copy = orig
+        copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
+        for (attr, range) in orig.runs[k] {
+            let origAttr1 = AttributedString.SingleAttributeTransformer<K>(range: range, attr: attr)
+            var changedAttr1 = origAttr1
+            c(&changedAttr1)
+            applyRemovals(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyChanges(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+        }
+        return copy
+    }
+
+    public func transformingAttributes<K1, K2>(_ k:  K1.Type, _ k2: K2.Type,
+                                                   _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
+                                                         inout AttributedString.SingleAttributeTransformer<K2>) -> Void) -> AttributedString {
+        let orig = AttributedString(_guts)
+        var copy = orig
+        copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
+        for (attr, attr2, range) in orig.runs[k, k2] {
+            let origAttr1 = AttributedString.SingleAttributeTransformer<K1>(range: range, attr: attr)
+            let origAttr2 = AttributedString.SingleAttributeTransformer<K2>(range: range, attr: attr2)
+            var changedAttr1 = origAttr1
+            var changedAttr2 = origAttr2
+            c(&changedAttr1, &changedAttr2)
+            applyRemovals(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyRemovals(withOriginal: origAttr2, andChanged: changedAttr2, to: &copy, key: k2)
+            applyChanges(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyChanges(withOriginal: origAttr2, andChanged: changedAttr2, to: &copy, key: k2)
+        }
+        return copy
+    }
+
+    public func transformingAttributes<K1, K2, K3>(_ k:  K1.Type, _ k2: K2.Type, _ k3: K3.Type,
+                                                   _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
+                                                         inout AttributedString.SingleAttributeTransformer<K2>,
+                                                         inout AttributedString.SingleAttributeTransformer<K3>) -> Void) -> AttributedString {
+        let orig = AttributedString(_guts)
+        var copy = orig
+        copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
+        for (attr, attr2, attr3, range) in orig.runs[k, k2, k3] {
+            let origAttr1 = AttributedString.SingleAttributeTransformer<K1>(range: range, attr: attr)
+            let origAttr2 = AttributedString.SingleAttributeTransformer<K2>(range: range, attr: attr2)
+            let origAttr3 = AttributedString.SingleAttributeTransformer<K3>(range: range, attr: attr3)
+            var changedAttr1 = origAttr1
+            var changedAttr2 = origAttr2
+            var changedAttr3 = origAttr3
+            c(&changedAttr1, &changedAttr2, &changedAttr3)
+            applyRemovals(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyRemovals(withOriginal: origAttr2, andChanged: changedAttr2, to: &copy, key: k2)
+            applyRemovals(withOriginal: origAttr3, andChanged: changedAttr3, to: &copy, key: k3)
+            applyChanges(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyChanges(withOriginal: origAttr2, andChanged: changedAttr2, to: &copy, key: k2)
+            applyChanges(withOriginal: origAttr3, andChanged: changedAttr3, to: &copy, key: k3)
+        }
+        return copy
+    }
+
+    public func transformingAttributes<K1, K2, K3, K4>(_ k:  K1.Type, _ k2: K2.Type, _ k3: K3.Type, _ k4: K4.Type,
+                                                       _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
+                                                             inout AttributedString.SingleAttributeTransformer<K2>,
+                                                             inout AttributedString.SingleAttributeTransformer<K3>,
+                                                             inout AttributedString.SingleAttributeTransformer<K4>) -> Void) -> AttributedString {
+        let orig = AttributedString(_guts)
+        var copy = orig
+        copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
+        for (attr, attr2, attr3, attr4, range) in orig.runs[k, k2, k3, k4] {
+            let origAttr1 = AttributedString.SingleAttributeTransformer<K1>(range: range, attr: attr)
+            let origAttr2 = AttributedString.SingleAttributeTransformer<K2>(range: range, attr: attr2)
+            let origAttr3 = AttributedString.SingleAttributeTransformer<K3>(range: range, attr: attr3)
+            let origAttr4 = AttributedString.SingleAttributeTransformer<K4>(range: range, attr: attr4)
+            var changedAttr1 = origAttr1
+            var changedAttr2 = origAttr2
+            var changedAttr3 = origAttr3
+            var changedAttr4 = origAttr4
+            c(&changedAttr1, &changedAttr2, &changedAttr3, &changedAttr4)
+            applyRemovals(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyRemovals(withOriginal: origAttr2, andChanged: changedAttr2, to: &copy, key: k2)
+            applyRemovals(withOriginal: origAttr3, andChanged: changedAttr3, to: &copy, key: k3)
+            applyRemovals(withOriginal: origAttr4, andChanged: changedAttr4, to: &copy, key: k4)
+            applyChanges(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyChanges(withOriginal: origAttr2, andChanged: changedAttr2, to: &copy, key: k2)
+            applyChanges(withOriginal: origAttr3, andChanged: changedAttr3, to: &copy, key: k3)
+            applyChanges(withOriginal: origAttr4, andChanged: changedAttr4, to: &copy, key: k4)
+        }
+        return copy
+    }
+
+    public func transformingAttributes<K1, K2, K3, K4, K5>(_ k:  K1.Type, _ k2: K2.Type, _ k3: K3.Type, _ k4: K4.Type, _ k5: K5.Type,
+                                                           _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
+                                                                 inout AttributedString.SingleAttributeTransformer<K2>,
+                                                                 inout AttributedString.SingleAttributeTransformer<K3>,
+                                                                 inout AttributedString.SingleAttributeTransformer<K4>,
+                                                                 inout AttributedString.SingleAttributeTransformer<K5>) -> Void) -> AttributedString {
+        let orig = AttributedString(_guts)
+        var copy = orig
+        copy.ensureUniqueReference() // ???: Is this best practice? We're going behind the back of the AttributedString mutation API surface, so it doesn't happen anywhere else. It's also aggressively speculative.
+        for (attr, attr2, attr3, attr4, attr5, range) in orig.runs[k, k2, k3, k4, k5] {
+            let origAttr1 = AttributedString.SingleAttributeTransformer<K1>(range: range, attr: attr)
+            let origAttr2 = AttributedString.SingleAttributeTransformer<K2>(range: range, attr: attr2)
+            let origAttr3 = AttributedString.SingleAttributeTransformer<K3>(range: range, attr: attr3)
+            let origAttr4 = AttributedString.SingleAttributeTransformer<K4>(range: range, attr: attr4)
+            let origAttr5 = AttributedString.SingleAttributeTransformer<K5>(range: range, attr: attr5)
+            var changedAttr1 = origAttr1
+            var changedAttr2 = origAttr2
+            var changedAttr3 = origAttr3
+            var changedAttr4 = origAttr4
+            var changedAttr5 = origAttr5
+            c(&changedAttr1, &changedAttr2, &changedAttr3, &changedAttr4, &changedAttr5)
+            applyRemovals(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyRemovals(withOriginal: origAttr2, andChanged: changedAttr2, to: &copy, key: k2)
+            applyRemovals(withOriginal: origAttr3, andChanged: changedAttr3, to: &copy, key: k3)
+            applyRemovals(withOriginal: origAttr4, andChanged: changedAttr4, to: &copy, key: k4)
+            applyRemovals(withOriginal: origAttr5, andChanged: changedAttr5, to: &copy, key: k5)
+            applyChanges(withOriginal: origAttr1, andChanged: changedAttr1, to: &copy, key: k)
+            applyChanges(withOriginal: origAttr2, andChanged: changedAttr2, to: &copy, key: k2)
+            applyChanges(withOriginal: origAttr3, andChanged: changedAttr3, to: &copy, key: k3)
+            applyChanges(withOriginal: origAttr4, andChanged: changedAttr4, to: &copy, key: k4)
+            applyChanges(withOriginal: origAttr5, andChanged: changedAttr5, to: &copy, key: k5)
+        }
+        return copy
+    }
+    
+    public func transformingAttributes<K>(_ k: KeyPath<AttributeDynamicLookup, K>, _ c: (inout AttributedString.SingleAttributeTransformer<K>) -> Void) -> AttributedString {
+        self.transformingAttributes(K.self, c)
+    }
+    
+    public func transformingAttributes<K1, K2>(
+        _ k:  KeyPath<AttributeDynamicLookup, K1>,
+        _ k2: KeyPath<AttributeDynamicLookup, K2>, _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
+                                                         inout AttributedString.SingleAttributeTransformer<K2>) -> Void) -> AttributedString {
+        self.transformingAttributes(K1.self, K2.self, c)
+    }
+    
+    public func transformingAttributes<K1, K2, K3>(
+        _ k:  KeyPath<AttributeDynamicLookup, K1>,
+        _ k2: KeyPath<AttributeDynamicLookup, K2>,
+        _ k3: KeyPath<AttributeDynamicLookup, K3>, _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
+                                                         inout AttributedString.SingleAttributeTransformer<K2>,
+                                                         inout AttributedString.SingleAttributeTransformer<K3>) -> Void) -> AttributedString {
+        self.transformingAttributes(K1.self, K2.self, K3.self, c)
+    }
+    
+    public func transformingAttributes<K1, K2, K3, K4>(
+        _ k:  KeyPath<AttributeDynamicLookup, K1>,
+        _ k2: KeyPath<AttributeDynamicLookup, K2>,
+        _ k3: KeyPath<AttributeDynamicLookup, K3>,
+        _ k4: KeyPath<AttributeDynamicLookup, K4>, _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
+                                                         inout AttributedString.SingleAttributeTransformer<K2>,
+                                                         inout AttributedString.SingleAttributeTransformer<K3>,
+                                                         inout AttributedString.SingleAttributeTransformer<K4>) -> Void) -> AttributedString {
+        self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, c)
+    }
+    
+    public func transformingAttributes<K1, K2, K3, K4, K5>(
+        _ k:  KeyPath<AttributeDynamicLookup, K1>,
+        _ k2: KeyPath<AttributeDynamicLookup, K2>,
+        _ k3: KeyPath<AttributeDynamicLookup, K3>,
+        _ k4: KeyPath<AttributeDynamicLookup, K4>,
+        _ k5: KeyPath<AttributeDynamicLookup, K5>, _ c: (inout AttributedString.SingleAttributeTransformer<K1>,
+                                                         inout AttributedString.SingleAttributeTransformer<K2>,
+                                                         inout AttributedString.SingleAttributeTransformer<K3>,
+                                                         inout AttributedString.SingleAttributeTransformer<K4>,
+                                                         inout AttributedString.SingleAttributeTransformer<K5>) -> Void) -> AttributedString {
+        self.transformingAttributes(K1.self, K2.self, K3.self, K4.self, K5.self, c)
+
+    }
+    
+    internal struct _AttributeStorage : Hashable, CustomStringConvertible {
+        internal var contents : [String : Any]
+        
+        subscript <T: AttributedStringKey>(_ attribute: T.Type) -> T.Value? {
+            get { self.contents[T.name] as? T.Value }
+            set { self.contents[T.name] = newValue }
+        }
+        
+        internal mutating func mergeIn(_ otherContents: [String: Any]) {
+            for (key, value) in otherContents {
+                contents[key] = value
+            }
+        }
+        
+        internal mutating func mergeIn(_ otherContents: [String: Any], uniquingKeysWith: (Any, Any) -> Any) {
+            contents.merge(otherContents, uniquingKeysWith: uniquingKeysWith)
+        }
+        
+        internal mutating func mergeIn(_ other: _AttributeStorage) {
+            self.mergeIn(other.contents)
+        }
+        
+        internal mutating func mergeIn(_ other: AttributeContainer) {
+            self.mergeIn(other.contents)
+        }
+        
+        public init(_ contents: [String : Any] = [:]) {
+            self.contents = contents
+        }
+        
+        public static func == (lhs: AttributedString._AttributeStorage, rhs: AttributedString._AttributeStorage) -> Bool {
+            guard lhs.contents.keys == rhs.contents.keys else {
+                return false
+            }
+            for (key, value) in lhs.contents {
+                if !__equalAttributes(value, rhs.contents[key]) {
+                    return false
+                }
+            }
+            return true
+        }
+        
+        public var description : String {
+            contents._attrStrDescription
+        }
+        
+        public func hash(into hasher: inout Hasher) {
+            let c = contents as! [String : AnyHashable]
+            c.hash(into: &hasher)
+        }
+    }
+    
+    public struct SingleAttributeTransformer<T: AttributedStringKey> {
+        public var range: Range<Index>
+        
+        internal var attrName = T.name
+        internal var attr : Any?
+        
+        public var value: T.Value? {
+            get { attr as? T.Value }
+            set { attr = newValue }
+        }
+        
+        public mutating func replace<U: AttributedStringKey>(with key: U.Type, value: U.Value) {
+            attrName = key.name
+            attr = value
+        }
+
+        public mutating func replace<U: AttributedStringKey>(with keyPath: KeyPath<AttributeDynamicLookup, U>, value: U.Value) {
+            self.replace(with: U.self, value: value)
+        }
+    }
+        
+    public struct Index : Comparable {
+        internal let characterIndex: String.Index
+        public static func < (lhs: AttributedString.Index, rhs: AttributedString.Index) -> Bool {
+            return lhs.characterIndex < rhs.characterIndex
+        }
+    }
+
+    internal struct _InternalRun : Hashable {
+        // UTF-8 Code Unit Length
+        internal var length : Int
+        internal var attributes : _AttributeStorage
+        
+        public static func == (lhs: _InternalRun, rhs: _InternalRun) -> Bool {
+            if lhs.length != rhs.length {
+                return false
+            }
+            return lhs.attributes == rhs.attributes
+        }
+        
+        public func get<T: AttributedStringKey>(_ k: T.Type) -> T.Value? {
+            attributes[k]
+        }
+    }
+    
+    internal class Guts : Hashable {
+        var string : String
+        
+        // NOTE: the runs and runOffsetCache should never be modified directly. Instead, use the functions defined in AttributedStringRunCoalescing.swift
+        var runs : [_InternalRun]
+        var runOffsetCache : RunOffset
+        var runOffsetCacheLock : Lock
+        
+        static func == (lhs: AttributedString.Guts, rhs: AttributedString.Guts) -> Bool {
+            return lhs.string == rhs.string && lhs.runs == rhs.runs
+        }
+        
+        init(string: String, runs : [_InternalRun]) {
+            precondition(string.isEmpty == runs.isEmpty, "An empty attributed string should not contain any runs")
+            self.string = string
+            self.runs = runs
+            runOffsetCache = RunOffset()
+            runOffsetCacheLock = Lock()
+            // Ensure the string is a native contiguous string to prevent performance issues when indexing via offsets
+            self.string.makeContiguousUTF8()
+        }
+        
+        init(_ guts: Guts, range: Range<Index>) {
+            string = String(guts.string[range._stringRange])
+            runs = guts.runs(in: range, relativeTo: string)
+            runOffsetCache = RunOffset()
+            runOffsetCacheLock = Lock()
+        }
+        
+        init(_ guts: Guts) {
+            string = guts.string
+            runs = guts.runs
+            runOffsetCache = RunOffset()
+            runOffsetCacheLock = Lock()
+        }
+        
+        deinit {
+            runOffsetCacheLock.cleanupLock()
+        }
+        
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(string)
+            hasher.combine(runs)
+        }
+        
+        var startIndex : Index {
+            Index(characterIndex: string.startIndex)
+        }
+        
+        var endIndex : Index {
+            Index(characterIndex: string.endIndex)
+        }
+        
+        func index(byCharactersAfter i: Index) -> Index {
+            return Index(characterIndex: string.index(after: i.characterIndex))
+        }
+        
+        func index(byCharactersBefore i: Index) -> Index {
+            return Index(characterIndex: string.index(before: i.characterIndex))
+        }
+        
+        func index(byUTF8Before i: Index) -> Index {
+            return Index(characterIndex: string.utf8.index(before: i.characterIndex))
+        }
+        
+        func index(for utf8Offset: Int) -> Index {
+            return index(startIndex, offsetByUTF8: utf8Offset)
+        }
+        
+        func index(_ i: Index, offsetByUTF8 distance: Int) -> Index {
+            return Index(characterIndex: string.utf8.index(i.characterIndex, offsetBy: distance))
+        }
+        
+        func utf8OffsetRange(from range: Range<Index>) -> Range<Int> {
+            return utf8Distance(from: startIndex, to: range.lowerBound) ..< utf8Distance(from: startIndex, to: range.upperBound)
+        }
+        
+        func utf8Distance(from: Index, to: Index) -> Int {
+            return string.utf8.distance(from: from.characterIndex, to: to.characterIndex)
+        }
+        
+        func boundsCheck(_ idx: AttributedString.Index) {
+            precondition(idx.characterIndex >= string.startIndex && idx.characterIndex <= string.endIndex, "AttributedString index is out of bounds")
+        }
+        
+        func boundsCheck(_ range: Range<AttributedString.Index>) {
+            precondition(range.lowerBound.characterIndex >= string.startIndex && range.upperBound.characterIndex <= string.endIndex, "AttributedString index range is out of bounds")
+        }
+        
+        func boundsCheck(_ idx: Runs.Index) {
+            precondition(idx.rangeIndex >= 0 && idx.rangeIndex < runs.count, "AttributedString.Runs index is out of bounds")
+        }
+        
+        func run(at position: Runs.Index, clampedBy range: Range<AttributedString.Index>) -> Runs.Run {
+            boundsCheck(position)
+            let (internalRun, loc) = runAndLocation(at: position.rangeIndex)
+            let result = Runs.Run(_internal: internalRun, _rangeOrStartIndex: .startIndex(index(for: loc)), _guts: self)
+            return result.run(clampedTo: range)
+            
+        }
+        
+        func run(at position: AttributedString.Index, clampedBy clampRange: Range<AttributedString.Index>) -> (_InternalRun, Range<AttributedString.Index>) {
+            boundsCheck(position)
+            let location = utf8Distance(from: startIndex, to: position)
+            let (run, startIdx) = runAndLocation(containing: location)
+            let start = index(for: startIdx)
+            let end = index(for: startIdx + run.length)
+            return (run, (start ..< end).clamped(to: clampRange))
+        }
+        
+        func indexOfRun(at position: AttributedString.Index) -> Runs.Index {
+            boundsCheck(position)
+            // !!!: Blech
+            if position == self.endIndex {
+                return Runs.Index(rangeIndex: runs.endIndex)
+            }
+            
+            return Runs.Index(rangeIndex: indexOfRun(containing: utf8Distance(from: startIndex, to: position)))
+        }
+        
+        // Returns all the runs in the receiver, in the given range.
+        func runs(in range: Range<Index>, relativeTo newString: String) -> [_InternalRun] {
+            let lowerBound = utf8Distance(from: startIndex, to: range.lowerBound)
+            let upperBound = lowerBound + utf8Distance(from: range.lowerBound, to: range.upperBound)
+            return runs(containing: lowerBound ..< upperBound)
+        }
+
+        func getValue(at index: Index, key: String) -> Any? {
+            run(containing: utf8Distance(from: startIndex, to: index)).attributes.contents[key]
+        }
+
+        func getValue(in range: Range<Index>, key: String) -> Any? {
+            var result : Any? = nil
+            let lowerBound = utf8Distance(from: startIndex, to: range.lowerBound)
+            let upperBound = lowerBound + utf8Distance(from: range.lowerBound, to: range.upperBound)
+            enumerateRuns(containing: lowerBound ..< upperBound) { run, location, stop, modified in
+                modified = .guaranteedNotModified
+                guard let value = run.attributes.contents[key] else {
+                    result = nil
+                    stop = true
+                    return
+                }
+                
+                if let previous = result, !__equalAttributes(previous, value) {
+                    result = nil
+                    stop = true
+                    return
+                }
+                result = value
+            }
+            return result
+        }
+        
+        func getValues(in range: Range<Index>) -> [String : Any] {
+            var contents = [String : Any]()
+            let lowerBound = utf8Distance(from: startIndex, to: range.lowerBound)
+            let upperBound = lowerBound + utf8Distance(from: range.lowerBound, to: range.upperBound)
+            enumerateRuns(containing: lowerBound ..< upperBound) { run, _, stop, modification in
+                modification = .guaranteedNotModified
+                if contents.isEmpty {
+                    contents = run.attributes.contents
+                } else {
+                    contents = contents.filter {
+                        run.attributes.contents.keys.contains($0.key) && __equalAttributes($0.value, run.attributes.contents[$0.key])
+                    }
+                }
+                if contents.isEmpty {
+                    stop = true
+                }
+            }
+            return contents
+        }
+
+        func add(value: Any, in range: Range<Index>, key: String) {
+            self.enumerateRuns(containing: utf8OffsetRange(from: range)) { run, _, _, _ in
+                run.attributes.contents[key] = value
+            }
+        }
+        
+        func add(attributes: AttributeContainer, in range: Range<Index>, mergePolicy:  AttributeMergePolicy = .keepNew) {
+            let newAttrDict = attributes.contents
+            let closure = mergePolicy.combinerClosure
+            self.enumerateRuns(containing: utf8OffsetRange(from: range)) { run, _, _, _ in
+                run.attributes.mergeIn(newAttrDict, uniquingKeysWith: closure)
+            }
+        }
+        
+        func set(attributes: AttributeContainer, in range: Range<Index>) {
+            let newAttrDict = attributes.contents
+            let range = utf8OffsetRange(from: range)
+            self.replaceRunsSubrange(locations: range, with: [_InternalRun(length: range.endIndex - range.startIndex, attributes: _AttributeStorage(newAttrDict))])
+        }
+        
+        func remove<T : AttributedStringKey>(attribute: T.Type, in range: Range<Index>) {
+            self.enumerateRuns(containing: utf8OffsetRange(from: range)) { run, _, _, _ in
+                run.attributes.contents[T.name] = nil
+            }
+        }
+        
+        func remove(key: String, in range: Range<Index>) {
+            self.enumerateRuns(containing: utf8OffsetRange(from: range)) { run, _, _, _ in
+                run.attributes.contents[key] = nil
+            }
+        }
+                
+        func replaceSubrange<S: AttributedStringProtocol>(_ range: Range<Index>, with s: S) {
+            let otherStringRange = s.startIndex.characterIndex ..< s.endIndex.characterIndex
+            let thisStringRange = range._stringRange
+            let otherString = s.__guts.string[otherStringRange]
+            let lowerBound = utf8Distance(from: startIndex, to: range.lowerBound)
+            let upperBound = lowerBound + utf8Distance(from: range.lowerBound, to: range.upperBound)
+            if string[thisStringRange] != otherString {
+                // Faster to allocate and pass String(otherString) than pass otherString because taking
+                // replaceSubrange's fast paths for String objects is better than not allocating a String
+                string.replaceSubrange(thisStringRange, with: String(otherString))
+            }
+            let otherLowerBound = utf8Distance(from: s.__guts.startIndex, to: s.startIndex)
+            let otherUpperBound = otherLowerBound + utf8Distance(from: s.startIndex, to: s.endIndex)
+            self.replaceRunsSubrange(locations: lowerBound ..< upperBound, with: s.__guts.runs(containing: otherLowerBound ..< otherUpperBound))
+        }
+        
+        func attributesToUseForReplacement(in range: Range<Index>) -> _AttributeStorage {
+            guard !self.string.isEmpty else {
+                return _AttributeStorage()
+            }
+            if !range.isEmpty {
+                return self.run(at: range.lowerBound, clampedBy: self.startIndex ..< self.endIndex).0.attributes
+            } else if range.lowerBound > self.startIndex {
+                let prevIndex = self.index(byUTF8Before: range.lowerBound)
+                return self.run(at: prevIndex, clampedBy: self.startIndex ..< self.endIndex).0.attributes
+            } else {
+                return self.run(at: self.startIndex, clampedBy: self.startIndex ..< self.endIndex).0.attributes
+            }
+        }
+        
+    }
+    
+    internal var _guts : Guts
+    
+    internal enum RangeOrStartIndex : Equatable {
+        case range(Range<AttributedString.Index>)
+        case startIndex(AttributedString.Index)
+    }
+    public struct Runs : BidirectionalCollection, Equatable, CustomStringConvertible {
+        public struct Index : Comparable, Strideable {
+            internal let rangeIndex : Int
+            
+            public static func < (lhs: AttributedString.Runs.Index, rhs: AttributedString.Runs.Index) -> Bool {
+                return lhs.rangeIndex < rhs.rangeIndex
+            }
+            
+            public func distance(to other: AttributedString.Runs.Index) -> Int {
+                return other.rangeIndex - rangeIndex
+            }
+            
+            public func advanced(by n: Int) -> AttributedString.Runs.Index {
+                Index(rangeIndex: rangeIndex + n)
+            }
+        }
+        
+        @dynamicMemberLookup
+        public struct Run : Equatable, CustomStringConvertible {
+
+            public var range : Range<AttributedString.Index> {
+                switch _rangeOrStartIndex {
+                case .range(let range):
+                    return range
+                case .startIndex(let startIndex):
+                    return startIndex ..< _guts.index(startIndex, offsetByUTF8: _internal.length)
+                }
+            }
+            internal var startIndex : AttributedString.Index {
+                switch _rangeOrStartIndex {
+                case .range(let range):
+                    return range.lowerBound
+                case .startIndex(let startIndex):
+                    return startIndex
+                }
+            }
+            internal var _attributes : _AttributeStorage {
+                return _internal.attributes
+            }
+
+            internal let _internal : _InternalRun
+            internal let _rangeOrStartIndex : RangeOrStartIndex
+            internal let _guts : AttributedString.Guts
+            internal init(_internal: _InternalRun, _rangeOrStartIndex: RangeOrStartIndex, _guts: AttributedString.Guts) {
+                self._internal = _internal
+                self._rangeOrStartIndex = _rangeOrStartIndex
+                self._guts = _guts
+            }
+            internal init(_ other: Runs.Run) {
+                self._internal = other._internal
+                self._rangeOrStartIndex = other._rangeOrStartIndex
+                self._guts = other._guts
+            }
+            
+            public static func == (lhs: Run, rhs: Run) -> Bool {
+                return lhs._internal == rhs._internal
+            }
+            
+            public var description: String {
+                AttributedSubstring(_guts, range).description
+            }
+            
+            internal func run(clampedTo range: Range<AttributedString.Index>) -> Run {
+                var newInternal = _internal
+                let newRange = self.range.clamped(to: range)
+                newInternal.length = _guts.utf8Distance(from: newRange.lowerBound, to: newRange.upperBound)
+                return Run(_internal: newInternal, _rangeOrStartIndex: .range(newRange), _guts: _guts)
+            }
+            
+            public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? {
+                get { self[K.self] }
+            }
+            
+            public subscript<K : AttributedStringKey>(_: K.Type) -> K.Value? {
+                get { _internal.attributes.contents[K.name] as? K.Value }
+            }
+            
+            public subscript<S: AttributeScope>(dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>) -> ScopedAttributeContainer<S> {
+                get { ScopedAttributeContainer(_internal.attributes.contents) }
+            }
+
+            internal subscript<S: AttributeScope>(_ scope: S.Type) -> ScopedAttributeContainer<S> {
+                get { ScopedAttributeContainer(_internal.attributes.contents) }
+            }
+
+            public var attributes : AttributeContainer {
+                AttributeContainer(self._attributes.contents)
+            }
+        }
+
+        
+        public typealias Element = Run
+        
+        internal var _guts : Guts
+        internal var _range : Range<AttributedString.Index>
+        internal var _startingRunIndex : Int
+        internal var _endingRunIndex : Int
+        internal init(_ g: Guts, _ r: Range<AttributedString.Index>) {
+            _guts = g
+            _range = r
+            _startingRunIndex = _guts.indexOfRun(at: _range.lowerBound).rangeIndex
+            if _range.upperBound == _guts.endIndex {
+                _endingRunIndex = _guts.runs.count
+            } else if _range.upperBound == _guts.startIndex {
+                _endingRunIndex = 0
+            } else {
+                _endingRunIndex = _guts.indexOfRun(at: _guts.index(byUTF8Before: _range.upperBound)).rangeIndex + 1
+            }
+        }
+        
+        public static func == (lhs: Runs, rhs: Runs) -> Bool {
+            let lhsSlice = lhs._guts.runs[lhs._startingRunIndex ..< lhs._endingRunIndex]
+            let rhsSlice = rhs._guts.runs[rhs._startingRunIndex ..< rhs._endingRunIndex]
+            guard lhsSlice.count == rhs.count else {
+                return false
+            }
+            // Compare all inner runs (their lengths will not be limited by _range)
+            if lhsSlice.count > 2 && !lhsSlice[lhsSlice.startIndex + 1 ..< lhsSlice.endIndex - 1].elementsEqual(rhsSlice[rhsSlice.startIndex + 1 ..< rhsSlice.endIndex - 1]) {
+                return false
+            }
+            // If the inner runs are equivalent, check the first and last runs with clamped ranges
+            if lhsSlice.count > 1 && lhs._guts.run(at: Index(rangeIndex: lhs._endingRunIndex - 1), clampedBy: lhs._range) != rhs._guts.run(at: Index(rangeIndex: rhs._endingRunIndex - 1), clampedBy: rhs._range) {
+                return false
+            }
+            return lhs._guts.run(at: lhs.startIndex, clampedBy: lhs._range) == rhs._guts.run(at: rhs.startIndex, clampedBy: rhs._range)
+        }
+        
+        public var description: String {
+            AttributedSubstring(_guts, _range).description
+        }
+        
+        public func index(before i: Index) -> Index {
+            return Index(rangeIndex: i.rangeIndex-1)
+        }
+        
+        public func index(after i: Index) -> Index {
+            return Index(rangeIndex: i.rangeIndex+1)
+        }
+        
+        public var startIndex: Index {
+            return Index(rangeIndex: _startingRunIndex)
+        }
+        
+        public var endIndex: Index {
+            return Index(rangeIndex: _endingRunIndex)
+        }
+        
+        public subscript(position: Index) -> Run {
+            return _guts.run(at: position, clampedBy: _range)
+        }
+        
+        internal subscript(internal position: Index) -> _InternalRun {
+            return _guts.runs[position.rangeIndex]
+        }
+        
+        public subscript(position: AttributedString.Index) -> Run {
+            let (internalRun, range) = _guts.run(at: position, clampedBy: _range)
+            return Run(_internal: internalRun, _rangeOrStartIndex: .range(range), _guts: _guts)
+        }
+        
+        // ???: public?
+        internal func indexOfRun(at position: AttributedString.Index) -> Index {
+            return _guts.indexOfRun(at: position)
+        }
+
+        internal static func __equalAttributeSlices(lhs: _AttributeStorage, rhs: _AttributeStorage, attributes: [String]) -> Bool {
+            for name in attributes {
+                if !__equalAttributes(lhs.contents[name], rhs.contents[name]) {
+                    return false
+                }
+            }
+            return true
+        }
+        
+        internal func _runs_index(before i: AttributedString.Index, startIndex: AttributedString.Index, endIndex: AttributedString.Index, attributeNames: [String], findingStartOfCurrentSlice: Bool = false) -> AttributedString.Index {
+            let beginningOfInitialRun = (i == endIndex) ? endIndex : self[i].startIndex
+            var currentIndex = i
+            var attributes : _AttributeStorage?
+            var result = i
+            if findingStartOfCurrentSlice {
+                attributes = self[currentIndex]._attributes
+            }
+            repeat {
+                if beginningOfInitialRun < currentIndex {
+                    currentIndex = beginningOfInitialRun
+                } else {
+                    currentIndex = self._guts.index(byCharactersBefore: currentIndex)
+                }
+                let currentRun = self[currentIndex]
+                if let attrs = attributes {
+                    if !Self.__equalAttributeSlices(lhs: attrs, rhs: currentRun._attributes, attributes: attributeNames) {
+                        break
+                    }
+                } else {
+                    attributes = currentRun._attributes
+                }
+                
+                switch currentRun._rangeOrStartIndex {
+                case .range(let r):
+                    result = r.clamped(to: startIndex ..< endIndex).lowerBound
+                case .startIndex(let si):
+                    result = Swift.max(si, startIndex)
+                }
+            } while result > startIndex
+            return result
+        }
+        
+        internal func _runs_index(after i: AttributedString.Index, startIndex: AttributedString.Index, endIndex: AttributedString.Index, attributeNames: [String]) -> AttributedString.Index {
+            let thisRunIndex = self.indexOfRun(at: i)
+            let thisRun = self[internal: thisRunIndex]
+            var nextRunIndex = self.index(after: thisRunIndex)
+            while nextRunIndex < self.endIndex {
+                let (nextRun, location) = self._guts.runAndLocation(at: nextRunIndex.rangeIndex) // Call to guts directly to avoid unneccesary range clamping
+                if !Self.__equalAttributeSlices(lhs: thisRun.attributes, rhs: nextRun.attributes, attributes: attributeNames) {
+                    return self._guts.index(_guts.startIndex, offsetByUTF8: location)
+                }
+                nextRunIndex = self.index(after: nextRunIndex)
+            }
+            return endIndex
+        }
+        
+        internal func _runs_attributesAndRangeAt(position: AttributedString.Index, from previousRunIndex: AttributedString.Index, through nextRunIndex: AttributedString.Index) -> (_AttributeStorage, Range<AttributedString.Index>) {
+            let thisRunIndex = self.indexOfRun(at: position)
+            let thisRun = self[thisRunIndex]
+            let range = previousRunIndex ..< nextRunIndex
+            return (thisRun._attributes, range)
+        }
+        
+        public struct AttributesSlice1<T : AttributedStringKey> : BidirectionalCollection {
+            public typealias Index = AttributedString.Index
+            public typealias Element = (T.Value?, Range<AttributedString.Index>)
+            
+            public struct Iterator: IteratorProtocol {
+                public typealias Element = AttributesSlice1.Element
+                
+                let slice: AttributesSlice1
+                var currentIndex: AttributedString.Index
+                var cachedNextRunIndex: AttributedString.Index?
+                
+                internal init(_ slice: AttributesSlice1) {
+                    self.slice = slice
+                    currentIndex = slice.startIndex
+                }
+                
+                public mutating func next() -> Element? {
+                    if let cached = cachedNextRunIndex {
+                        currentIndex = cached
+                    }
+                    if currentIndex == slice.endIndex {
+                        return nil
+                    }
+                    cachedNextRunIndex = slice.runs._runs_index(after: currentIndex, startIndex: slice.startIndex, endIndex: slice.endIndex, attributeNames: [T.name])
+                    let (attrContents, range) = slice.runs._runs_attributesAndRangeAt(position: currentIndex, from: currentIndex, through: cachedNextRunIndex!)
+                    return (attrContents[T.self], range)
+                }
+            }
+            
+            public func makeIterator() -> Iterator {
+                Iterator(self)
+            }
+            
+            public var startIndex: Index {
+                runs._range.lowerBound
+            }
+            public var endIndex: Index {
+                runs._range.upperBound
+            }
+            
+            public func index(before i: Index) -> Index {
+                runs._runs_index(before: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name])
+            }
+            
+            public func index(after i: Index) -> Index {
+                runs._runs_index(after: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name])
+            }
+            
+            public subscript(position: AttributedString.Index) -> Element {
+                let nextRunIndex = self.index(after: position)
+                let previousRunIndex : AttributedString.Index
+                if position == startIndex {
+                    previousRunIndex = position
+                } else {
+                    previousRunIndex = runs._runs_index(before: position, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name], findingStartOfCurrentSlice: true)
+                }
+                let (attrContents, range) = runs._runs_attributesAndRangeAt(position: position, from: previousRunIndex, through: nextRunIndex)
+                return (attrContents[T.self], range)
+            }
+            
+            let runs : Runs
+        }
+        
+        public struct AttributesSlice2
+            <T : AttributedStringKey,
+             U : AttributedStringKey> : BidirectionalCollection {
+            public typealias Index = AttributedString.Index
+            public typealias Element = (T.Value?, U.Value?, Range<AttributedString.Index>)
+            
+            public struct Iterator: IteratorProtocol {
+                public typealias Element = AttributesSlice2.Element
+                
+                let slice: AttributesSlice2
+                var currentIndex: AttributedString.Index
+                var cachedNextRunIndex: AttributedString.Index?
+                
+                internal init(_ slice: AttributesSlice2) {
+                    self.slice = slice
+                    currentIndex = slice.startIndex
+                }
+                
+                public mutating func next() -> Element? {
+                    if let cached = cachedNextRunIndex {
+                        currentIndex = cached
+                    }
+                    if currentIndex == slice.endIndex {
+                        return nil
+                    }
+                    cachedNextRunIndex = slice.runs._runs_index(after: currentIndex, startIndex: slice.startIndex, endIndex: slice.endIndex, attributeNames: [T.name, U.name])
+                    let (attrContents, range) = slice.runs._runs_attributesAndRangeAt(position: currentIndex, from: currentIndex, through: cachedNextRunIndex!)
+                    return (attrContents[T.self], attrContents[U.self], range)
+                }
+            }
+            
+            public func makeIterator() -> Iterator {
+                Iterator(self)
+            }
+            
+            public var startIndex: Index {
+                runs._range.lowerBound
+            }
+            public var endIndex: Index {
+                runs._range.upperBound
+            }
+            
+            public func index(before i: Index) -> Index {
+                runs._runs_index(before: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name])
+            }
+            
+            public func index(after i: Index) -> Index {
+                runs._runs_index(after: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name])
+            }
+            
+            public subscript(position: AttributedString.Index) -> Element {
+                let nextRunIndex = self.index(after: position)
+                let previousRunIndex : AttributedString.Index
+                if position == startIndex {
+                    previousRunIndex = position
+                } else {
+                    previousRunIndex = runs._runs_index(before: position, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name], findingStartOfCurrentSlice: true)
+                }
+                let (attrContents, range) = runs._runs_attributesAndRangeAt(position: position, from: previousRunIndex, through: nextRunIndex)
+                return (attrContents[T.self], attrContents[U.self], range)
+            }
+            
+            let runs : Runs
+        }
+        
+        public struct AttributesSlice3
+            <T : AttributedStringKey,
+             U : AttributedStringKey,
+             V : AttributedStringKey> : BidirectionalCollection {
+            public typealias Index = AttributedString.Index
+            public typealias Element = (T.Value?, U.Value?, V.Value?, Range<AttributedString.Index>)
+            
+            public struct Iterator: IteratorProtocol {
+                public typealias Element = AttributesSlice3.Element
+                
+                let slice: AttributesSlice3
+                var currentIndex: AttributedString.Index
+                var cachedNextRunIndex: AttributedString.Index?
+                
+                internal init(_ slice: AttributesSlice3) {
+                    self.slice = slice
+                    currentIndex = slice.startIndex
+                }
+                
+                public mutating func next() -> Element? {
+                    if let cached = cachedNextRunIndex {
+                        currentIndex = cached
+                    }
+                    if currentIndex == slice.endIndex {
+                        return nil
+                    }
+                    cachedNextRunIndex = slice.runs._runs_index(after: currentIndex, startIndex: slice.startIndex, endIndex: slice.endIndex, attributeNames: [T.name, U.name, V.name])
+                    let (attrContents, range) = slice.runs._runs_attributesAndRangeAt(position: currentIndex, from: currentIndex, through: cachedNextRunIndex!)
+                    return (attrContents[T.self], attrContents[U.self], attrContents[V.self], range)
+                }
+            }
+            
+            public func makeIterator() -> Iterator {
+                Iterator(self)
+            }
+            
+            public var startIndex: Index {
+                runs._range.lowerBound
+            }
+            public var endIndex: Index {
+                runs._range.upperBound
+            }
+            
+            public func index(before i: Index) -> Index {
+                runs._runs_index(before: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name])
+            }
+            
+            public func index(after i: Index) -> Index {
+                runs._runs_index(after: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name])
+            }
+            
+            public subscript(position: AttributedString.Index) -> Element {
+                let nextRunIndex = self.index(after: position)
+                let previousRunIndex : AttributedString.Index
+                if position == startIndex {
+                    previousRunIndex = position
+                } else {
+                    previousRunIndex = runs._runs_index(before: position, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name], findingStartOfCurrentSlice: true)
+                }
+                let (attrContents, range) = runs._runs_attributesAndRangeAt(position: position, from: previousRunIndex, through: nextRunIndex)
+                return (attrContents[T.self], attrContents[U.self], attrContents[V.self], range)
+            }
+            
+            let runs : Runs
+        }
+        
+        public struct AttributesSlice4
+            <T : AttributedStringKey,
+             U : AttributedStringKey,
+             V : AttributedStringKey,
+             W : AttributedStringKey> : BidirectionalCollection {
+            public typealias Index = AttributedString.Index
+            public typealias Element = (T.Value?, U.Value?, V.Value?, W.Value?, Range<AttributedString.Index>)
+            
+            public struct Iterator: IteratorProtocol {
+                public typealias Element = AttributesSlice4.Element
+                
+                let slice: AttributesSlice4
+                var currentIndex: AttributedString.Index
+                var cachedNextRunIndex: AttributedString.Index?
+                
+                internal init(_ slice: AttributesSlice4) {
+                    self.slice = slice
+                    currentIndex = slice.startIndex
+                }
+                
+                public mutating func next() -> Element? {
+                    if let cached = cachedNextRunIndex {
+                        currentIndex = cached
+                    }
+                    if currentIndex == slice.endIndex {
+                        return nil
+                    }
+                    cachedNextRunIndex = slice.runs._runs_index(after: currentIndex, startIndex: slice.startIndex, endIndex: slice.endIndex, attributeNames: [T.name, U.name, V.name, W.name])
+                    let (attrContents, range) = slice.runs._runs_attributesAndRangeAt(position: currentIndex, from: currentIndex, through: cachedNextRunIndex!)
+                    return (attrContents[T.self], attrContents[U.self], attrContents[V.self], attrContents[W.self], range)
+                }
+            }
+            
+            public func makeIterator() -> Iterator {
+                Iterator(self)
+            }
+            
+            public var startIndex: Index {
+                runs._range.lowerBound
+            }
+            public var endIndex: Index {
+                runs._range.upperBound
+            }
+            
+            public func index(before i: Index) -> Index {
+                runs._runs_index(before: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name, W.name])
+            }
+            
+            public func index(after i: Index) -> Index {
+                runs._runs_index(after: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name, W.name])
+            }
+            
+            public subscript(position: AttributedString.Index) -> Element {
+                let nextRunIndex = self.index(after: position)
+                let previousRunIndex : AttributedString.Index
+                if position == startIndex {
+                    previousRunIndex = position
+                } else {
+                    previousRunIndex = runs._runs_index(before: position, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name, W.name], findingStartOfCurrentSlice: true)
+                }
+                let (attrContents, range) = runs._runs_attributesAndRangeAt(position: position, from: previousRunIndex, through: nextRunIndex)
+                return (attrContents[T.self], attrContents[U.self], attrContents[V.self], attrContents[W.self], range)
+            }
+            
+            let runs : Runs
+        }
+        
+        public struct AttributesSlice5
+            <T : AttributedStringKey,
+             U : AttributedStringKey,
+             V : AttributedStringKey,
+             W : AttributedStringKey,
+             X : AttributedStringKey> : BidirectionalCollection {
+            public typealias Index = AttributedString.Index
+            public typealias Element = (T.Value?, U.Value?, V.Value?, W.Value?, X.Value?, Range<AttributedString.Index>)
+            
+            public struct Iterator: IteratorProtocol {
+                public typealias Element = AttributesSlice5.Element
+                
+                let slice: AttributesSlice5
+                var currentIndex: AttributedString.Index
+                var cachedNextRunIndex: AttributedString.Index?
+                
+                internal init(_ slice: AttributesSlice5) {
+                    self.slice = slice
+                    currentIndex = slice.startIndex
+                }
+                
+                public mutating func next() -> Element? {
+                    if let cached = cachedNextRunIndex {
+                        currentIndex = cached
+                    }
+                    if currentIndex == slice.endIndex {
+                        return nil
+                    }
+                    cachedNextRunIndex = slice.runs._runs_index(after: currentIndex, startIndex: slice.startIndex, endIndex: slice.endIndex, attributeNames: [T.name, U.name, V.name, W.name, X.name])
+                    let (attrContents, range) = slice.runs._runs_attributesAndRangeAt(position: currentIndex, from: currentIndex, through: cachedNextRunIndex!)
+                    return (attrContents[T.self], attrContents[U.self], attrContents[V.self], attrContents[W.self], attrContents[X.self], range)
+                }
+            }
+            
+            public func makeIterator() -> Iterator {
+                Iterator(self)
+            }
+            
+            public var startIndex: Index {
+                runs._range.lowerBound
+            }
+            public var endIndex: Index {
+                runs._range.upperBound
+            }
+            
+            public func index(before i: Index) -> Index {
+                runs._runs_index(before: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name, W.name, X.name])
+            }
+            
+            public func index(after i: Index) -> Index {
+                runs._runs_index(after: i, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name, W.name, X.name])
+            }
+            
+            public subscript(position: AttributedString.Index) -> Element {
+                let nextRunIndex = self.index(after: position)
+                let previousRunIndex : AttributedString.Index
+                if position == startIndex {
+                    previousRunIndex = position
+                } else {
+                    previousRunIndex = runs._runs_index(before: position, startIndex: startIndex, endIndex: endIndex, attributeNames: [T.name, U.name, V.name, W.name, X.name], findingStartOfCurrentSlice: true)
+                }
+                let (attrContents, range) = runs._runs_attributesAndRangeAt(position: position, from: previousRunIndex, through: nextRunIndex)
+                return (attrContents[T.self], attrContents[U.self], attrContents[V.self], attrContents[W.self], attrContents[X.self], range)
+            }
+            
+            let runs : Runs
+        }
+        
+        public subscript <
+            T : AttributedStringKey,
+            U : AttributedStringKey,
+            V : AttributedStringKey,
+            W : AttributedStringKey,
+            X : AttributedStringKey> (_ t: KeyPath<AttributeDynamicLookup, T>,
+                                      _ u: KeyPath<AttributeDynamicLookup, U>,
+                                      _ v: KeyPath<AttributeDynamicLookup, V>,
+                                      _ w: KeyPath<AttributeDynamicLookup, W>,
+                                      _ x: KeyPath<AttributeDynamicLookup, X>) -> AttributesSlice5<T, U, V, W, X>
+        {
+            return AttributesSlice5<T, U, V, W, X>(runs: self)
+        }
+        
+        public subscript <
+            T : AttributedStringKey,
+            U : AttributedStringKey,
+            V : AttributedStringKey,
+            W : AttributedStringKey> (_ t: KeyPath<AttributeDynamicLookup, T>,
+                                      _ u: KeyPath<AttributeDynamicLookup, U>,
+                                      _ v: KeyPath<AttributeDynamicLookup, V>,
+                                      _ w: KeyPath<AttributeDynamicLookup, W>) -> AttributesSlice4<T, U, V, W>
+        {
+            return AttributesSlice4<T, U, V, W>(runs: self)
+        }
+        
+        public subscript <
+            T : AttributedStringKey,
+            U : AttributedStringKey,
+            V : AttributedStringKey> (_ t: KeyPath<AttributeDynamicLookup, T>,
+                                      _ u: KeyPath<AttributeDynamicLookup, U>,
+                                      _ v: KeyPath<AttributeDynamicLookup, V>) -> AttributesSlice3<T, U, V>
+        {
+            return AttributesSlice3<T, U, V>(runs: self)
+        }
+
+        public subscript <
+            T : AttributedStringKey,
+            U : AttributedStringKey> (_ t: KeyPath<AttributeDynamicLookup, T>,
+                                      _ u: KeyPath<AttributeDynamicLookup, U>) -> AttributesSlice2<T, U>
+        {
+            return AttributesSlice2<T, U>(runs: self)
+        }
+
+        public subscript<T : AttributedStringKey>(_ keyPath: KeyPath<AttributeDynamicLookup, T>) -> AttributesSlice1<T> {
+            return AttributesSlice1<T>(runs: self)
+        }
+
+        public subscript <
+            T : AttributedStringKey,
+            U : AttributedStringKey,
+            V : AttributedStringKey,
+            W : AttributedStringKey,
+            X : AttributedStringKey> (_ t: T.Type,
+                                      _ u: U.Type,
+                                      _ v: V.Type,
+                                      _ w: W.Type,
+                                      _ x: X.Type) -> AttributesSlice5<T, U, V, W, X>
+        {
+            return AttributesSlice5<T, U, V, W, X>(runs: self)
+        }
+
+        public subscript <
+            T : AttributedStringKey,
+            U : AttributedStringKey,
+            V : AttributedStringKey,
+            W : AttributedStringKey> (_ t: T.Type,
+                                      _ u: U.Type,
+                                      _ v: V.Type,
+                                      _ w: W.Type) -> AttributesSlice4<T, U, V, W>
+        {
+            return AttributesSlice4<T, U, V, W>(runs: self)
+        }
+
+        public subscript <
+            T : AttributedStringKey,
+            U : AttributedStringKey,
+            V : AttributedStringKey> (_ t: T.Type,
+                                      _ u: U.Type,
+                                      _ v: V.Type) -> AttributesSlice3<T, U, V>
+        {
+            return AttributesSlice3<T, U, V>(runs: self)
+        }
+
+        public subscript <
+            T : AttributedStringKey,
+            U : AttributedStringKey> (_ t: T.Type,
+                                      _ u: U.Type) -> AttributesSlice2<T, U>
+        {
+            return AttributesSlice2<T, U>(runs: self)
+        }
+
+        public subscript<T : AttributedStringKey>(_ t: T.Type) -> AttributesSlice1<T> {
+            return AttributesSlice1<T>(runs: self)
+        }
+ 
+    }
+    
+    public var runs : Runs {
+        get { .init(_guts, _guts.startIndex ..< _guts.endIndex) }
+    }
+    
+    public struct CharacterView : BidirectionalCollection, RangeReplaceableCollection {
+        public typealias Element = Character
+        public typealias Index = AttributedString.Index
+
+        internal var _guts : Guts
+        internal var _range : Range<Index>
+        internal var _identity : Int = 0
+        internal init(_ g: Guts, _ r: Range<Index>) {
+            _guts = g
+            _range = r
+        }
+        
+        public init() {
+            _guts = Guts(string: "", runs: [])
+            _range = _guts.startIndex ..< _guts.endIndex
+        }
+        
+        public var startIndex: AttributedString.Index {
+            return _range.lowerBound
+        }
+        
+        public var endIndex: AttributedString.Index {
+            return _range.upperBound
+        }
+    
+        public func index(before i: AttributedString.Index) -> AttributedString.Index {
+            return _guts.index(byCharactersBefore: i)
+        }
+        
+        public func index(after i: AttributedString.Index) -> AttributedString.Index {
+            return _guts.index(byCharactersAfter: i)
+        }
+        
+        internal mutating func ensureUniqueReference() {
+            if !isKnownUniquelyReferenced(&_guts) {
+                _guts = Guts(_guts)
+            }
+        }
+        
+        public subscript(index: AttributedString.Index) -> Character {
+            get {
+                _guts.string[index.characterIndex]
+            }
+            set {
+                self.replaceSubrange(index ..< _guts.index(byCharactersAfter: index), with: [newValue])
+            }
+        }
+        
+        public subscript(bounds: Range<AttributedString.Index>) -> Slice<AttributedString.CharacterView> {
+            get {
+                Slice(base: self, bounds: bounds)
+            }
+            set {
+                ensureUniqueReference()
+                let newAttributedString = AttributedString(String(newValue))
+                if newAttributedString._guts.runs.count > 0 {
+                    var run = newAttributedString._guts.runs[0]
+                    run.attributes = _guts.run(at: bounds.lowerBound, clampedBy: _range).0.attributes // ???: Is this right?
+                    newAttributedString._guts.updateAndCoalesce(run: run, at: 0)
+                }
+                _guts.replaceSubrange(bounds, with: newAttributedString)
+            }
+        }
+        
+        public mutating func replaceSubrange<C : Collection>(_ subrange: Range<Index>, with newElements: C) where C.Element == Character {
+            ensureUniqueReference()
+            let newAttributedString = AttributedString(String(newElements))
+            if newAttributedString._guts.runs.count > 0 {
+                var run = newAttributedString._guts.runs[0]
+                run.attributes = _guts.attributesToUseForReplacement(in: subrange)
+                newAttributedString._guts.updateAndCoalesce(run: run, at: 0)
+            }
+            
+            // !!!: We're dealing with Characters in this view, but the subrange could sub-Character indexes. I'm pretty sure this will FATALERROR if they do if we try to compute character distance. This needs serious vetting & testing.
+            let sliceOffset = _guts.utf8Distance(from: _guts.startIndex, to: self.startIndex)
+            let newSliceCount = _guts.utf8Distance(from: self.startIndex, to: subrange.lowerBound) + _guts.utf8Distance(from: subrange.upperBound, to: self.endIndex) + String(newElements).utf8.count
+            _guts.replaceSubrange(subrange, with: newAttributedString)
+            _range = _guts.index(_guts.startIndex, offsetByUTF8: sliceOffset) ..< _guts.index(self.startIndex, offsetByUTF8: newSliceCount)
+        }
+    }
+    
+    public struct UnicodeScalarView : RangeReplaceableCollection, BidirectionalCollection {
+        public typealias Element = UnicodeScalar
+        public typealias Index = AttributedString.Index
+        
+        internal var _guts : Guts
+        internal var _range : Range<Index>
+        internal var _identity : Int = 0
+        internal init(_ g: Guts, _ r: Range<Index>) {
+            _guts = g
+            _range = r
+        }
+        
+        public init() {
+            _guts = Guts(string: "", runs: [])
+            _range = _guts.startIndex ..< _guts.endIndex
+        }
+        
+        public var startIndex: AttributedString.Index {
+            return _range.lowerBound
+        }
+        
+        public var endIndex: AttributedString.Index {
+            return _range.upperBound
+        }
+    
+        public func index(before i: AttributedString.Index) -> AttributedString.Index {
+            let index = _guts.string.unicodeScalars.index(before: i.characterIndex)
+            return Index(characterIndex: index)
+        }
+        
+        public func index(after i: AttributedString.Index) -> AttributedString.Index {
+            let index = _guts.string.unicodeScalars.index(after: i.characterIndex)
+            return Index(characterIndex: index)
+        }
+        
+        public func index(_ i: AttributedString.Index, offsetBy distance: Int) -> AttributedString.Index {
+            let index = _guts.string.unicodeScalars.index(i.characterIndex, offsetBy: distance)
+            return Index(characterIndex: index)
+        }
+        
+        public subscript(index: AttributedString.Index) -> UnicodeScalar {
+            _guts.string.unicodeScalars[index.characterIndex]
+        }
+        
+        public subscript(bounds: Range<AttributedString.Index>) -> Slice<AttributedString.UnicodeScalarView> {
+            Slice(base: self, bounds: bounds)
+        }
+        
+        internal mutating func ensureUniqueReference() {
+            if !isKnownUniquelyReferenced(&_guts) {
+                _guts = Guts(_guts)
+            }
+        }
+        
+        public mutating func replaceSubrange<C : Collection>(_ subrange: Range<Index>, with newElements: C) where C.Element == UnicodeScalar {
+            ensureUniqueReference()
+            let unicodeScalarView = String.UnicodeScalarView(newElements)
+            let newAttributedString = AttributedString(String(unicodeScalarView))
+            if newAttributedString._guts.runs.count > 0 {
+                var run = newAttributedString._guts.runs[0]
+                run.attributes = _guts.attributesToUseForReplacement(in: subrange)
+                newAttributedString._guts.updateAndCoalesce(run: run, at: 0)
+            }
+            
+            // !!!: We're dealing with Characters in this view, but the subrange could sub-Character indexes. I'm pretty sure this will FATALERROR if they do if we try to compute character distance. This needs serious vetting & testing.
+            let sliceOffset = _guts.utf8Distance(from: _guts.startIndex, to: self.startIndex)
+            let newSliceCount = _guts.utf8Distance(from: self.startIndex, to: subrange.lowerBound) + _guts.utf8Distance(from: subrange.upperBound, to: self.endIndex) + newElements.count
+            _guts.replaceSubrange(subrange, with: newAttributedString)
+            _range = _guts.index(_guts.startIndex, offsetByUTF8: sliceOffset) ..< _guts.index(self.startIndex, offsetByUTF8: newSliceCount)
+        }
+    }
+    
+    public var characters : CharacterView {
+        get {
+            return CharacterView(_guts, startIndex ..< endIndex)
+        }
+        _modify {
+            ensureUniqueReference()
+            var cv = CharacterView(_guts, startIndex ..< endIndex)
+            let ident = Self._nextModifyIdentity
+            cv._identity = ident
+            _guts = Guts(string: "", runs: []) // Dummy guts so the CharacterView has (hopefully) the sole reference
+            defer {
+                if cv._identity != ident {
+                    fatalError("Mutating a CharacterView by replacing it with another from a different source is unsupported")
+                }
+                _guts = cv._guts
+            }
+            yield &cv
+        } set {
+            self.characters.replaceSubrange(startIndex ..< endIndex, with: newValue)
+        }
+    }
+    
+    public var unicodeScalars : UnicodeScalarView {
+        get {
+            UnicodeScalarView(_guts, startIndex ..< endIndex)
+        }
+        _modify {
+            ensureUniqueReference()
+            var usv = UnicodeScalarView(_guts, startIndex ..< endIndex)
+            let ident = Self._nextModifyIdentity
+            usv._identity = ident
+            _guts = Guts(string: "", runs: []) // Dummy guts so the UnicodeScalarView has (hopefully) the sole reference
+            defer {
+                if usv._identity != ident {
+                    fatalError("Mutating a UnicodeScalarView by replacing it with another from a different source is unsupported")
+                }
+                _guts = usv._guts
+            }
+            yield &usv
+        } set {
+            self.unicodeScalars.replaceSubrange(startIndex ..< endIndex, with: newValue)
+        }
+    }
+        
+    // MARK: Protocol conformance
+    
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        return lhs._guts == rhs._guts
+    }
+
+    // MARK: Initialization
+    
+    public init() {
+        self.init("")
+    }
+    
+    fileprivate init(_ string: String, attributes: _AttributeStorage) {
+        if string.isEmpty {
+            _guts = Guts(string: string, runs: [])
+        } else {
+            let run = _InternalRun(length: string.utf8.count, attributes: attributes)
+            _guts = Guts(string: string, runs: [run])
+        }
+    }
+    
+    /// Creates a new attributed string with the given `String` value associated with the given
+    /// attributes.
+    public init(_ string: String, attributes: AttributeContainer = .init()) {
+        var storage = _AttributeStorage()
+        storage.contents = attributes.contents
+        self.init(string, attributes: storage)
+    }
+
+    /// Creates a new attributed string with the given `Substring` value associated with the given
+    /// attributes.
+    public init(_ substring: Substring, attributes: AttributeContainer = .init()) {
+        self.init(String(substring), attributes: attributes)
+    }
+    
+    public init<S : Sequence>(_ elements: S, attributes: AttributeContainer = .init()) where S.Element == Character {
+        if let string = elements as? String {
+            self.init(string, attributes: attributes)
+            return
+        }
+        if let substring = elements as? Substring {
+            self.init(substring, attributes: attributes)
+            return
+        }
+        self.init(String(elements), attributes: attributes)
+    }
+        
+    public init(_ substring: AttributedSubstring) {
+        let newString = String(substring._guts.string[substring._range._stringRange])
+        let newRuns = substring._guts.runs(in: substring._range, relativeTo: newString)
+        _guts = Guts(string: newString, runs: newRuns)
+    }
+    
+    internal init(_ guts: Guts) {
+        _guts = guts
+    }
+    
+    public init<S : AttributeScope, T : AttributedStringProtocol>(_ other: T, including scope: KeyPath<AttributeScopes, S.Type>) {
+        self.init(other, including: S.self)
+    }
+    
+    public init<S : AttributeScope, T : AttributedStringProtocol>(_ other: T, including scope: S.Type) {
+        self.init(Guts(other.__guts, range: other.startIndex ..< other.endIndex))
+        var attributeCache = [String : Bool]()
+        _guts.enumerateRuns { run, _, _, modification in
+            modification = .guaranteedNotModified
+            for key in run.attributes.contents.keys {
+                var inScope: Bool
+                if let cachedInScope = attributeCache[key] {
+                    inScope = cachedInScope
+                } else {
+                    inScope = scope.attributeKeyType(matching: key) != nil
+                    attributeCache[key] = inScope
+                }
+                
+                if !inScope {
+                    run.attributes.contents.removeValue(forKey: key)
+                    modification = .guaranteedModified
+                }
+            }
+        }
+    }
+
+    // MARK: Appending
+    
+    internal mutating func ensureUniqueReference() {
+        if !isKnownUniquelyReferenced(&_guts) {
+            _guts = Guts(_guts)
+        }
+    }
+
+    public static func + <T: AttributedStringProtocol> (lhs: AttributedString, rhs: T) -> AttributedString {
+        var result = lhs
+        result.append(rhs)
+        return result
+    }
+
+    public static func += <T: AttributedStringProtocol> (lhs: inout AttributedString, rhs: T) {
+        lhs.append(rhs)
+    }
+
+    public static func + (lhs: AttributedString, rhs: AttributedString) -> AttributedString {
+        var result = lhs
+        result.append(rhs)
+        return result
+    }
+
+    public static func += (lhs: inout Self, rhs: AttributedString) {
+        lhs.append(rhs)
+    }
+
+    // MARK: Attribute Access
+
+    internal static var currentIdentity = 0
+    internal static var currentIdentityLock = Lock()
+    internal static var _nextModifyIdentity : Int {
+        currentIdentityLock.lock()
+        currentIdentity += 1
+        let result = currentIdentity
+        currentIdentityLock.unlock()
+        return result
+    }
+
+    public subscript<R: RangeExpression>(bounds: R) -> AttributedSubstring where R.Bound == Index {
+        get {
+            return AttributedSubstring(_guts, bounds.relative(to: characters))
+        }
+        _modify {
+            ensureUniqueReference()
+            var substr = AttributedSubstring(_guts, bounds.relative(to: characters))
+            let ident = Self._nextModifyIdentity
+            substr._identity = ident
+            _guts = Guts(string: "", runs: []) // Dummy guts so the substr has (hopefully) the sole reference
+            defer {
+                if substr._identity != ident {
+                    fatalError("Mutating an AttributedSubstring by replacing it with another from a different source is unsupported")
+                }
+                _guts = substr._guts
+            }
+            yield &substr
+        }
+        set {
+            self.replaceSubrange(bounds, with: newValue)
+        }
+    }
+    
+    public mutating func append<S: AttributedStringProtocol>(_ s: S) {
+        replaceSubrange(endIndex ..< endIndex, with: s)
+    }
+    
+    public mutating func insert<S: AttributedStringProtocol>(_ s: S, at index: AttributedString.Index) {
+        replaceSubrange(index ..< index, with: s)
+    }
+    
+    public mutating func removeSubrange<R: RangeExpression>(_ range: R) where R.Bound == Index {
+        replaceSubrange(range, with: AttributedString())
+    }
+    
+    public mutating func replaceSubrange<R: RangeExpression, S: AttributedStringProtocol>(_ range: R, with s: S) where R.Bound == Index {
+        ensureUniqueReference()
+        _guts.replaceSubrange(range.relative(to: characters), with: s)
+    }
+    
+    public var startIndex : Index {
+        return _guts.startIndex
+    }
+    
+    public var endIndex : Index {
+        return _guts.endIndex
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString : ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+}
+
+@dynamicMemberLookup
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct AttributedSubstring {
+    internal var _guts: AttributedString.Guts
+    internal var _range: Range<AttributedString.Index>
+    internal var _identity: Int = 0
+    
+    internal init(_ guts: AttributedString.Guts, _ range: Range<AttributedString.Index>) {
+        self._guts = guts
+        self._range = range
+    }
+    
+    public init() {
+        let str = AttributedString()
+        self.init(str._guts, str.startIndex ..< str.endIndex)
+    }
+    
+    public var base : AttributedString {
+        return AttributedString(_guts)
+    }
+    
+    public var description: String {
+        var result = ""
+        self._guts.enumerateRuns(containing: self._guts.utf8OffsetRange(from: _range)) { run, loc, _, modified in
+            let range = self._guts.index(_guts.startIndex, offsetByUTF8: loc) ..< self._guts.index(_guts.startIndex, offsetByUTF8: loc + run.length)
+            result += (result.isEmpty ? "" : "\n") + "\(String(self.characters[range])) \(run.attributes)"
+            modified = .guaranteedNotModified
+        }
+        return result
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedSubstring : AttributedStringProtocol {
+    public var startIndex: AttributedString.Index {
+        get {
+            return _range.lowerBound
+        }
+    }
+    
+    public var endIndex: AttributedString.Index {
+        get {
+            return _range.upperBound
+        }
+    }
+
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        guard lhs._guts.string[lhs._range._stringRange] == rhs._guts.string[rhs._range._stringRange] else {
+            return false
+        }
+        return lhs.runs == rhs.runs
+    }
+    
+    internal mutating func ensureUniqueReference() {
+        // Ideally we'd only copy the portions that this range covers. However, we need to be able to vend the .base AttributedString, so we copy the entire Guts.
+        if !isKnownUniquelyReferenced(&_guts) {
+            _guts = AttributedString.Guts(_guts, range: _guts.startIndex ..< _guts.endIndex)
+        }
+    }
+    
+    public mutating func setAttributes(_ attributes: AttributeContainer) {
+        ensureUniqueReference()
+        _guts.set(attributes: attributes, in: _range)
+    }
+    
+    public mutating func mergeAttributes(_ attributes: AttributeContainer, mergePolicy:  AttributedString.AttributeMergePolicy = .keepNew) {
+        ensureUniqueReference()
+        _guts.add(attributes: attributes, in: _range, mergePolicy:  mergePolicy)
+    }
+    
+    public mutating func replaceAttributes(_ attributes: AttributeContainer, with others: AttributeContainer) {
+        guard attributes != others else {
+            return
+        }
+        ensureUniqueReference()
+        _guts.enumerateRuns { run, _, _, modified in
+            if _run(run, matches: attributes) {
+                for key in attributes.contents.keys {
+                    run.attributes.contents.removeValue(forKey: key)
+                }
+                run.attributes.mergeIn(others)
+                modified = .guaranteedModified
+            } else {
+                modified = .guaranteedNotModified
+            }
+        }
+    }
+    
+    public var runs : AttributedString.Runs {
+        get { .init(_guts, _range) }
+    }
+    
+    public var characters : AttributedString.CharacterView {
+        return AttributedString.CharacterView(_guts, startIndex ..< endIndex)
+    }
+    
+    public var unicodeScalars : AttributedString.UnicodeScalarView {
+        return AttributedString.UnicodeScalarView(_guts, startIndex ..< endIndex)
+    }
+
+    public subscript<R: RangeExpression>(bounds: R) -> AttributedSubstring where R.Bound == AttributedString.Index {
+        return AttributedSubstring(_guts, bounds.relative(to: characters))
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedSubstring {
+    public subscript<K: AttributedStringKey>(_: K.Type) -> K.Value? {
+        get { _guts.getValue(in: _range, key: K.name) as? K.Value }
+        set {
+            ensureUniqueReference()
+            if let v = newValue {
+                _guts.add(value: v, in: _range, key: K.name)
+            } else {
+                _guts.remove(attribute: K.self, in: _range)
+            }
+        }
+    }
+
+    public subscript<K: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeDynamicLookup, K>) -> K.Value? {
+        get { self[K.self] }
+        set { self[K.self] = newValue }
+    }
+    
+    public subscript<S: AttributeScope>(dynamicMember keyPath: KeyPath<AttributeScopes, S.Type>) -> ScopedAttributeContainer<S> {
+        get {
+            return ScopedAttributeContainer(_guts.getValues(in: _range))
+        }
+        _modify {
+            ensureUniqueReference()
+            var container = ScopedAttributeContainer<S>()
+            defer {
+                if let removedKey = container.removedKey {
+                    _guts.remove(key: removedKey, in: _range)
+                } else {
+                    _guts.add(attributes: AttributeContainer(container.contents), in: _range)
+                }
+            }
+            yield &container
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension String {
+    init(_ attrStrSlice: Slice<AttributedString.CharacterView>) {
+        self = String(attrStrSlice.base._guts.string[attrStrSlice.startIndex.characterIndex ..< attrStrSlice.endIndex.characterIndex])
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal func _run(_ run : AttributedString._InternalRun, matches container: AttributeContainer) -> Bool {
+    let attrs = run.attributes.contents
+    for (key, value) in container.contents {
+        if !__equalAttributes(attrs[key], value) {
+            return false
+        }
+    }
+    return true
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Range where Bound == AttributedString.Index {
+    internal var _stringRange : Range<String.Index> {
+        lowerBound.characterIndex ..< upperBound.characterIndex
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Range where Bound == String.Index {
+    internal var _attributedStringRange : Range<AttributedString.Index> {
+        AttributedString.Index(characterIndex: lowerBound) ..< AttributedString.Index(characterIndex: upperBound)
+    }
+}
+
+internal func __equalAttributes(_ lhs: Any?, _ rhs: Any?) ->Bool {
+    switch (lhs, rhs) {
+    case (.none, .none):
+        return true
+    case (.none, .some(_)):
+        return false
+    case (.some(_), .none):
+        return false
+    case (.some(let lhs), .some(let rhs)):
+        func openLHS<LHS>(_ lhs: LHS) -> Bool {
+            if let rhs = rhs as? LHS {
+                return CheckEqualityIfEquatable(lhs, rhs).attemptAction() ?? false
+            } else {
+                return false
+            }
+        }
+        return _openExistential(lhs, do: openLHS)
+    }
+}

--- a/Sources/Foundation/AttributedString/AttributedStringAttribute.swift
+++ b/Sources/Foundation/AttributedString/AttributedStringAttribute.swift
@@ -1,0 +1,626 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Reflection) import Swift
+
+// MARK: API
+
+// Developers define new attributes by implementing AttributeKey.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol AttributedStringKey {
+    associatedtype Value : Hashable
+    static var name : String { get }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension AttributedStringKey {
+    var description: String { Self.name }
+}
+
+// Developers can also add the attributes to pre-defined scopes of attributes, which are used to provide type information to the encoding and decoding of AttributedString values, as well as allow for dynamic member lookup in Runss of AttributedStrings.
+// Example, where ForegroundColor is an existing AttributedStringKey:
+// struct MyAttributes : AttributeScope {
+//     var foregroundColor : ForegroundColor
+// }
+// An AttributeScope can contain other scopes as well.
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol AttributeScope : DecodingConfigurationProviding, EncodingConfigurationProviding {
+    static var decodingConfiguration: AttributeScopeCodableConfiguration { get }
+    static var encodingConfiguration: AttributeScopeCodableConfiguration { get }
+}
+
+@frozen
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public enum AttributeScopes { }
+
+@dynamicMemberLookup @frozen
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public enum AttributeDynamicLookup {
+    public subscript<T: AttributedStringKey>(_: T.Type) -> T {
+        get { fatalError("Called outside of a dynamicMemberLookup subscript overload") }
+    }
+}
+
+@dynamicMemberLookup
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct ScopedAttributeContainer<S: AttributeScope> {
+    internal var contents : [String : Any]
+    
+    // Record the most recently deleted key for use in AttributedString mutation subscripts that use _modify
+    // Note: if ScopedAttributeContainer ever adds a mutating function that can mutate multiple attributes, this will need to record multiple removed keys
+    internal var removedKey : String?
+
+    public subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<S, T>) -> T.Value? {
+        get { contents[T.name] as? T.Value }
+        set {
+            contents[T.name] = newValue
+            if newValue == nil {
+                removedKey = T.name
+            }
+        }
+    }
+
+    internal init(_ contents : [String : Any] = [:]) {
+        self.contents = contents
+    }
+
+    internal func equals(_ other: Self) -> Bool {
+        var equal = true
+        _forEachField(of: S.self, options: [.ignoreUnknown]) { name, offset, type, kind -> Bool in
+            func project<T>( _: T.Type) -> Bool {
+                if let name = GetNameIfAttribute(T.self).attemptAction() {
+                    if !__equalAttributes(self.contents[name], other.contents[name]) {
+                        equal = false
+                        return false
+                    }
+                }
+                // TODO: Nested scopes
+                return true
+            }
+            return _openExistential(type, do: project)
+        }
+        return equal
+    }
+
+    internal var attributes : AttributeContainer {
+        var contents = [String : Any]()
+        _forEachField(of: S.self, options: [.ignoreUnknown]) { name, offset, type, kind -> Bool in
+            func project<T>( _: T.Type) -> Bool {
+                if let name = GetNameIfAttribute(T.self).attemptAction() {
+                    contents[name] = self.contents[name]
+                }
+                // TODO: Nested scopes
+                return true
+            }
+            return _openExistential(type, do: project)
+        }
+        return AttributeContainer(contents)
+    }
+}
+
+
+// MARK: Internals
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal extension AttributeScope {
+    static func attributeKeyType(matching key: String) -> Any.Type? {
+        var result : Any.Type?
+        _forEachField(of: Self.self, options: [.ignoreUnknown]) { name, offset, type, kind -> Bool in
+            func project<T>( _: T.Type) -> Bool {
+                if GetNameIfAttribute(T.self).attemptAction() == key {
+                    result = type
+                    return false
+                } else if let t = GetAttributeTypeIfAttributeScope(T.self, key: key).attemptAction() ?? nil {
+                    result = t
+                    return false
+                }
+                return true
+            }
+            return _openExistential(type, do: project)
+        }
+        return result
+    }
+    
+    static func markdownAttributeKeyType(matching key: String) -> Any.Type? {
+        var result : Any.Type?
+        _forEachField(of: Self.self, options: [.ignoreUnknown]) { name, offset, type, kind -> Bool in
+            func project<T>( _: T.Type) -> Bool {
+                if GetMarkdownNameIfMarkdownDecodableAttribute(T.self).attemptAction() == key {
+                    result = type
+                    return false
+                } else if let t = GetMarkdownAttributeTypeIfAttributeScope(T.self, key: key).attemptAction() ?? nil {
+                    result = t
+                    return false
+                }
+                return true
+            }
+            return _openExistential(type, do: project)
+        }
+        return result
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension AttributeDynamicLookup {
+}
+
+// MARK: Attribute Protocol Unwrappers
+
+internal protocol ProxyProtocol {
+    associatedtype Wrapped
+}
+
+internal enum Proxy<Wrapped>: ProxyProtocol {}
+
+internal protocol DynamicallyDispatched {
+    associatedtype Input
+    associatedtype Result
+    func attemptAction() -> Result?
+}
+
+internal protocol ThrowingDynamicallyDispatched {
+    associatedtype Input
+    associatedtype Result
+    func attemptAction() throws -> Result?
+}
+
+private protocol KnownConformance {
+    static func performAction<T: DynamicallyDispatched>(_ t: T) -> T.Result
+}
+
+private protocol KnownThrowingConformance {
+    static func performAction<T: ThrowingDynamicallyDispatched>(_ t: T) throws -> T.Result
+}
+
+private protocol ConformanceMarker {
+    associatedtype A: DynamicallyDispatched
+}
+
+private protocol ThrowingConformanceMarker {
+    associatedtype A: ThrowingDynamicallyDispatched
+}
+
+extension ConformanceMarker {
+    fileprivate static func attempt(_ a: A) -> A.Result? {
+        (self as? KnownConformance.Type)?.performAction(a)
+    }
+}
+
+extension ThrowingConformanceMarker {
+    fileprivate static func attempt(_ a: A) throws -> A.Result? {
+        try (self as? KnownThrowingConformance.Type)?.performAction(a)
+    }
+}
+
+// Specific to CodableAttributedStringKey
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal protocol AttemptIfCodable : ThrowingDynamicallyDispatched {
+    override associatedtype Result
+
+    func action<T: CodableAttributedStringKey>(_ t: T.Type) throws -> Result where T == Input
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttemptIfCodable {
+    func attemptAction() throws -> Result? {
+        try CodableAttributeMarker.attempt(self)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private enum CodableAttributeMarker<A: AttemptIfCodable>: ThrowingConformanceMarker {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension CodableAttributeMarker: KnownThrowingConformance where A.Input: CodableAttributedStringKey {
+    static func performAction<T: ThrowingDynamicallyDispatched>(_ t: T) throws -> T.Result {
+        try (t as! A).action(A.Input.self) as! T.Result
+    }
+}
+
+// Specific to Encoding and Decoding
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct EncodeIfCodable<P: ProxyProtocol> : AttemptIfCodable where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = Void
+
+    private var x : Input.Type
+    private var v : Any
+    private var e : Encoder
+
+    init<T>(_ x: T.Type, value : Any, encoder: Encoder) where P == Proxy<T> {
+        self.x = x
+        self.v = value
+        self.e = encoder
+    }
+
+    func action<T : CodableAttributedStringKey>(_ t: T.Type) throws -> Result where T == Input {
+        try x.encode(v as! T.Value, to: e)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct DecodeIfCodable<P: ProxyProtocol> : AttemptIfCodable where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = AnyHashable
+
+    private var x : Input.Type
+    private var d : Decoder
+
+    init<T>(_ x: T.Type, decoder: Decoder) where P == Proxy<T> {
+        self.x = x
+        self.d = decoder
+    }
+
+    func action<T>(_ t: T.Type) throws -> AnyHashable where T : CodableAttributedStringKey, T == P.Wrapped {
+        try x.decode(from: d)
+    }
+}
+
+// Specific to MarkdownDecodableAttributedStringKey
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal protocol AttemptIfMarkdownDecodable : DynamicallyDispatched {
+    override associatedtype Result
+
+    func action<T: MarkdownDecodableAttributedStringKey>(_ t: T.Type) -> Result where T == Input
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttemptIfMarkdownDecodable {
+    func attemptAction() -> Result? {
+        MarkdownDecodableAttributeMarker.attempt(self)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private enum MarkdownDecodableAttributeMarker<A: AttemptIfMarkdownDecodable>: ConformanceMarker {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension MarkdownDecodableAttributeMarker: KnownConformance where A.Input: MarkdownDecodableAttributedStringKey {
+    static func performAction<T: DynamicallyDispatched>(_ t: T) -> T.Result {
+        (t as! A).action(A.Input.self) as! T.Result
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal protocol ThrowingAttemptIfMarkdownDecodable : ThrowingDynamicallyDispatched {
+    override associatedtype Result
+
+    func action<T: MarkdownDecodableAttributedStringKey>(_ t: T.Type) throws -> Result where T == Input
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension ThrowingAttemptIfMarkdownDecodable {
+    func attemptAction() throws -> Result? {
+        try ThrowingMarkdownDecodableAttributeMarker.attempt(self)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private enum ThrowingMarkdownDecodableAttributeMarker<A: ThrowingAttemptIfMarkdownDecodable>: ThrowingConformanceMarker {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension ThrowingMarkdownDecodableAttributeMarker: KnownThrowingConformance where A.Input: MarkdownDecodableAttributedStringKey {
+    static func performAction<T: ThrowingDynamicallyDispatched>(_ t: T) throws -> T.Result {
+        try (t as! A).action(A.Input.self) as! T.Result
+    }
+}
+
+// Specific to Markdown decoding
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct DecodeIfMarkdownDecodable<P: ProxyProtocol> : ThrowingAttemptIfMarkdownDecodable where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = AnyHashable
+
+    private var x : Input.Type
+    private var d : Decoder
+
+    init<T>(_ x: T.Type, decoder: Decoder) where P == Proxy<T> {
+        self.x = x
+        self.d = decoder
+    }
+
+    func action<T>(_ t: T.Type) throws -> AnyHashable where T : MarkdownDecodableAttributedStringKey, T == P.Wrapped {
+        try x.decodeMarkdown(from: d)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct GetMarkdownNameIfMarkdownDecodableAttribute<P: ProxyProtocol> : AttemptIfMarkdownDecodable where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = String
+
+    private var x : Input.Type
+
+    init<T>(_ x: T.Type) where P == Proxy<T> {
+        self.x = x
+    }
+
+    func action<T>(_ t: T.Type) -> String where T : MarkdownDecodableAttributedStringKey, T == P.Wrapped {
+        x.markdownName
+    }
+}
+
+// Specific to AttributedStringKey
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal protocol AttemptIfAttribute : DynamicallyDispatched {
+    override associatedtype Result
+
+    func action<T: AttributedStringKey>(_ t: T.Type) -> Result where T == Input
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttemptIfAttribute {
+    func attemptAction() -> Result? {
+        AttributeMarker.attempt(self)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private enum AttributeMarker<A: AttemptIfAttribute>: ConformanceMarker {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributeMarker: KnownConformance where A.Input: AttributedStringKey {
+    static func performAction<T: DynamicallyDispatched>(_ t: T) -> T.Result {
+        (t as! A).action(A.Input.self) as! T.Result
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal protocol ThrowingAttemptIfAttribute : ThrowingDynamicallyDispatched {
+    override associatedtype Result
+
+    func action<T: AttributedStringKey>(_ t: T.Type) throws -> Result where T == Input
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension ThrowingAttemptIfAttribute {
+    func attemptAction() throws -> Result? {
+        try ThrowingAttributeMarker.attempt(self)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private enum ThrowingAttributeMarker<A: ThrowingAttemptIfAttribute>: ThrowingConformanceMarker {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension ThrowingAttributeMarker: KnownThrowingConformance where A.Input: AttributedStringKey {
+    static func performAction<T: ThrowingDynamicallyDispatched>(_ t: T) throws -> T.Result {
+        try (t as! A).action(A.Input.self) as! T.Result
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct GetNameIfAttribute<P: ProxyProtocol> : AttemptIfAttribute where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = String
+
+    private var x : Input.Type
+
+    init<T>(_ x: T.Type) where P == Proxy<T> {
+        self.x = x
+    }
+
+    func action<T : AttributedStringKey>(_ t: T.Type) -> Result where T == Input {
+        return t.name
+    }
+}
+
+// Specific to NSAS Conversion
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal protocol AttemptIfObjCAttribute : ThrowingDynamicallyDispatched {
+    override associatedtype Result
+
+    func action<T: ObjectiveCConvertibleAttributedStringKey>(_ t: T.Type) throws -> Result where T == Input
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttemptIfObjCAttribute {
+    func attemptAction() throws -> Result? {
+        try ObjCAttributeMarker.attempt(self)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private enum ObjCAttributeMarker<A: AttemptIfObjCAttribute>: ThrowingConformanceMarker {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension ObjCAttributeMarker: KnownThrowingConformance where A.Input: ObjectiveCConvertibleAttributedStringKey {
+    static func performAction<T: ThrowingDynamicallyDispatched>(_ t: T) throws -> T.Result {
+        try (t as! A).action(A.Input.self) as! T.Result
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct ConvertToObjCIfObjCAttribute<P: ProxyProtocol> : AttemptIfObjCAttribute where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = AnyObject
+
+    private var x : Input.Type
+    private var v : Any
+
+    init<T>(_ x: T.Type, value : Any) where P == Proxy<T> {
+        self.x = x
+        self.v = value
+    }
+
+    func action<T : ObjectiveCConvertibleAttributedStringKey>(_ t: T.Type) throws -> Result where T == Input {
+        return try t.objectiveCValue(for: v as! T.Value)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct ConvertFromObjCIfObjCAttribute<P: ProxyProtocol> : AttemptIfObjCAttribute where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = AnyHashable
+
+    private var x : Input.Type
+    private var v : AnyObject
+
+    init<T>(_ x: T.Type, value : AnyObject) where P == Proxy<T> {
+        self.x = x
+        self.v = value
+    }
+
+    func action<T : ObjectiveCConvertibleAttributedStringKey>(_ t: T.Type) throws -> Result where T == Input {
+        guard let objCValue = v as? T.ObjectiveCValue else {
+            throw CocoaError(.coderInvalidValue)
+        }
+        return try t.value(for: objCValue)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct ConvertFromObjCIfAttribute<P: ProxyProtocol> : ThrowingAttemptIfAttribute where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = AnyHashable?
+
+    private var x : Input.Type
+    private var v : AnyObject
+
+    init<T>(_ x: T.Type, value : AnyObject) where P == Proxy<T> {
+        self.x = x
+        self.v = value
+    }
+
+    func action<T : AttributedStringKey>(_ t: T.Type) throws -> Result where T == Input {
+        guard let value = v as? T.Value else {
+            throw CocoaError(.coderInvalidValue)
+        }
+        return value
+    }
+}
+
+// For implementing generic Equatable without Hashable conformance
+
+internal protocol AttemptIfEquatable : DynamicallyDispatched {
+    override associatedtype Result
+
+    func action<T: Equatable>(_ t: T.Type) -> Result where T == Input
+}
+
+extension AttemptIfEquatable {
+    public func attemptAction() -> Result? {
+        EquatableMarker.attempt(self)
+    }
+}
+
+private enum EquatableMarker<A: AttemptIfEquatable>: ConformanceMarker {}
+
+extension EquatableMarker: KnownConformance where A.Input: Equatable {
+  static func performAction<T: DynamicallyDispatched>(_ t: T) -> T.Result {
+    (t as! A).action(A.Input.self) as! T.Result
+  }
+}
+
+internal struct CheckEqualityIfEquatable<P: ProxyProtocol> : AttemptIfEquatable where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = Bool
+
+    private var lhs : Input
+    private var rhs : Input
+
+    init<T>(_ lhs: T, _ rhs: T) where P == Proxy<T> {
+        self.lhs = lhs
+        self.rhs = rhs
+    }
+
+    func action<T: Equatable>(_ t: T.Type) -> Result where T == Input {
+        return lhs == rhs
+    }
+}
+
+// Specific to AttributeScope.
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal protocol AttemptIfAttributeScope : DynamicallyDispatched {
+    override associatedtype Result
+
+    func action<T: AttributeScope>(_ t: T.Type) -> Result where T == Input
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttemptIfAttributeScope {
+    func attemptAction() -> Result? {
+        AttributeScopeMarker.attempt(self)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+private enum AttributeScopeMarker<A: AttemptIfAttributeScope>: ConformanceMarker {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributeScopeMarker: KnownConformance where A.Input: AttributeScope {
+    static func performAction<T: DynamicallyDispatched>(_ t: T) -> T.Result {
+        (t as! A).action(A.Input.self) as! T.Result
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct GetAttributeTypeIfAttributeScope<P: ProxyProtocol> : AttemptIfAttributeScope where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = Any.Type?
+    private var x : Input.Type
+    private var key: String
+    init<T>(_ x: T.Type, key: String) where P == Proxy<T> {
+        self.x = x
+        self.key = key
+    }
+    func action<T : AttributeScope>(_ t: T.Type) -> Result where T == Input {
+        return t.attributeKeyType(matching: key)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct GetAllAttributeTypesIfAttributeScope<P: ProxyProtocol> : AttemptIfAttributeScope where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = [String : Any.Type]
+    private var x : Input.Type
+    init<T>(_ x: T.Type) where P == Proxy<T> {
+        self.x = x
+    }
+    func action<T : AttributeScope>(_ t: T.Type) -> Result where T == Input {
+        var result = [String : Any.Type]()
+        _forEachField(of: t, options: [.ignoreUnknown]) { pointer, offset, type, kind -> Bool in
+            func project<K>(_: K.Type) {
+                if let key = GetNameIfAttribute(K.self).attemptAction() {
+                    result[key] = type
+                } else if let subResults = GetAllAttributeTypesIfAttributeScope<Proxy<K>>(K.self).attemptAction() {
+                    result.merge(subResults, uniquingKeysWith: { current, new in new })
+                }
+            }
+            _openExistential(type, do: project)
+            return true
+        }
+        return result
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal struct GetMarkdownAttributeTypeIfAttributeScope<P: ProxyProtocol> : AttemptIfAttributeScope where P.Wrapped : Any {
+    typealias Input = P.Wrapped
+    typealias Result = Any.Type?
+    private var x : Input.Type
+    private var key: String
+    init<T>(_ x: T.Type, key: String) where P == Proxy<T> {
+        self.x = x
+        self.key = key
+    }
+    func action<T : AttributeScope>(_ t: T.Type) -> Result where T == Input {
+        return t.markdownAttributeKeyType(matching: key)
+    }
+}

--- a/Sources/Foundation/AttributedString/AttributedStringCodable.swift
+++ b/Sources/Foundation/AttributedString/AttributedStringCodable.swift
@@ -1,0 +1,534 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Reflection) import Swift
+
+// MARK: AttributedStringKey
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol EncodableAttributedStringKey : AttributedStringKey {
+    static func encode(_ value: Value, to encoder: Encoder) throws
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol DecodableAttributedStringKey : AttributedStringKey {
+    static func decode(from decoder: Decoder) throws -> Value
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public typealias CodableAttributedStringKey = EncodableAttributedStringKey & DecodableAttributedStringKey
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension EncodableAttributedStringKey where Value : Encodable {
+    static func encode(_ value: Value, to encoder: Encoder) throws { try value.encode(to: encoder) }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension DecodableAttributedStringKey where Value : Decodable {
+    static func decode(from decoder: Decoder) throws -> Value { return try Value.init(from: decoder) }
+}
+
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol MarkdownDecodableAttributedStringKey : AttributedStringKey {
+    static func decodeMarkdown(from decoder: Decoder) throws -> Value
+    static var markdownName: String { get }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension MarkdownDecodableAttributedStringKey {
+    static var markdownName: String { name }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension MarkdownDecodableAttributedStringKey where Self : DecodableAttributedStringKey {
+    static func decodeMarkdown(from decoder: Decoder) throws -> Value { try Self.decode(from: decoder) }
+}
+
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension EncodableAttributedStringKey where Value : NSSecureCoding & NSObject {
+    static func encode(_ value: Value, to encoder: Encoder) throws {
+        let data = try NSKeyedArchiver.archivedData(withRootObject: value, requiringSecureCoding: true)
+        var container = encoder.singleValueContainer()
+        try container.encode(data)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension DecodableAttributedStringKey where Value : NSSecureCoding & NSObject {
+    static func decode(from decoder: Decoder) throws -> Value {
+        let container = try decoder.singleValueContainer()
+        let data = try container.decode(Data.self)
+        if let result = try NSKeyedUnarchiver.unarchivedObject(ofClass: Value.self, from: data) {
+            return result
+        } else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Unable to unarchive object, result was nil"))
+        }
+    }
+}
+
+// MARK: Codable With Configuration
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol EncodingConfigurationProviding {
+    associatedtype EncodingConfiguration
+    static var encodingConfiguration: EncodingConfiguration { get }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol EncodableWithConfiguration {
+    associatedtype EncodingConfiguration
+    func encode(to encoder: Encoder, configuration: EncodingConfiguration) throws
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol DecodingConfigurationProviding {
+    associatedtype DecodingConfiguration
+    static var decodingConfiguration: DecodingConfiguration { get }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol DecodableWithConfiguration {
+    associatedtype DecodingConfiguration
+    init(from decoder: Decoder, configuration: DecodingConfiguration) throws
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public typealias CodableWithConfiguration = EncodableWithConfiguration & DecodableWithConfiguration
+
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension KeyedEncodingContainer {
+    mutating func encode<T, C>(_ wrapper: CodableConfiguration<T?, C>, forKey key: Self.Key) throws {
+        switch wrapper.wrappedValue {
+        case .some(let val):
+            try val.encode(to: self.superEncoder(forKey: key), configuration: C.encodingConfiguration)
+            break
+        default: break
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension KeyedDecodingContainer {
+    func decode<T, C>(_: CodableConfiguration<T?, C>.Type, forKey key: Self.Key) throws -> CodableConfiguration<T?, C> {
+        if self.contains(key) {
+            let wrapper = try self.decode(CodableConfiguration<T, C>.self, forKey: key)
+            return CodableConfiguration<T?, C>(wrappedValue: wrapper.wrappedValue)
+        } else {
+            return CodableConfiguration<T?, C>(wrappedValue: nil)
+        }
+    }
+
+}
+
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension KeyedEncodingContainer {
+
+    mutating func encode<T: EncodableWithConfiguration, C: EncodingConfigurationProviding>(_ t: T, forKey key: Self.Key, configuration: C.Type) throws where T.EncodingConfiguration == C.EncodingConfiguration {
+        try t.encode(to: self.superEncoder(forKey: key), configuration: C.encodingConfiguration)
+    }
+    mutating func encodeIfPresent<T: EncodableWithConfiguration, C: EncodingConfigurationProviding>(_ t: T?, forKey key: Self.Key, configuration: C.Type) throws where T.EncodingConfiguration == C.EncodingConfiguration {
+        guard let value = t else { return }
+        try self.encode(value, forKey: key, configuration: configuration)
+    }
+
+    mutating func encode<T: EncodableWithConfiguration>(_ t: T, forKey key: Self.Key, configuration: T.EncodingConfiguration) throws {
+        try t.encode(to: self.superEncoder(forKey: key), configuration: configuration)
+    }
+    mutating func encodeIfPresent<T: EncodableWithConfiguration>(_ t: T?, forKey key: Self.Key, configuration: T.EncodingConfiguration) throws {
+        guard let value = t else { return }
+        try self.encode(value, forKey: key, configuration: configuration)
+    }
+
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension KeyedDecodingContainer {
+
+    func decode<T: DecodableWithConfiguration, C: DecodingConfigurationProviding>(_ : T.Type, forKey key: Self.Key, configuration: C.Type) throws -> T where T.DecodingConfiguration == C.DecodingConfiguration {
+        return try T(from: self.superDecoder(forKey: key), configuration: C.decodingConfiguration)
+    }
+    func decodeIfPresent<T: DecodableWithConfiguration, C: DecodingConfigurationProviding>(_ : T.Type, forKey key: Self.Key, configuration: C.Type) throws -> T? where T.DecodingConfiguration == C.DecodingConfiguration {
+        if contains(key) {
+            return try self.decode(T.self, forKey: key, configuration: configuration)
+        } else {
+            return nil
+        }
+    }
+
+    func decode<T: DecodableWithConfiguration>(_ : T.Type, forKey key: Self.Key, configuration: T.DecodingConfiguration) throws -> T {
+        return try T(from: self.superDecoder(forKey: key), configuration: configuration)
+    }
+    func decodeIfPresent<T: DecodableWithConfiguration>(_ : T.Type, forKey key: Self.Key, configuration: T.DecodingConfiguration) throws -> T? {
+        if contains(key) {
+            return try self.decode(T.self, forKey: key, configuration: configuration)
+        } else {
+            return nil
+        }
+    }
+
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension UnkeyedEncodingContainer {
+
+    mutating func encode<T: EncodableWithConfiguration, C: EncodingConfigurationProviding>(_ t: T, configuration: C.Type) throws where T.EncodingConfiguration == C.EncodingConfiguration {
+        try t.encode(to: self.superEncoder(), configuration: C.encodingConfiguration)
+    }
+
+    mutating func encode<T: EncodableWithConfiguration>(_ t: T, configuration: T.EncodingConfiguration) throws {
+        try t.encode(to: self.superEncoder(), configuration: configuration)
+    }
+
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension UnkeyedDecodingContainer {
+
+    mutating func decode<T: DecodableWithConfiguration, C: DecodingConfigurationProviding>(_ : T.Type, configuration: C.Type) throws -> T where T.DecodingConfiguration == C.DecodingConfiguration {
+        return try T(from: try self.superDecoder(), configuration: C.decodingConfiguration)
+    }
+    mutating func decodeIfPresent<T: DecodableWithConfiguration, C: DecodingConfigurationProviding>(_ : T.Type, configuration: C.Type) throws -> T? where T.DecodingConfiguration == C.DecodingConfiguration {
+        if try self.decodeNil() {
+            return nil
+        } else {
+            return try self.decode(T.self, configuration: configuration)
+        }
+    }
+
+    mutating func decode<T: DecodableWithConfiguration>(_ : T.Type, configuration: T.DecodingConfiguration) throws -> T {
+        return try T(from: try self.superDecoder(), configuration: configuration)
+    }
+    mutating func decodeIfPresent<T: DecodableWithConfiguration>(_ : T.Type, configuration: T.DecodingConfiguration) throws -> T? {
+        if try self.decodeNil() {
+            return nil
+        } else {
+            return try self.decode(T.self, configuration: configuration)
+        }
+    }
+
+}
+
+@propertyWrapper
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct CodableConfiguration<T, ConfigurationProvider> : Codable where T : CodableWithConfiguration, ConfigurationProvider : EncodingConfigurationProviding & DecodingConfigurationProviding, ConfigurationProvider.EncodingConfiguration == T.EncodingConfiguration, ConfigurationProvider.DecodingConfiguration == T.DecodingConfiguration {
+    public var wrappedValue: T
+
+    public init(wrappedValue: T) {
+        self.wrappedValue = wrappedValue
+    }
+
+    public init(wrappedValue: T, from configurationProvider: ConfigurationProvider.Type) {
+        self.wrappedValue = wrappedValue
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder, configuration: ConfigurationProvider.encodingConfiguration)
+    }
+
+    public init(from decoder: Decoder) throws {
+        wrappedValue = try T(from: decoder, configuration: ConfigurationProvider.decodingConfiguration)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension CodableConfiguration : Equatable where T : Equatable { }
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension CodableConfiguration : Hashable where T : Hashable { }
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Optional : EncodableWithConfiguration where Wrapped : EncodableWithConfiguration {
+    public func encode(to encoder: Encoder, configuration: Wrapped.EncodingConfiguration) throws {
+        if let wrapped = self {
+            try wrapped.encode(to: encoder, configuration: configuration)
+        } else {
+            var c = encoder.singleValueContainer()
+            try c.encodeNil()
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Optional : DecodableWithConfiguration where Wrapped : DecodableWithConfiguration {
+    public init(from decoder: Decoder, configuration: Wrapped.DecodingConfiguration) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() {
+            self = nil
+        } else {
+            self = try Wrapped.init(from: decoder, configuration: configuration)
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Array : EncodableWithConfiguration where Element : EncodableWithConfiguration {
+    public func encode(to encoder: Encoder, configuration: Element.EncodingConfiguration) throws {
+        var c = encoder.unkeyedContainer()
+        for e in self {
+            try c.encode(e, configuration: configuration)
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Array : DecodableWithConfiguration where Element : DecodableWithConfiguration {
+    public init(from decoder: Decoder, configuration: Element.DecodingConfiguration) throws {
+        var result = [Element]()
+        var c = try decoder.unkeyedContainer()
+        while !c.isAtEnd {
+            try result.append(c.decode(Element.self, configuration: configuration))
+        }
+        self = result
+    }
+}
+
+// MARK: AttributedString CodableWithConfiguration Conformance
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public struct AttributeScopeCodableConfiguration {
+    internal let scopeType : Any.Type
+    internal let extraAttributesTable : [String : Any.Type]
+    
+    internal init(scopeType: Any.Type, extraAttributesTable: [String : Any.Type] = [:]) {
+        self.scopeType = scopeType
+        self.extraAttributesTable = extraAttributesTable
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension AttributeScope {
+    static var encodingConfiguration: AttributeScopeCodableConfiguration { AttributeScopeCodableConfiguration(scopeType: self) }
+    static var decodingConfiguration: AttributeScopeCodableConfiguration { AttributeScopeCodableConfiguration(scopeType: self) }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString : Codable {
+    public func encode(to encoder: Encoder) throws {
+        try encode(to: encoder, configuration: AttributeScopeCodableConfiguration(scopeType: AttributeScopes.FoundationAttributes.self, extraAttributesTable: _loadDefaultAttributes()))
+    }
+    
+    public init(from decoder: Decoder) throws {
+        try self.init(from: decoder, configuration: AttributeScopeCodableConfiguration(scopeType: AttributeScopes.FoundationAttributes.self, extraAttributesTable: _loadDefaultAttributes()))
+    }
+}
+
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString : CodableWithConfiguration {
+
+    private enum CodingKeys : String, CodingKey {
+        case runs
+        case attributeTable
+    }
+
+    private struct AttributeKey: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        init?(intValue: Int) {
+            self.stringValue = "\(intValue)"
+            self.intValue = intValue
+        }
+    }
+
+    public func encode(to encoder: Encoder, configuration: AttributeScopeCodableConfiguration) throws {
+        if self._guts.runs.count == 0 || (self._guts.runs.count == 1 && self._guts.runs[0].attributes.contents.isEmpty) {
+            var container = encoder.singleValueContainer()
+            try container.encode(self._guts.string)
+            return
+        }
+
+        var runsContainer: UnkeyedEncodingContainer
+        var attributeTable = [_AttributeStorage : Int]()
+        var attributeTableNextIndex = 0
+        var attributeTableContainer: UnkeyedEncodingContainer?
+        if self._guts.runs.count <= 10 {
+            runsContainer = encoder.unkeyedContainer()
+        } else {
+            var topLevelContainer = encoder.container(keyedBy: CodingKeys.self)
+            runsContainer = topLevelContainer.nestedUnkeyedContainer(forKey: .runs)
+            attributeTableContainer = topLevelContainer.nestedUnkeyedContainer(forKey: .attributeTable)
+        }
+
+        var currentIndex = self.startIndex
+        var attributeKeyTypes = configuration.extraAttributesTable
+        for run in self._guts.runs {
+            let currentEndIndex = self._guts.index(currentIndex, offsetByUTF8: run.length)
+            let substring = self._guts.string[(currentIndex ..< currentEndIndex)._stringRange]
+            try runsContainer.encode(String(substring))
+
+            if !run.attributes.contents.isEmpty, var attributeTableContainer = attributeTableContainer {
+                let index = attributeTable[run.attributes, default: attributeTableNextIndex]
+                if index == attributeTableNextIndex {
+                    try Self.encodeAttributeContainer(run.attributes, to: attributeTableContainer.superEncoder(), configuration: configuration, using: &attributeKeyTypes)
+                    attributeTable[run.attributes] = index
+                    attributeTableNextIndex += 1
+                }
+                try runsContainer.encode(index)
+            } else {
+                try Self.encodeAttributeContainer(run.attributes, to: runsContainer.superEncoder(), configuration: configuration, using: &attributeKeyTypes)
+            }
+
+            currentIndex = currentEndIndex
+        }
+    }
+
+    fileprivate static func encodeAttributeContainer(_ attributes: _AttributeStorage, to encoder: Encoder, configuration: AttributeScopeCodableConfiguration, using attributeKeyTypeTable: inout [String : Any.Type]) throws {
+        func projectScopeType<S>(_: S.Type) throws {
+            var attributesContainer = encoder.container(keyedBy: AttributeKey.self)
+            for (name, value) in attributes.contents {
+                if let attributeKeyType = attributeKeyTypeTable[name] ?? GetAttributeTypeIfAttributeScope(S.self, key: name).attemptAction() ?? nil {
+                    attributeKeyTypeTable[name] = attributeKeyType
+                    func project<T>( _: T.Type) throws {
+                        let attributeEncoder = attributesContainer.superEncoder(forKey: AttributeKey(stringValue: name)!)
+                        let encodeIfCodable = EncodeIfCodable(T.self, value: value, encoder: attributeEncoder)
+                        let _ = try encodeIfCodable.attemptAction() // Ignores result to drop attributes that are not codable
+                    }
+                    try _openExistential(attributeKeyType, do: project)
+                } // else: the attribute was not in the provided scope, so drop it
+            }
+        }
+        try _openExistential(configuration.scopeType, do: projectScopeType)
+    }
+
+    public init(from decoder: Decoder, configuration: AttributeScopeCodableConfiguration) throws {
+        if let svc = try? decoder.singleValueContainer(), let str = try? svc.decode(String.self) {
+            self.init(str)
+            return
+        }
+
+        var runsContainer: UnkeyedDecodingContainer
+        var attributeTable: [_AttributeStorage]?
+        var attributeKeyTypeTable = configuration.extraAttributesTable
+
+        if let runs = try? decoder.unkeyedContainer() {
+            runsContainer = runs
+            attributeTable = nil
+        } else {
+            let topLevelContainer = try decoder.container(keyedBy: CodingKeys.self)
+            runsContainer = try topLevelContainer.nestedUnkeyedContainer(forKey: .runs)
+            attributeTable = try Self.decodeAttributeTable(from: topLevelContainer.superDecoder(forKey: .attributeTable), configuration: configuration, using: &attributeKeyTypeTable)
+        }
+
+        var string = ""
+        var runs = [_InternalRun]()
+        if let containerCount = runsContainer.count {
+            runs.reserveCapacity(containerCount / 2)
+        }
+        while !runsContainer.isAtEnd {
+            let substring = try runsContainer.decode(String.self)
+            var attributes: _AttributeStorage
+
+            if let tableIndex = try? runsContainer.decode(Int.self) {
+                guard let attributeTable = attributeTable else {
+                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                            debugDescription: "Attribute table index present with no reference attribute table"))
+                }
+                guard tableIndex >= 0 && tableIndex < attributeTable.count else {
+                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                            debugDescription: "Attribute table index \(tableIndex) is not within the bounds of the attribute table [0...\(attributeTable.count - 1)]"))
+                }
+                attributes = attributeTable[tableIndex]
+            } else {
+                attributes = try Self.decodeAttributeContainer(from: try runsContainer.superDecoder(), configuration: configuration, using: &attributeKeyTypeTable)
+            }
+
+            if substring.isEmpty && (runs.count > 0 || !runsContainer.isAtEnd) {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                        debugDescription: "When multiple runs are present, runs with empty substrings are not allowed"))
+            }
+            if substring.isEmpty && !attributes.contents.isEmpty {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                        debugDescription: "Runs of empty substrings cannot contain attributes"))
+            }
+
+            string += substring
+            if let previous = runs.last, previous.attributes == attributes {
+                runs[runs.count - 1].length += substring.count
+            } else {
+                runs.append(_InternalRun(length: substring.count, attributes: attributes))
+            }
+        }
+        if runs.isEmpty {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath,
+                                                                    debugDescription: "Runs container must not be empty"))
+        }
+        self.init(Guts(string: string, runs: runs))
+    }
+
+    private static func decodeAttributeTable(from decoder: Decoder, configuration: AttributeScopeCodableConfiguration, using attributeKeyTypeTable: inout [String : Any.Type]) throws -> [_AttributeStorage] {
+        var container = try decoder.unkeyedContainer()
+        var table = [_AttributeStorage]()
+        if let size = container.count {
+            table.reserveCapacity(size)
+        }
+        while !container.isAtEnd {
+            table.append(try decodeAttributeContainer(from: try container.superDecoder(), configuration: configuration, using: &attributeKeyTypeTable))
+        }
+        return table
+    }
+
+    fileprivate static func decodeAttributeContainer(from decoder: Decoder, configuration: AttributeScopeCodableConfiguration, using attributeKeyTypeTable: inout [String : Any.Type]) throws -> _AttributeStorage {
+        let attributesContainer = try decoder.container(keyedBy: AttributeKey.self)
+        var attributes = _AttributeStorage()
+        func projectScopeType<S>(_: S.Type) throws {
+            for key in attributesContainer.allKeys {
+                let name = key.stringValue
+                if let attributeKeyType = attributeKeyTypeTable[name] ?? GetAttributeTypeIfAttributeScope(S.self, key: name).attemptAction() ?? nil {
+                    attributeKeyTypeTable[name] = attributeKeyType
+                    func project<T>( _: T.Type) throws {
+                        let decodeIfCodable = DecodeIfCodable(T.self, decoder: try attributesContainer.superDecoder(forKey: key))
+                        if let decoded = try decodeIfCodable.attemptAction() {
+                            attributes.contents[name] = decoded
+                        } // else: attribute was not codable, so drop it
+                    }
+                    try _openExistential(attributeKeyType, do: project)
+                }
+                // else: the attribute was not in the provided scope, so drop it
+            }
+        }
+        try _openExistential(configuration.scopeType, do: projectScopeType)
+        return attributes
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributeContainer : CodableWithConfiguration {
+    public func encode(to encoder: Encoder, configuration: AttributeScopeCodableConfiguration) throws {
+        var attributeKeyTypeTable = configuration.extraAttributesTable
+        var storage = AttributedString._AttributeStorage()
+        storage.contents = self.contents
+        try AttributedString.encodeAttributeContainer(storage, to: encoder, configuration: configuration, using: &attributeKeyTypeTable)
+    }
+
+    public init(from decoder: Decoder, configuration: AttributeScopeCodableConfiguration) throws {
+        var attributeKeyTypeTable = configuration.extraAttributesTable
+        let storage = try AttributedString.decodeAttributeContainer(from: decoder, configuration: configuration, using: &attributeKeyTypeTable)
+        self.contents = storage.contents
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension CodableConfiguration where ConfigurationProvider : AttributeScope {
+    init(wrappedValue: T, from keyPath: KeyPath<AttributeScopes, ConfigurationProvider.Type>) {
+        self.wrappedValue = wrappedValue
+    }
+}

--- a/Sources/Foundation/AttributedString/AttributedStringRunCoalescing.swift
+++ b/Sources/Foundation/AttributedString/AttributedStringRunCoalescing.swift
@@ -1,0 +1,278 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString.Guts {
+    internal struct RunOffset {
+        fileprivate var location: Int = 0
+        fileprivate var block: Int = 0
+    }
+    
+    // MARK: - Helper Functions
+    
+    /// Retrieve the UTF-8 `location` and `block` index of the run containing the UTF-8 `location`, and update the cache accordingly
+    @discardableResult
+    private func seekToRun(location: Int) -> RunOffset {
+        var currentLocation = 0
+        var currentBlock = 0
+        
+        runOffsetCacheLock.lock()
+        defer { runOffsetCacheLock.unlock() }
+        
+        if location > runOffsetCache.location / 2 {
+            currentLocation = runOffsetCache.location
+            currentBlock = runOffsetCache.block
+        }
+        
+        if currentLocation <= location {
+            while currentBlock < runs.count && currentLocation + runs[currentBlock].length <= location {
+                currentLocation += runs[currentBlock].length
+                currentBlock += 1
+            }
+        } else {
+            repeat {
+                currentBlock -= 1
+                currentLocation -= runs[currentBlock].length
+            } while currentLocation > location && currentBlock >= 0
+        }
+        
+        let currentOffset = RunOffset(location: currentLocation, block: currentBlock)
+        runOffsetCache = currentOffset
+        return currentOffset
+    }
+    
+    /// Retrieve the UTF-8 `location` and `block` index of the run at the `rangeIndex` block, and update the cache accordingly
+    @discardableResult
+    private func seekToRun(rangeIndex: Int) -> RunOffset {
+        runOffsetCacheLock.lock()
+        defer { runOffsetCacheLock.unlock() }
+        return seekToRunAlreadyLocked(rangeIndex: rangeIndex)
+    }
+    
+    /// Retrieve the UTF-8 `location` and `block` index of the run at the `rangeIndex` block, and update the cache accordingly
+    @discardableResult
+    private func seekToRunAlreadyLocked(rangeIndex: Int) -> RunOffset {
+        var currentLocation = 0
+        var currentBlock = 0
+        
+        if rangeIndex > runOffsetCache.block / 2 {
+            currentLocation = runOffsetCache.location
+            currentBlock = runOffsetCache.block
+        }
+        
+        if currentBlock <= rangeIndex {
+            while currentBlock != rangeIndex {
+                currentLocation += runs[currentBlock].length
+                currentBlock += 1
+            }
+        } else {
+            repeat {
+                currentBlock -= 1
+                currentLocation -= runs[currentBlock].length
+            } while currentBlock != rangeIndex
+        }
+        
+        let currentOffset = RunOffset(location: currentLocation, block: currentBlock)
+        runOffsetCache = currentOffset
+        return currentOffset
+    }
+    
+    /// Update the run at the given block `index` with the provided `run` and coalesce it with its neighbors if necessary.
+    /// - Returns: The new index of the updated run (potentially different from the provided `index` due to coalescing)
+    @discardableResult
+    func updateAndCoalesce(run: AttributedString._InternalRun, at index: Int) -> Int {
+        runOffsetCacheLock.lock()
+        defer { runOffsetCacheLock.unlock() }
+        if runOffsetCache.block > index {
+            runOffsetCache.location += run.length - runs[index].length
+        }
+        runs[index] = run
+        
+        if index < runs.count - 1 && run.attributes == runs[index + 1].attributes {
+            if runOffsetCache.block == index + 1 {
+                runOffsetCache.location += runs[index + 1].length
+            } else if runOffsetCache.block > index + 1{
+                runOffsetCache.block -= 1
+            }
+            runs[index].length += runs[index + 1].length
+            runs.remove(at: index + 1)
+        }
+        var newIndex = index
+        if index > 0 && run.attributes == runs[index - 1].attributes {
+            if runOffsetCache.block == index {
+                runOffsetCache.location += runs[index].length
+            } else if runOffsetCache.block > index {
+                runOffsetCache.block -= 1
+            }
+            runs[index - 1].length += runs[index].length
+            runs.remove(at: index)
+            newIndex -= 1
+        }
+        return newIndex
+    }
+    
+    func runAndLocation(at index: Int) -> (run: AttributedString._InternalRun, location: Int) {
+        let result = seekToRun(rangeIndex: index)
+        return (runs[result.block], result.location)
+    }
+    
+    func run(containing location: Int) -> AttributedString._InternalRun {
+        return runs[seekToRun(location: location).block]
+    }
+    
+    func runAndLocation(containing location: Int) -> (run: AttributedString._InternalRun, location: Int) {
+        let result = seekToRun(location: location)
+        return (runs[result.block], result.location)
+    }
+    
+    func runs(containing range: Range<Int>) -> [AttributedString._InternalRun] {
+        var runs = [AttributedString._InternalRun]()
+        var location = range.lowerBound
+        while location < range.upperBound {
+            let run = self.runs[seekToRun(location: location).block]
+            let clampedRange = (location..<location + run.length).clamped(to: range)
+            runs.append(AttributedString._InternalRun(length: clampedRange.count, attributes: run.attributes))
+            location += run.length
+        }
+        return runs
+    }
+    
+    enum RunEnumerationModification {
+        case guaranteedNotModified
+        case guaranteedModified
+        case notGuaranteed
+    }
+    
+    /// Enumerate each run in the provided range of UTF-8 locations. Mutating of attributes during this enumeration via the passed `inout AttributedString._InternalRun` IS allowed.
+    ///
+    /// - It is expected that only attributes will be mutated and not the length of the run (any changes to the length of the run will be ignored).
+    /// - If a run that spans both the inside and outside of the provided `range` is modified, the run will be broken into pieces and only the piece within the `range` will be modified.
+    /// - If a run is modified such that it becomes coalesced with the next run to be enumerated, that next run will not be passed to the `block` and the next call to the `block` will be with the next non-coalesced run.
+    ///
+    /// - Parameters:
+    ///   - range: The range of UTF-8 indices to enumerate between. Runs will be clamped to this range.
+    ///   - block: A block to call with each enumerated run. Mutation is ONLY supported by changing attributes on the provided `inout AttributedString._InternalRun` while enumerating.
+    ///   - run: The current run provided via enumeration
+    ///   - location: The UTF-8 distance from the start of the string to the start of this run (clamped to the provided `range`)
+    ///   - stop: Stops further enumeration when set to `true`
+    func enumerateRuns(containing range: Range<Int>? = nil, _ block: (_ run: inout AttributedString._InternalRun, _ location: Int, _ stop: inout Bool, _ modificationStatus: inout RunEnumerationModification) throws -> Void) rethrows {
+        var location = range?.lowerBound ?? 0
+        // When endLocation=-1, the return statement will break the loop
+        // We do this to avoid needing to scan the whole runs array to find endLocation when range is nil
+        let endLocation = range?.upperBound ?? -1
+        while endLocation == -1 || location < endLocation {
+            let result = seekToRun(location: location)
+            if result.block >= runs.count {
+                return
+            }
+            let run = runs[result.block]
+            let runRange = result.location ..< result.location + run.length
+            let clampedRange : Range<Int>
+            if endLocation == -1 {
+                clampedRange = runRange.clamped(to: location ..< runRange.endIndex)
+            } else {
+                clampedRange = runRange.clamped(to: location ..< endLocation)
+            }
+            var stop = false
+            let clampedRun = AttributedString._InternalRun(length: clampedRange.count, attributes: run.attributes)
+            var maybeChangedRun = clampedRun
+            var modificationStatus: RunEnumerationModification = .notGuaranteed
+            try block(&maybeChangedRun, location, &stop, &modificationStatus)
+            maybeChangedRun.length = clampedRun.length // Ignore any changes to length
+            if modificationStatus == .guaranteedModified || (modificationStatus == .notGuaranteed && maybeChangedRun.attributes != clampedRun.attributes) {
+                if runRange != clampedRange {
+                    var replacementRuns = [AttributedString._InternalRun]()
+                    if runRange.startIndex != clampedRange.startIndex {
+                        let splitOffStartLength = clampedRange.startIndex - runRange.startIndex
+                        replacementRuns.append(AttributedString._InternalRun(length: splitOffStartLength, attributes: run.attributes))
+                    }
+                    replacementRuns.append(maybeChangedRun)
+                    if runRange.endIndex != clampedRange.endIndex {
+                        let splitOffEndLength = runRange.endIndex - clampedRange.endIndex
+                        replacementRuns.append(AttributedString._InternalRun(length: splitOffEndLength, attributes: run.attributes))
+                    }
+                    replaceRunsSubrange(result.block ..< result.block + 1, with: replacementRuns)
+                    let newResult = seekToRun(location: location)
+                    location = newResult.location + runs[newResult.block].length
+                } else {
+                    let newBlock = self.updateAndCoalesce(run: maybeChangedRun, at: result.block)
+                    let newResult = seekToRun(rangeIndex: newBlock)
+                    location = newResult.location + runs[newResult.block].length
+                }
+            } else {
+                location += maybeChangedRun.length
+            }
+            if stop {
+                return
+            }
+        }
+    }
+    
+    func indexOfRun(containing location: Int) -> Int {
+        return seekToRun(location: location).block
+    }
+    
+    /// Replace the runs for a specified range of UTF-8 locations with the provided collection. This will split runs at the start/end if the bounds of the range fall in the middle of an existing run
+    /// Note: the provided `newElements` must already be coalesced together if needed.
+    func replaceRunsSubrange<C: Collection>(locations subrange: Range<Int>, with newElements: C) where C.Element == AttributedString._InternalRun {
+        let start = seekToRun(location: subrange.startIndex)
+        let newStartLength = subrange.startIndex - start.location
+        var insertingRuns = [AttributedString._InternalRun](newElements)
+        if newStartLength > 0 {
+            if insertingRuns.isEmpty || runs[start.block].attributes != insertingRuns[0].attributes {
+                insertingRuns.insert(AttributedString._InternalRun(length: newStartLength, attributes: runs[start.block].attributes), at: 0)
+            } else {
+                insertingRuns[0].length += newStartLength
+            }
+        }
+        
+        let end = seekToRun(location: subrange.endIndex)
+        if end.block != runs.endIndex {
+            let endRun = runs[end.block]
+            let newEndLength = end.location + endRun.length - subrange.endIndex
+            if newEndLength > 0 {
+                if insertingRuns.isEmpty || runs[end.block].attributes != insertingRuns.last!.attributes {
+                    insertingRuns.append(AttributedString._InternalRun(length: newEndLength, attributes: runs[end.block].attributes))
+                } else {
+                    insertingRuns[insertingRuns.endIndex - 1].length += newEndLength
+                }
+            }
+            replaceRunsSubrange(start.block ..< end.block + 1, with: insertingRuns)
+        } else {
+            replaceRunsSubrange(start.block ..< end.block, with: insertingRuns)
+        }
+    }
+    
+    /// Replaces the runs for a specified range of block indices with the given `newElements`
+    /// Note: The provided `newElements` must already be coalsced together if needed.
+    func replaceRunsSubrange<C: Collection>(_ subrange: Range<Int>, with newElements: C) where C.Element == AttributedString._InternalRun {
+        runOffsetCacheLock.lock()
+        defer { runOffsetCacheLock.unlock() }
+        if runOffsetCache.block > subrange.lowerBound {
+            // Move the cached location to a place where it won't be corrupted
+            seekToRunAlreadyLocked(rangeIndex: subrange.lowerBound)
+        }
+        runs.replaceSubrange(subrange, with: newElements)
+        let startOfReplacement = subrange.startIndex
+        let endOfReplacement = subrange.endIndex + (newElements.count - (subrange.endIndex - subrange.startIndex))
+        if endOfReplacement < runs.count && endOfReplacement > 0 && runs[endOfReplacement - 1].attributes == runs[endOfReplacement].attributes {
+            runs[endOfReplacement - 1].length += runs[endOfReplacement].length
+            runs.remove(at: endOfReplacement)
+        }
+        if startOfReplacement < runs.count && startOfReplacement > 0 && runs[startOfReplacement - 1].attributes == runs[startOfReplacement].attributes {
+            runOffsetCache.block -= 1
+            runOffsetCache.location -= runs[startOfReplacement - 1].length
+            runs[startOfReplacement - 1].length += runs[startOfReplacement].length
+            runs.remove(at: startOfReplacement)
+        }
+    }
+}

--- a/Sources/Foundation/AttributedString/Conversion.swift
+++ b/Sources/Foundation/AttributedString/Conversion.swift
@@ -1,0 +1,379 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Reflection) import Swift
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public protocol ObjectiveCConvertibleAttributedStringKey : AttributedStringKey {
+    associatedtype ObjectiveCValue : NSObject
+
+    static func objectiveCValue(for value: Value) throws -> ObjectiveCValue
+    static func value(for object: ObjectiveCValue) throws -> Value
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension ObjectiveCConvertibleAttributedStringKey where Value : RawRepresentable, Value.RawValue == Int, ObjectiveCValue == NSNumber {
+    static func objectiveCValue(for value: Value) throws -> ObjectiveCValue {
+        return NSNumber(value: value.rawValue)
+    }
+    static func value(for object: ObjectiveCValue) throws -> Value {
+        if let val = Value(rawValue: object.intValue) {
+            return val
+        }
+        throw CocoaError(.coderInvalidValue)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension ObjectiveCConvertibleAttributedStringKey where Value : RawRepresentable, Value.RawValue == String, ObjectiveCValue == NSString {
+    static func objectiveCValue(for value: Value) throws -> ObjectiveCValue {
+        return value.rawValue as NSString
+    }
+    static func value(for object: ObjectiveCValue) throws -> Value {
+        if let val = Value(rawValue: object as String) {
+            return val
+        }
+        throw CocoaError(.coderInvalidValue)
+    }
+}
+
+internal struct _AttributeConversionOptions : OptionSet {
+    let rawValue: Int
+    
+    // If an attribute's value(for: ObjectieCValue) or objectiveCValue(for: Value) function throws, ignore the error and drop the attribute
+    static let dropThrowingAttributes = Self(rawValue: 1 << 0)
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension AttributeContainer {
+    init(_ dictionary: [NSAttributedString.Key : Any]) {
+        var attributeKeyTypes = _loadDefaultAttributes()
+        // Passing .dropThrowingAttributes causes attributes that throw during conversion to be dropped, so it is safe to do try! here
+        try! self.init(dictionary, including: AttributeScopes.FoundationAttributes.self, attributeKeyTypes: &attributeKeyTypes, options: .dropThrowingAttributes)
+    }
+    
+    
+    init<S: AttributeScope>(_ dictionary: [NSAttributedString.Key : Any], including scope: KeyPath<AttributeScopes, S.Type>) throws {
+        try self.init(dictionary, including: S.self)
+    }
+    
+    init<S: AttributeScope>(_ dictionary: [NSAttributedString.Key : Any], including scope: S.Type) throws {
+        var attributeKeyTypes = [String : Any.Type]()
+        try self.init(dictionary, including: scope, attributeKeyTypes: &attributeKeyTypes)
+    }
+    
+    fileprivate init<S: AttributeScope>(_ dictionary: [NSAttributedString.Key : Any], including scope: S.Type, attributeKeyTypes: inout [String : Any.Type], options: _AttributeConversionOptions = []) throws {
+        contents = [:]
+        for (key, value) in dictionary {
+            if let type = attributeKeyTypes[key.rawValue] ?? S.attributeKeyType(matching: key.rawValue) {
+                attributeKeyTypes[key.rawValue] = type
+                var swiftVal: AnyHashable?
+                func project<T>(_: T.Type) throws {
+                    if let val = try ConvertFromObjCIfObjCAttribute(T.self, value: value as AnyObject).attemptAction() {
+                        // Value is converted via the function defined by `ObjectiveCConvertibleAttributedStringKey`
+                        swiftVal = val
+                    } else if let val = try ConvertFromObjCIfAttribute(T.self, value: value as AnyObject).attemptAction() {
+                        // Attribute is only `AttributedStringKey`, so converted by casting to Value type
+                        // This implicitly bridges or unboxes the value
+                        swiftVal = val
+                    } // else: the type was not an attribute (should never happen)
+                }
+                do {
+                    try _openExistential(type, do: project)
+                } catch let conversionError {
+                    if !options.contains(.dropThrowingAttributes) {
+                        throw conversionError
+                    }
+                }
+                if let swiftVal = swiftVal {
+                    contents[key.rawValue] = swiftVal
+                }
+            } // else, attribute is not in provided scope, so drop it
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension Dictionary where Key == NSAttributedString.Key, Value == Any {
+    init(_ container: AttributeContainer) {
+        var attributeKeyTypes = _loadDefaultAttributes()
+        // Passing .dropThrowingAttributes causes attributes that throw during conversion to be dropped, so it is safe to do try! here
+        try! self.init(container, including: AttributeScopes.FoundationAttributes.self, attributeKeyTypes: &attributeKeyTypes, options: .dropThrowingAttributes)
+    }
+    
+    init<S: AttributeScope>(_ container: AttributeContainer, including scope: KeyPath<AttributeScopes, S.Type>) throws {
+        try self.init(container, including: S.self)
+    }
+    
+    init<S: AttributeScope>(_ container: AttributeContainer, including scope: S.Type) throws {
+        var attributeKeyTypes = [String : Any.Type]()
+        try self.init(container, including: scope, attributeKeyTypes: &attributeKeyTypes)
+    }
+    
+    // These includingOnly SPI initializers were provided originally when conversion boxed attributes outside of the given scope as an AnyObject
+    // After rdar://80201634, these SPI initializers have the same behavior as the API initializers
+    @_spi(AttributedString)
+    init<S: AttributeScope>(_ container: AttributeContainer, includingOnly scope: KeyPath<AttributeScopes, S.Type>) throws {
+        try self.init(container, including: S.self)
+    }
+    
+    @_spi(AttributedString)
+    init<S: AttributeScope>(_ container: AttributeContainer, includingOnly scope: S.Type) throws {
+        try self.init(container, including: S.self)
+    }
+    
+    fileprivate init<S: AttributeScope>(_ container: AttributeContainer, including scope: S.Type, attributeKeyTypes: inout [String : Any.Type], options: _AttributeConversionOptions = []) throws {
+        self.init()
+        for (key, value) in container.contents {
+            if let type = attributeKeyTypes[key] ?? S.attributeKeyType(matching: key) {
+                attributeKeyTypes[key] = type
+                var objcVal: AnyObject?
+                func project<T>(_: T.Type) throws {
+                    if let val = try ConvertToObjCIfObjCAttribute(T.self, value: value).attemptAction() {
+                        objcVal = val
+                    } else {
+                        // Attribute is not `ObjectiveCConvertibleAttributedStringKey`, so cast it to AnyObject to implicitly bridge it or box it
+                        objcVal = value as AnyObject
+                    }
+                }
+                do {
+                    try _openExistential(type, do: project)
+                } catch let conversionError {
+                    if !options.contains(.dropThrowingAttributes) {
+                        throw conversionError
+                    }
+                }
+                if let val = objcVal {
+                    self[NSAttributedString.Key(rawValue: key)] = val
+                }
+            }
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension NSAttributedString {
+    convenience init(_ attrStr: AttributedString) {
+        // Passing .dropThrowingAttributes causes attributes that throw during conversion to be dropped, so it is safe to do try! here
+        try! self.init(attrStr, scope: AttributeScopes.FoundationAttributes.self, otherAttributeTypes: _loadDefaultAttributes(), options: .dropThrowingAttributes)
+    }
+    
+    convenience init<S: AttributeScope>(_ attrStr: AttributedString, including scope: KeyPath<AttributeScopes, S.Type>) throws {
+        try self.init(attrStr, scope: S.self)
+    }
+    
+    convenience init<S: AttributeScope>(_ attrStr: AttributedString, including scope: S.Type) throws {
+        try self.init(attrStr, scope: scope)
+    }
+    
+    @_spi(AttributedString)
+    convenience init<S: AttributeScope>(_ attrStr: AttributedString, includingOnly scope: KeyPath<AttributeScopes, S.Type>) throws {
+        try self.init(attrStr, scope: S.self)
+    }
+    
+    @_spi(AttributedString)
+    convenience init<S: AttributeScope>(_ attrStr: AttributedString, includingOnly scope: S.Type) throws {
+        try self.init(attrStr, scope: scope)
+    }
+    
+    internal convenience init<S: AttributeScope>(_ attrStr: AttributedString, scope: S.Type, otherAttributeTypes: [String : Any.Type] = [:], options: _AttributeConversionOptions = []) throws {
+        let result = NSMutableAttributedString(string: attrStr._guts.string)
+        var attributeKeyTypes: [String : Any.Type] = otherAttributeTypes
+        // Iterate through each run of the source
+        var nsStartIndex = 0
+        var stringStart = attrStr._guts.string.startIndex
+        for run in attrStr._guts.runs {
+            let stringEnd = attrStr._guts.string.utf8.index(stringStart, offsetBy: run.length)
+            let utf16Length = attrStr._guts.string.utf16.distance(from: stringStart, to: stringEnd)
+            let range = NSRange(location: nsStartIndex, length: utf16Length)
+            let attributes = try Dictionary(AttributeContainer(run.attributes.contents), including: scope, attributeKeyTypes: &attributeKeyTypes, options: options)
+            result.setAttributes(attributes, range: range)
+            nsStartIndex += utf16Length
+            stringStart = stringEnd
+        }
+        self.init(attributedString: result)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension AttributedString {
+    init(_ nsStr: NSAttributedString) {
+        // Passing .dropThrowingAttributes causes attributes that throw during conversion to be dropped, so it is safe to do try! here
+        try! self.init(nsStr, scope: AttributeScopes.FoundationAttributes.self, otherAttributeTypes: _loadDefaultAttributes(), options: .dropThrowingAttributes)
+    }
+    
+    init<S: AttributeScope>(_ nsStr: NSAttributedString, including scope: KeyPath<AttributeScopes, S.Type>) throws {
+        try self.init(nsStr, scope: S.self)
+    }
+    
+    init<S: AttributeScope>(_ nsStr: NSAttributedString, including scope: S.Type) throws {
+        try self.init(nsStr, scope: S.self)
+    }
+    
+    private init<S: AttributeScope>(_ nsStr: NSAttributedString, scope: S.Type, otherAttributeTypes: [String : Any.Type] = [:], options: _AttributeConversionOptions = []) throws {
+        let string = nsStr.string
+        var runs: [_InternalRun] = []
+        var attributeKeyTypes: [String : Any.Type] = otherAttributeTypes
+        var conversionError: Error?
+        var stringStart = string.startIndex
+        nsStr.enumerateAttributes(in: NSMakeRange(0, nsStr.length), options: []) { (nsAttrs, range, stop) in
+            let container: AttributeContainer
+            do {
+                container = try AttributeContainer(nsAttrs, including: scope, attributeKeyTypes: &attributeKeyTypes, options: options)
+            } catch {
+                conversionError = error
+                stop.pointee = true
+                return
+            }
+            let stringEnd = string.utf16.index(stringStart, offsetBy: range.length)
+            let runLength = string.utf8.distance(from: stringStart, to: stringEnd)
+            let attrStorage = _AttributeStorage(container.contents)
+            if let previous = runs.last, previous.attributes == attrStorage {
+                runs[runs.endIndex - 1].length += runLength
+            } else {
+                runs.append(_InternalRun(length: runLength, attributes: attrStorage))
+            }
+            stringStart = stringEnd
+        }
+        if let error = conversionError {
+            throw error
+        }
+        self = AttributedString(Guts(string: string, runs: runs))
+    }
+}
+
+fileprivate var _loadedScopeCache = [String : [String : Any.Type]]()
+fileprivate var _loadedScopeCacheLock = Lock()
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal func _loadDefaultAttributes() -> [String : Any.Type] {
+    #if os(macOS)
+    #if !targetEnvironment(macCatalyst)
+        // AppKit scope on macOS
+        let macOSSymbol = ("$s10Foundation15AttributeScopesO6AppKitE0dE10AttributesVN", "/usr/lib/swift/libswiftAppKit.dylib")
+    #else
+        // UIKit scope on macOS
+        let macOSSymbol = ("$s10Foundation15AttributeScopesO5UIKitE0D10AttributesVN", "/System/iOSSupport/usr/lib/swift/libswiftUIKit.dylib")
+    #endif
+
+    let loadedScopes = [
+        macOSSymbol,
+        // UIKit scope on non-macOS
+        ("$s10Foundation15AttributeScopesO5UIKitE0D10AttributesVN", "/usr/lib/swift/libswiftUIKit.dylib"),
+        // SwiftUI scope
+        ("$s10Foundation15AttributeScopesO7SwiftUIE0D12UIAttributesVN", "/System/Library/Frameworks/SwiftUI.framework/SwiftUI"),
+        // Accessibility scope
+        ("$s10Foundation15AttributeScopesO13AccessibilityE0D10AttributesVN", "/System/Library/Frameworks/Accessibility.framework/Accessibility")
+    ].compactMap {
+        _loadScopeAttributes(forSymbol: $0.0, from: $0.1)
+    }
+
+    return loadedScopes.reduce([:]) { result, item in
+        result.merging(item) { current, new in new }
+    }
+    #else
+    return [:]
+    #endif // os(macOS)
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+fileprivate func _loadScopeAttributes(forSymbol symbol: String, from path: String) -> [String : Any.Type]? {
+    _loadedScopeCacheLock.lock()
+    defer { _loadedScopeCacheLock.unlock() }
+    if let cachedResult = _loadedScopeCache[symbol] {
+        return cachedResult
+    }
+    guard let handle = dlopen(path, RTLD_NOLOAD) else {
+        return nil
+    }
+    guard let symbolPointer = dlsym(handle, symbol) else {
+        return nil
+    }
+    let scopeType = unsafeBitCast(symbolPointer, to: Any.Type.self)
+    let attributeTypes =  _loadAttributeTypes(from: scopeType)
+    _loadedScopeCache[symbol] = attributeTypes
+    return attributeTypes
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+fileprivate func _loadAttributeTypes(from scope: Any.Type) -> [String : Any.Type] {
+    var result = [String : Any.Type]()
+    _forEachField(of: scope, options: [.ignoreUnknown]) { pointer, offset, type, kind -> Bool in
+        func project<K>(_: K.Type) {
+            if let key = GetNameIfAttribute(K.self).attemptAction() {
+                result[key] = type
+            } else if let subResults = GetAllAttributeTypesIfAttributeScope(K.self).attemptAction() {
+                result.merge(subResults, uniquingKeysWith: { current, new in new })
+            }
+        }
+        _openExistential(type, do: project)
+        return true
+    }
+    return result
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension String.Index {
+    public init?<S: StringProtocol>(_ sourcePosition: AttributedString.Index, within target: S) {
+        self.init(sourcePosition.characterIndex, within: target)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedString.Index {
+    public init?<S: AttributedStringProtocol>(_ sourcePosition: String.Index, within target: S) {
+        guard let strIndex = String.Index(sourcePosition, within: target.__guts.string) else {
+            return nil
+        }
+        self.init(characterIndex: strIndex)
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension NSRange {
+    public init<R: RangeExpression, S: AttributedStringProtocol>(_ region: R, in target: S) where R.Bound == AttributedString.Index {
+        let str = target.__guts.string
+        let r = region.relative(to: target.characters)._stringRange.relative(to: str)
+        self.init(str._toUTF16Offsets(r))
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Range where Bound == AttributedString.Index {
+    public init?<S: AttributedStringProtocol>(_ range: NSRange, in attrStr: S) {
+        if let r = Range<String.Index>(range, in: attrStr.__guts.string) {
+            self = r._attributedStringRange
+        } else {
+            return nil
+        }
+    }
+    public init?<R: RangeExpression, S: AttributedStringProtocol>(_ region: R, in attrStr: S) where R.Bound == String.Index {
+        let range = region.relative(to: attrStr.__guts.string)
+        if let lwr = Bound(range.lowerBound, within: attrStr), let upr = Bound(range.upperBound, within: attrStr) {
+            self = lwr ..< upr
+        } else {
+            return nil
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Range where Bound == String.Index {
+    public init?<R: RangeExpression, S: StringProtocol>(_ region: R, in string: S) where R.Bound == AttributedString.Index {
+        let range = region.relative(to: AttributedString(string).characters)
+        if let lwr = Bound(range.lowerBound, within: string), let upr = Bound(range.upperBound, within: string) {
+            self = lwr ..< upr
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/Foundation/AttributedString/FoundationAttributes.swift
+++ b/Sources/Foundation/AttributedString/FoundationAttributes.swift
@@ -1,0 +1,330 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// MARK: Attribute Scope
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributeScopes {
+    public var foundation: FoundationAttributes.Type { FoundationAttributes.self }
+    
+    public struct FoundationAttributes : AttributeScope {
+        public let link: LinkAttribute
+        public let morphology: MorphologyAttribute
+        public let inflect: InflectionRuleAttribute
+        public let languageIdentifier: LanguageIdentifierAttribute
+        public let personNameComponent: PersonNameComponentAttribute
+        public let numberFormat: NumberFormatAttributes
+        public let dateField: DateFieldAttribute
+        public let replacementIndex : ReplacementIndexAttribute
+        public let measurement: MeasurementAttribute
+        public let inflectionAlternative: InflectionAlternativeAttribute
+        public let byteCount: ByteCountAttribute
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+public extension AttributeDynamicLookup {
+    subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.FoundationAttributes, T>) -> T {
+        return self[T.self]
+    }
+
+    subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.FoundationAttributes.NumberFormatAttributes, T>) -> T { self[T.self] }
+}
+
+// MARK: Attribute Definitions
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributeScopes.FoundationAttributes {
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum LinkAttribute : CodableAttributedStringKey, ObjectiveCConvertibleAttributedStringKey {
+        public typealias Value = URL
+        public typealias ObjectiveCValue = NSObject // NSURL or NSString
+        public static var name = "NSLink"
+        
+        public static func objectiveCValue(for value: URL) throws -> NSObject {
+            value as NSURL
+        }
+        
+        public static func value(for object: NSObject) throws -> URL {
+            if let object = object as? NSURL {
+                return object as URL
+            } else if let object = object as? NSString {
+                // TODO: Do we need to call up to [NSTextView _URLForString:] on macOS here?
+                if let result = URL(string: object as String) {
+                    return result
+                }
+            }
+            throw CocoaError(.coderInvalidValue)
+        }
+    }
+    
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum MorphologyAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        public typealias Value = Morphology
+        public static let name = NSAttributedString.Key.morphology.rawValue
+        public static let markdownName = "morphology"
+    }
+
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum InflectionRuleAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        public typealias Value = InflectionRule
+        public static let name = NSAttributedString.Key.inflectionRule.rawValue
+        public static let markdownName = "inflect"
+    }
+
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum LanguageIdentifierAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        public typealias Value = String
+        public static let name = NSAttributedString.Key.language.rawValue
+        public static let markdownName = "languageIdentifier"
+    }
+    
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum PersonNameComponentAttribute : CodableAttributedStringKey, ObjectiveCConvertibleAttributedStringKey {
+        public typealias Value = Component
+        public typealias ObjectiveCValue = NSString
+        public static let name = "NSPersonNameComponentKey"
+
+        public enum Component: String, Codable {
+            case givenName, familyName, middleName, namePrefix, nameSuffix, nickname, delimiter
+        }
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public struct NumberFormatAttributes: AttributeScope {
+        public let numberSymbol: SymbolAttribute
+        public let numberPart: NumberPartAttribute
+
+        @frozen
+        public enum NumberPartAttribute : CodableAttributedStringKey {
+            public enum NumberPart : Int, Codable {
+                case integer
+                case fraction
+            }
+
+            public static let name = "Foundation.NumberFormatPart"
+            public typealias Value = NumberPart
+        }
+
+        @frozen
+        public enum SymbolAttribute : CodableAttributedStringKey {
+            public enum Symbol : Int, Codable {
+                case groupingSeparator
+                case sign
+                case decimalSeparator
+                case currency
+                case percent
+            }
+
+            public static let name = "Foundation.NumberFormatSymbol"
+            public typealias Value = Symbol
+        }
+    }
+
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum DateFieldAttribute : CodableAttributedStringKey {
+        public enum Field : Hashable, Codable {
+            case era
+            case year
+            /// For non-Gregorian calendars, this corresponds to the extended Gregorian year in which the calendar’s year begins.
+            case relatedGregorianYear
+            case quarter
+            case month
+            case weekOfYear
+            case weekOfMonth
+            case weekday
+            /// The ordinal position of the weekday unit within the month unit. For example, `2` in "2nd Wednesday in July"
+            case weekdayOrdinal
+            case day
+            case dayOfYear
+            case amPM
+            case hour
+            case minute
+            case second
+            case secondFraction
+            case timeZone
+
+            var rawValue: String {
+                switch self {
+                case .era:
+                    return "G"
+                case .year:
+                    return "y"
+                case .relatedGregorianYear:
+                    return "r"
+                case .quarter:
+                    return "Q"
+                case .month:
+                    return "M"
+                case .weekOfYear:
+                    return "w"
+                case .weekOfMonth:
+                    return "W"
+                case .weekday:
+                    return "E"
+                case .weekdayOrdinal:
+                    return "F"
+                case .day:
+                    return "d"
+                case .dayOfYear:
+                    return "D"
+                case .amPM:
+                    return "a"
+                case .hour:
+                    return "h"
+                case .minute:
+                    return "m"
+                case .second:
+                    return "s"
+                case .secondFraction:
+                    return "S"
+                case .timeZone:
+                    return "z"
+                }
+            }
+
+            init?(rawValue: String) {
+                let mappings: [String: Self] = [
+                    "G": .era,
+                    "y": .year,
+                    "Y": .year,
+                    "u": .year,
+                    "U": .year,
+                    "r": .relatedGregorianYear,
+                    "Q": .quarter,
+                    "q": .quarter,
+                    "M": .month,
+                    "L": .month,
+                    "w": .weekOfYear,
+                    "W": .weekOfMonth,
+                    "e": .weekday,
+                    "c": .weekday,
+                    "E": .weekday,
+                    "F": .weekdayOrdinal,
+                    "d": .day,
+                    "g": .day,
+                    "D": .dayOfYear,
+                    "a": .amPM,
+                    "b": .amPM,
+                    "B": .amPM,
+                    "h": .hour,
+                    "H": .hour,
+                    "k": .hour,
+                    "K": .hour,
+                    "m": .minute,
+                    "s": .second,
+                    "A": .second,
+                    "S": .secondFraction,
+                    "v": .timeZone,
+                    "z": .timeZone,
+                    "Z": .timeZone,
+                    "O": .timeZone,
+                    "V": .timeZone,
+                    "X": .timeZone,
+                    "x": .timeZone,
+                ]
+
+                guard let field = mappings[rawValue] else {
+                    return nil
+                }
+                self = field
+            }
+
+            // Codable
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let rawValue = try container.decode(String.self)
+                guard let field = Field(rawValue: rawValue) else {
+                    throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Invalid Field pattern <\(rawValue)>."))
+                }
+                self = field
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(rawValue)
+            }
+        }
+
+        public static let name = "Foundation.DateFormatField"
+        public typealias Value = Field
+    }
+
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum InflectionAlternativeAttribute : CodableAttributedStringKey, MarkdownDecodableAttributedStringKey, ObjectiveCConvertibleAttributedStringKey {
+        public typealias Value = AttributedString
+        public typealias ObjectiveCValue = NSObject
+        public static let name = NSAttributedString.Key.inflectionAlternative.rawValue
+        public static let markdownName = "inflectionAlternative"
+        
+        public static func objectiveCValue(for value: AttributedString) throws -> NSObject {
+            try NSAttributedString(value, including: \.foundation)
+        }
+        
+        public static func value(for object: NSObject) throws -> AttributedString {
+            if let attrString = object as? NSAttributedString {
+                return try AttributedString(attrString, including: \.foundation)
+            } else {
+                throw CocoaError(.coderInvalidValue)
+            }
+        }
+    }
+
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum ReplacementIndexAttribute : CodableAttributedStringKey {
+        public typealias Value = Int
+        public static let name = "NSReplacementIndex"
+    }
+
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public struct MeasurementAttribute: CodableAttributedStringKey {
+        public typealias Value = Component
+        public static let name = "Foundation.MeasurementAttribute"
+        public enum Component: Int, Codable {
+            case value
+            case unit
+        }
+    }
+    
+    @frozen
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    public enum ByteCountAttribute: CodableAttributedStringKey {
+        public typealias Value = Component
+        public static let name = "Foundation.ByteCountAttribute"
+        public enum Component: Codable, Hashable {
+            case value
+            case spelledOutValue
+            case unit(Unit)
+            case actualByteCount
+        }
+        
+        public enum Unit: Codable {
+            case byte
+            case kb
+            case mb
+            case gb
+            case tb
+            case pb
+            case eb
+            case zb
+            case yb
+        }
+    }
+}

--- a/Sources/Foundation/Bridging.swift
+++ b/Sources/Foundation/Bridging.swift
@@ -230,25 +230,23 @@ internal final class __SwiftValue : NSObject, NSCopying {
 // MARK: AnyHashable Bridging
 extension AnyHashable : _ObjectiveCBridgeable {
     public func _bridgeToObjectiveC() -> NSObject {
-        // This is unprincipled, but pretty much any object we'll encounter in
-        // Swift is NSObject-conforming enough to have -hash and -isEqual:.
-        return unsafeBitCast(base as AnyObject, to: NSObject.self)
+        return __SwiftValue.store(base)
     }
-    
+
     public static func _forceBridgeFromObjectiveC(_ x: NSObject, result: inout AnyHashable?) {
-        result = AnyHashable(x)
+        result = (__SwiftValue.fetch(x) as? AnyHashable) ?? AnyHashable(x)
     }
-    
+
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSObject, result: inout AnyHashable?) -> Bool {
         self._forceBridgeFromObjectiveC(x, result: &result)
         return result != nil
     }
-    
+
     @_effects(readonly)
     public static func _unconditionallyBridgeFromObjectiveC(_ source: NSObject?) -> AnyHashable {
         // `nil` has historically been used as a stand-in for an empty
         // string; map it to an empty string.
         if _slowPath(source == nil) { return AnyHashable(String()) }
-        return AnyHashable(source!)
+        return (__SwiftValue.fetch(source) as? AnyHashable) ?? AnyHashable(source!)
     }
 }

--- a/Sources/Foundation/Bridging.swift
+++ b/Sources/Foundation/Bridging.swift
@@ -226,3 +226,29 @@ internal final class __SwiftValue : NSObject, NSCopying {
 
     override var description: String { String(describing: value) }
 }
+
+// MARK: AnyHashable Bridging
+extension AnyHashable : _ObjectiveCBridgeable {
+    public func _bridgeToObjectiveC() -> NSObject {
+        // This is unprincipled, but pretty much any object we'll encounter in
+        // Swift is NSObject-conforming enough to have -hash and -isEqual:.
+        return unsafeBitCast(base as AnyObject, to: NSObject.self)
+    }
+    
+    public static func _forceBridgeFromObjectiveC(_ x: NSObject, result: inout AnyHashable?) {
+        result = AnyHashable(x)
+    }
+    
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSObject, result: inout AnyHashable?) -> Bool {
+        self._forceBridgeFromObjectiveC(x, result: &result)
+        return result != nil
+    }
+    
+    @_effects(readonly)
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSObject?) -> AnyHashable {
+        // `nil` has historically been used as a stand-in for an empty
+        // string; map it to an empty string.
+        if _slowPath(source == nil) { return AnyHashable(String()) }
+        return AnyHashable(source!)
+    }
+}

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -1,6 +1,11 @@
 add_library(Foundation
   AffineTransform.swift
   Array.swift
+  AttributedString/AttributedString.swift
+  AttributedString/AttributedStringAttribute.swift
+  AttributedString/AttributedStringCodable.swift
+  AttributedString/AttributedStringRunCoalescing.swift
+  AttributedString/AttributedString+Locking.swift
   Boxing.swift
   Bridging.swift
   Bundle.swift
@@ -11,6 +16,7 @@ add_library(Foundation
   Codable.swift
   Collections+DataProtocol.swift
   ContiguousBytes.swift
+  AttributedString/Conversion.swift
   Data.swift
   DataProtocol.swift
   Date.swift
@@ -30,6 +36,7 @@ add_library(Foundation
   FileManager+Win32.swift
   FileManager+XDG.swift
   Formatter.swift
+  AttributedString/FoundationAttributes.swift
   FoundationErrors.swift
   Host.swift
   IndexPath.swift
@@ -44,6 +51,7 @@ add_library(Foundation
   MassFormatter.swift
   Measurement.swift
   MeasurementFormatter.swift
+  Morphology.swift
   Notification.swift
   NotificationQueue.swift
   NSArray.swift

--- a/Sources/Foundation/Morphology.swift
+++ b/Sources/Foundation/Morphology.swift
@@ -342,8 +342,8 @@ extension Morphology {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension NSAttributedString.Key {
-    internal static var morphology = NSAttributedString.Key(rawValue: "NSMorphology")
-    internal static var inflectionRule = NSAttributedString.Key(rawValue: "NSInflect")
-    internal static var inflectionAlternative = NSAttributedString.Key(rawValue: "NSInflectionAlternative")
-    internal static var language = NSAttributedString.Key(rawValue: "NSLanguage")
+    public static let morphology = NSAttributedString.Key(rawValue: "NSMorphology")
+    public static let inflectionRule = NSAttributedString.Key(rawValue: "NSInflect")
+    public static let inflectionAlternative = NSAttributedString.Key(rawValue: "NSInflectionAlternative")
+    public static let language = NSAttributedString.Key(rawValue: "NSLanguage")
 }

--- a/Sources/Foundation/Morphology.swift
+++ b/Sources/Foundation/Morphology.swift
@@ -1,0 +1,349 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+public struct Morphology {
+    public init() {}
+    
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    public enum GrammaticalGender: Int, Hashable {
+        case feminine  = 1
+        case masculine
+        case neuter
+    }
+    public var grammaticalGender: GrammaticalGender?
+
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    public enum PartOfSpeech: Int, Hashable {
+        case determiner = 1
+        case pronoun
+        case letter
+        case adverb
+        case particle
+        case adjective
+        case adposition
+        case verb
+        case noun
+        case conjunction
+        case numeral
+        case interjection
+        case preposition
+        case abbreviation
+    }
+    public var partOfSpeech: PartOfSpeech?
+
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    public enum GrammaticalNumber: Int, Hashable {
+        case singular = 1
+        case zero
+        case plural
+        case pluralTwo
+        case pluralFew
+        case pluralMany
+    }
+    public var number: GrammaticalNumber?
+    
+    fileprivate var customPronouns: [String: CustomPronoun] = [:]
+}
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+public enum InflectionRule {
+    case automatic
+    case explicit(Morphology)
+
+    public init(morphology: Morphology) {
+        self = .explicit(morphology)
+    }
+}
+
+// MARK: -
+// MARK: Equatable & Hashable Support
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology: Hashable {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology.CustomPronoun: Hashable {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension InflectionRule: Hashable {}
+
+// MARK: -
+// MARK: Codable Support
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology: Codable {
+    enum CodingKeys: String, CodingKey {
+        case grammaticalGender
+        case partOfSpeech
+        case number
+        case customPronouns
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.grammaticalGender = try container.decodeIfPresent(GrammaticalGender.self, forKey: .grammaticalGender)
+        self.partOfSpeech = try container.decodeIfPresent(PartOfSpeech.self, forKey: .partOfSpeech)
+        self.number = try container.decodeIfPresent(GrammaticalNumber.self, forKey: .number)
+        self.customPronouns = try container.decodeIfPresent([String: CustomPronoun].self, forKey: .customPronouns) ?? [:]
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let grammaticalGender = grammaticalGender {
+            try container.encode(grammaticalGender, forKey: .grammaticalGender)
+        }
+        if let partOfSpeech = partOfSpeech {
+            try container.encode(partOfSpeech, forKey: .partOfSpeech)
+        }
+        if let number = number {
+            try container.encode(number, forKey: .number)
+        }
+        if !customPronouns.isEmpty {
+            try container.encode(customPronouns, forKey: .customPronouns)
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology.CustomPronoun: Codable {}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology.GrammaticalGender: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "feminine":  self = .feminine
+        case "masculine": self = .masculine
+        case "neuter":    self = .neuter
+        default: throw CocoaError(.coderInvalidValue)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .feminine:  try container.encode("feminine")
+        case .masculine: try container.encode("masculine")
+        case .neuter:    try container.encode("neuter")
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology.GrammaticalNumber: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "one":   self = .singular
+        case "zero":  self = .zero
+        case "other": self = .plural
+        case "two":   self = .pluralTwo
+        case "few":   self = .pluralFew
+        case "many":  self = .pluralMany
+        default: throw CocoaError(.coderInvalidValue)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .singular:   try container.encode("one")
+        case .zero:       try container.encode("zero")
+        case .plural:     try container.encode("other")
+        case .pluralTwo:  try container.encode("two")
+        case .pluralFew:  try container.encode("few")
+        case .pluralMany: try container.encode("many")
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology.PartOfSpeech: Codable {
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        switch try container.decode(String.self) {
+        case "determiner":   self = .determiner
+        case "pronoun":      self = .pronoun
+        case "letter":       self = .letter
+        case "adverb":       self = .adverb
+        case "particle":     self = .particle
+        case "adjective":    self = .adjective
+        case "adposition":   self = .adposition
+        case "verb":         self = .verb
+        case "noun":         self = .noun
+        case "conjunction":  self = .conjunction
+        case "numeral":      self = .numeral
+        case "interjection": self = .interjection
+        case "preposition":  self = .preposition
+        case "abbreviation": self = .abbreviation
+        default: throw CocoaError(.coderInvalidValue)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .determiner:   try container.encode("determiner")
+        case .pronoun:      try container.encode("pronoun")
+        case .letter:       try container.encode("letter")
+        case .adverb:       try container.encode("adverb")
+        case .particle:     try container.encode("particle")
+        case .adjective:    try container.encode("adjective")
+        case .adposition:   try container.encode("adposition")
+        case .verb:         try container.encode("verb")
+        case .noun:         try container.encode("noun")
+        case .conjunction:  try container.encode("conjunction")
+        case .numeral:      try container.encode("numeral")
+        case .interjection: try container.encode("interjection")
+        case .preposition:  try container.encode("preposition")
+        case .abbreviation: try container.encode("abbreviation")
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension InflectionRule: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let it = try? container.decode(Bool.self), it == true {
+            self = .automatic
+        } else {
+            let it = try container.decode(Morphology.self)
+            self = .explicit(it)
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .automatic:                try container.encode(true)
+        case .explicit(let morphology): try container.encode(morphology)
+        }
+    }
+}
+
+// MARK: -
+// MARK: Inflection Availability
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension InflectionRule {
+    // Whether inflection will edit strings for the specified language, specified as a BCP 47 language identifier.
+    public static func canInflect(language: String) -> Bool {
+        return false
+    }
+    
+    // Whether inflection will edit strings for the language of the user's
+    // current preferred localization. Does not change throughout the lifetime
+    // of a process.
+    public static var canInflectPreferredLocalization: Bool {
+        return false
+    }
+}
+
+// MARK: -
+// MARK: Per-Language Features
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology.CustomPronoun {
+    static func keyPath(forObjectiveCKey stringKey: String) -> KeyPath<Self, String?>? {
+        switch stringKey {
+        case "subjectForm": return \Self.subjectForm
+        case "objectForm": return \Self.objectForm
+        case "possessiveForm": return \Self.possessiveForm
+        case "possessiveAdjectiveForm": return \Self.possessiveAdjectiveForm
+        case "reflexiveForm": return \Self.reflexiveForm
+        default: return nil
+        }
+    }
+    
+    func value(forObjectiveCKey stringKey: String) -> Any? {
+        if let path = Self.keyPath(forObjectiveCKey: stringKey) {
+            return self[keyPath: path]
+        } else {
+            return nil
+        }
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension Morphology {
+    public func customPronoun(forLanguage language: String) -> CustomPronoun? {
+        return customPronouns[language.lowercased()]
+    }
+    
+    mutating public func setCustomPronoun(_ pronoun: CustomPronoun?, forLanguage language: String) throws {
+        if let pronoun = pronoun {
+            let result = pronoun.validate(forLanguage: language)
+            if !result {
+                throw CocoaError(.keyValueValidation)
+            }
+        }
+        
+        customPronouns[language.lowercased()] = pronoun
+    }
+
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    public struct CustomPronoun {
+        public init() {}
+
+        public static func isSupported(forLanguage language: String) -> Bool {
+            let indexAtTwo = language.index(language.startIndex, offsetBy: 2)
+            // For now we only support English custom pronoun
+            return language.count >= 2 &&
+                language.lowercased().starts(with: "en") &&
+                (language.count == 2 ||
+                 language[indexAtTwo ..< language.index(after: indexAtTwo)] == "-" ||
+                 language[indexAtTwo ..< language.index(after: indexAtTwo)] == "_")
+        }
+
+        public static func requiredKeys(forLanguage language: String) -> [PartialKeyPath<Self>] {
+            guard self.isSupported(forLanguage: language) else {
+                return []
+            }
+            return [\.subjectForm, \.objectForm, \.possessiveForm, \.possessiveAdjectiveForm, \.reflexiveForm]
+        }
+        
+        fileprivate func validate(forLanguage language: String) -> Bool {
+            guard Self.isSupported(forLanguage: language) else {
+                return false
+            }
+            
+            for keyPath in Self.requiredKeys(forLanguage: language) {
+                let value: Any? = self[keyPath: keyPath]
+                if value == nil {
+                    return false
+                }
+            }
+            
+            return true
+        }
+
+        public var subjectForm: String?
+        public var objectForm: String?
+        public var possessiveForm: String?
+        public var possessiveAdjectiveForm: String?
+        public var reflexiveForm: String?
+    }
+}
+
+// MARK: -
+// MARK: NSAttributedString Keys
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension NSAttributedString.Key {
+    internal static var morphology = NSAttributedString.Key(rawValue: "NSMorphology")
+    internal static var inflectionRule = NSAttributedString.Key(rawValue: "NSInflect")
+    internal static var inflectionAlternative = NSAttributedString.Key(rawValue: "NSInflectionAlternative")
+    internal static var language = NSAttributedString.Key(rawValue: "NSLanguage")
+}

--- a/Tests/Foundation/CMakeLists.txt
+++ b/Tests/Foundation/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(TestFoundation
 # Test Cases
 target_sources(TestFoundation PRIVATE
   Tests/TestAffineTransform.swift
+  Tests/TestAttributedString.swift
+  Tests/TestAttributedStringCOW.swift
+  Tests/TestAttributedStringPerformance.swift
+  Tests/TestAttributedStringSupport.swift
   Tests/TestBridging.swift
   Tests/TestBundle.swift
   Tests/TestByteCountFormatter.swift

--- a/Tests/Foundation/Tests/TestAttributedString.swift
+++ b/Tests/Foundation/Tests/TestAttributedString.swift
@@ -1,0 +1,2273 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
+
+/// Regression and coverage tests for `AttributedString` and its associated objects
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+final class TestAttributedString: XCTestCase {
+    // MARK: - Enumeration Tests
+
+    func testEmptyEnumeration() {
+        for _ in AttributedString().runs {
+            XCTFail("Empty AttributedString should not enumerate any attributes")
+        }
+    }
+
+    func verifyAttributes<T>(_ runs: AttributedString.Runs.AttributesSlice1<T>, string: AttributedString, expectation: [(String, T.Value?)]) {
+        // Test that the attribute is correct when iterating through attribute runs
+        var expectIterator = expectation.makeIterator()
+        for (attribute, range) in runs {
+            let expected = expectIterator.next()!
+            XCTAssertEqual(String(string[range].characters), expected.0, "Substring of AttributedString characters for range of run did not match expectation")
+            XCTAssertEqual(attribute, expected.1, "Attribute of run did not match expectation")
+        }
+        XCTAssertNil(expectIterator.next(), "Additional runs expected but not found")
+
+        // Test that the attribute is correct when iterating through reversed attribute runs
+        expectIterator = expectation.reversed().makeIterator()
+        for (attribute, range) in runs.reversed() {
+            let expected = expectIterator.next()!
+            XCTAssertEqual(String(string[range].characters), expected.0, "Substring of AttributedString characters for range of run did not match expectation")
+            XCTAssertEqual(attribute, expected.1, "Attribute of run did not match expectation")
+        }
+        XCTAssertNil(expectIterator.next(), "Additional runs expected but not found")
+    }
+
+    func verifyAttributes<T, U>(_ runs: AttributedString.Runs.AttributesSlice2<T, U>, string: AttributedString, expectation: [(String, T.Value?, U.Value?)]) {
+        // Test that the attributes are correct when iterating through attribute runs
+        var expectIterator = expectation.makeIterator()
+        for (attribute, attribute2, range) in runs {
+            let expected = expectIterator.next()!
+            XCTAssertEqual(String(string[range].characters), expected.0, "Substring of AttributedString characters for range of run did not match expectation")
+            XCTAssertEqual(attribute, expected.1, "Attribute of run did not match expectation")
+            XCTAssertEqual(attribute2, expected.2, "Attribute of run did not match expectation")
+        }
+        XCTAssertNil(expectIterator.next(), "Additional runs expected but not found")
+
+        // Test that the attributes are correct when iterating through reversed attribute runs
+        expectIterator = expectation.reversed().makeIterator()
+        for (attribute, attribute2, range) in runs.reversed() {
+            let expected = expectIterator.next()!
+            XCTAssertEqual(String(string[range].characters), expected.0, "Substring of AttributedString characters for range of run did not match expectation")
+            XCTAssertEqual(attribute, expected.1, "Attribute of run did not match expectation")
+            XCTAssertEqual(attribute2, expected.2, "Attribute of run did not match expectation")
+        }
+        XCTAssertNil(expectIterator.next(), "Additional runs expected but not found")
+    }
+
+    func testSimpleEnumeration() {
+        var attrStr = AttributedString("Hello", attributes: AttributeContainer().testInt(1))
+        attrStr += " "
+        attrStr += AttributedString("World", attributes: AttributeContainer().testDouble(2.0))
+
+        let expectation = [("Hello", 1, nil), (" ", nil, nil), ("World", nil, 2.0)]
+        var expectationIterator = expectation.makeIterator()
+        for run in attrStr.runs {
+            let expected = expectationIterator.next()!
+            XCTAssertEqual(String(attrStr[run.range].characters), expected.0)
+            XCTAssertEqual(run.testInt, expected.1)
+            XCTAssertEqual(run.testDouble, expected.2)
+            XCTAssertNil(run.testString)
+        }
+        XCTAssertNil(expectationIterator.next())
+
+        expectationIterator = expectation.reversed().makeIterator()
+        for run in attrStr.runs.reversed() {
+            let expected = expectationIterator.next()!
+            XCTAssertEqual(String(attrStr[run.range].characters), expected.0)
+            XCTAssertEqual(run.testInt, expected.1)
+            XCTAssertEqual(run.testDouble, expected.2)
+            XCTAssertNil(run.testString)
+        }
+        XCTAssertNil(expectationIterator.next())
+
+        let attrView = attrStr.runs
+        verifyAttributes(attrView[\.testInt], string: attrStr, expectation: [("Hello", 1), (" World", nil)])
+        verifyAttributes(attrView[\.testDouble], string: attrStr, expectation: [("Hello ", nil), ("World", 2.0)])
+        verifyAttributes(attrView[\.testString], string: attrStr, expectation: [("Hello World", nil)])
+        verifyAttributes(attrView[\.testInt, \.testDouble], string: attrStr, expectation: [("Hello", 1, nil), (" ", nil, nil), ("World", nil, 2.0)])
+    }
+
+    func testSliceEnumeration() {
+        var attrStr = AttributedString("Hello", attributes: AttributeContainer().testInt(1))
+        attrStr += AttributedString(" ")
+        attrStr += AttributedString("World", attributes: AttributeContainer().testDouble(2.0))
+
+        let attrStrSlice = attrStr[attrStr.characters.index(attrStr.startIndex, offsetBy: 3) ..< attrStr.characters.index(attrStr.endIndex, offsetBy: -3)]
+
+        let expectation = [("lo", 1, nil), (" ", nil, nil), ("Wo", nil, 2.0)]
+        var expectationIterator = expectation.makeIterator()
+        for run in attrStrSlice.runs {
+            let expected = expectationIterator.next()!
+            XCTAssertEqual(String(attrStr[run.range].characters), expected.0)
+            XCTAssertEqual(run.testInt, expected.1)
+            XCTAssertEqual(run.testDouble, expected.2)
+            XCTAssertNil(run.testString)
+        }
+        XCTAssertNil(expectationIterator.next())
+
+        expectationIterator = expectation.reversed().makeIterator()
+        for run in attrStrSlice.runs.reversed() {
+            let expected = expectationIterator.next()!
+            XCTAssertEqual(String(attrStr[run.range].characters), expected.0)
+            XCTAssertEqual(run.testInt, expected.1)
+            XCTAssertEqual(run.testDouble, expected.2)
+            XCTAssertNil(run.testString)
+        }
+        XCTAssertNil(expectationIterator.next())
+
+        let attrView = attrStrSlice.runs
+        verifyAttributes(attrView[\.testInt], string: attrStr, expectation: [("lo", 1), (" Wo", nil)])
+        verifyAttributes(attrView[\.testDouble], string: attrStr, expectation: [("lo ", nil), ("Wo", 2.0)])
+        verifyAttributes(attrView[\.testString], string: attrStr, expectation: [("lo Wo", nil)])
+        verifyAttributes(attrView[\.testInt, \.testDouble], string: attrStr, expectation: [("lo", 1, nil), (" ", nil, nil), ("Wo", nil, 2.0)])
+    }
+
+    // MARK: - Attribute Tests
+
+    func testSimpleAttribute() {
+        let attrStr = AttributedString("Foo", attributes: AttributeContainer().testInt(42))
+        let (value, range) = attrStr.runs[\.testInt][attrStr.startIndex]
+        XCTAssertEqual(value, 42)
+        XCTAssertEqual(range, attrStr.startIndex ..< attrStr.endIndex)
+    }
+
+    func testConstructorAttribute() {
+        // TODO: Re-evaluate whether we want these.
+        let attrStr = AttributedString("Hello", attributes: AttributeContainer().testString("Helvetica").testInt(2))
+        var expected = AttributedString("Hello")
+        expected.testString = "Helvetica"
+        expected.testInt = 2
+        XCTAssertEqual(attrStr, expected)
+    }
+
+    func testAddAndRemoveAttribute() {
+        let attr : Int = 42
+        let attr2 : Double = 1.0
+        var attrStr = AttributedString("Test")
+        attrStr.testInt = attr
+        attrStr.testDouble = attr2
+
+        let expected1 = AttributedString("Test", attributes: AttributeContainer().testInt(attr).testDouble(attr2))
+        XCTAssertEqual(attrStr, expected1)
+
+        attrStr.testDouble = nil
+
+        let expected2 = AttributedString("Test", attributes: AttributeContainer().testInt(attr))
+        XCTAssertEqual(attrStr, expected2)
+    }
+
+    func testAddingAndRemovingAttribute() {
+        let container = AttributeContainer().testInt(1).testDouble(2.2)
+        let attrStr = AttributedString("Test").mergingAttributes(container)
+        let expected = AttributedString("Test", attributes: AttributeContainer().testInt(1).testDouble(2.2))
+        XCTAssertEqual(attrStr, expected)
+        var doubleRemoved = attrStr
+        doubleRemoved.testDouble = nil
+        XCTAssertEqual(doubleRemoved, AttributedString("Test", attributes: AttributeContainer().testInt(1)))
+    }
+    
+    func testScopedAttributes() {
+        var str = AttributedString("Hello, world", attributes: AttributeContainer().testInt(2).testDouble(3.4))
+        XCTAssertEqual(str.test.testInt, 2)
+        XCTAssertEqual(str.test.testDouble, 3.4)
+        XCTAssertEqual(str.runs[str.runs.startIndex].test.testInt, 2)
+        
+        str.test.testInt = 4
+        XCTAssertEqual(str, AttributedString("Hello, world", attributes: AttributeContainer.testInt(4).testDouble(3.4)))
+        
+        let range = str.startIndex ..< str.characters.index(after: str.startIndex)
+        str[range].test.testBool = true
+        XCTAssertNil(str.test.testBool)
+        XCTAssertNotNil(str[range].test.testBool)
+        XCTAssertTrue(str[range].test.testBool!)
+    }
+
+    func testRunAttributes() {
+        var str = AttributedString("String", attributes: .init().testString("test1"))
+        str += "None"
+        str += AttributedString("String+Int", attributes: .init().testString("test2").testInt(42))
+
+        let attributes = str.runs.map { $0.attributes }
+        XCTAssertEqual(attributes.count, 3)
+        XCTAssertEqual(attributes[0], .init().testString("test1"))
+        XCTAssertEqual(attributes[1], .init())
+        XCTAssertEqual(attributes[2], .init().testString("test2").testInt(42))
+    }
+
+    // MARK: - Comparison Tests
+
+    func testAttributedStringEquality() {
+        XCTAssertEqual(AttributedString(), AttributedString())
+        XCTAssertEqual(AttributedString("abc"), AttributedString("abc"))
+        XCTAssertEqual(AttributedString("abc", attributes: AttributeContainer().testInt(1)), AttributedString("abc", attributes: AttributeContainer().testInt(1)))
+        XCTAssertNotEqual(AttributedString("abc", attributes: AttributeContainer().testInt(1)), AttributedString("abc", attributes: AttributeContainer().testInt(2)))
+        XCTAssertNotEqual(AttributedString("abc", attributes: AttributeContainer().testInt(1)), AttributedString("def", attributes: AttributeContainer().testInt(1)))
+
+        var a = AttributedString("abc", attributes: AttributeContainer().testInt(1))
+        a += AttributedString("def", attributes: AttributeContainer().testInt(1))
+        XCTAssertEqual(a, AttributedString("abcdef", attributes: AttributeContainer().testInt(1)))
+
+        a = AttributedString("ab", attributes: AttributeContainer().testInt(1))
+        a += AttributedString("cdef", attributes: AttributeContainer().testInt(2))
+        var b = AttributedString("abcd", attributes: AttributeContainer().testInt(1))
+        b += AttributedString("ef", attributes: AttributeContainer().testInt(2))
+        XCTAssertNotEqual(a, b)
+
+        a = AttributedString("abc")
+        a += AttributedString("defghi", attributes: AttributeContainer().testInt(2))
+        a += "jkl"
+        b = AttributedString("abc")
+        b += AttributedString("def", attributes: AttributeContainer().testInt(2))
+        b += "ghijkl"
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testAttributedSubstringEquality() {
+        let emptyStr = AttributedString("01234567890123456789")
+
+        let index0 = emptyStr.characters.startIndex
+        let index5 = emptyStr.characters.index(index0, offsetBy: 5)
+        let index10 = emptyStr.characters.index(index0, offsetBy: 10)
+        let index20 = emptyStr.characters.index(index0, offsetBy: 20)
+
+        var singleAttrStr = emptyStr
+        singleAttrStr[index0 ..< index10].testInt = 1
+
+        var halfhalfStr = emptyStr
+        halfhalfStr[index0 ..< index10].testInt = 1
+        halfhalfStr[index10 ..< index20].testDouble = 2.0
+
+        XCTAssertEqual(emptyStr[index0 ..< index0], emptyStr[index0 ..< index0])
+        XCTAssertEqual(emptyStr[index0 ..< index5], emptyStr[index0 ..< index5])
+        XCTAssertEqual(emptyStr[index0 ..< index20], emptyStr[index0 ..< index20])
+        XCTAssertEqual(singleAttrStr[index0 ..< index20], singleAttrStr[index0 ..< index20])
+        XCTAssertEqual(halfhalfStr[index0 ..< index20], halfhalfStr[index0 ..< index20])
+
+        XCTAssertEqual(emptyStr[index0 ..< index10], singleAttrStr[index10 ..< index20])
+        XCTAssertEqual(halfhalfStr[index0 ..< index10], singleAttrStr[index0 ..< index10])
+
+        XCTAssertNotEqual(emptyStr[index0 ..< index10], singleAttrStr[index0 ..< index10])
+        XCTAssertNotEqual(emptyStr[index0 ..< index10], singleAttrStr[index0 ..< index20])
+
+        XCTAssertTrue(emptyStr[index0 ..< index5] == AttributedString("01234"))
+    }
+    
+    func testRunEquality() {
+        var attrStr = AttributedString("Hello", attributes: AttributeContainer().testInt(1))
+        attrStr += AttributedString(" ")
+        attrStr += AttributedString("World", attributes: AttributeContainer().testInt(2))
+        
+        var attrStr2 = AttributedString("Hello", attributes: AttributeContainer().testInt(2))
+        attrStr2 += AttributedString("_")
+        attrStr2 += AttributedString("World", attributes: AttributeContainer().testInt(2))
+        attrStr2 += AttributedString("Hello", attributes: AttributeContainer().testInt(1))
+        
+        var attrStr3 = AttributedString("Hel", attributes: AttributeContainer().testInt(1))
+        attrStr3 += AttributedString("lo W")
+        attrStr3 += AttributedString("orld", attributes: AttributeContainer().testInt(2))
+        
+        func run(_ num: Int, in str: AttributedString) -> AttributedString.Runs.Run {
+            return str.runs[str.runs.index(str.runs.startIndex, offsetBy: num)]
+        }
+        
+        // Same string, same range, different attributes
+        XCTAssertNotEqual(run(0, in: attrStr), run(0, in: attrStr2))
+        
+        // Different strings, same range, same attributes
+        XCTAssertEqual(run(1, in: attrStr), run(1, in: attrStr2))
+        
+        // Same string, same range, same attributes
+        XCTAssertEqual(run(2, in: attrStr), run(2, in: attrStr2))
+        
+        // Different string, different range, same attributes
+        XCTAssertEqual(run(2, in: attrStr), run(0, in: attrStr2))
+        
+        // Same string, different range, same attributes
+        XCTAssertEqual(run(0, in: attrStr), run(3, in: attrStr2))
+        
+        // A runs collection of the same order but different run lengths
+        XCTAssertNotEqual(attrStr.runs, attrStr3.runs)
+    }
+    
+    func testSubstringRunEquality() {
+        var attrStr = AttributedString("Hello", attributes: AttributeContainer().testInt(1))
+        attrStr += AttributedString(" ")
+        attrStr += AttributedString("World", attributes: AttributeContainer().testInt(2))
+        
+        var attrStr2 = AttributedString("Hello", attributes: AttributeContainer().testInt(2))
+        attrStr2 += AttributedString("_")
+        attrStr2 += AttributedString("World", attributes: AttributeContainer().testInt(2))
+        
+        XCTAssertEqual(attrStr[attrStr.runs.last!.range].runs, attrStr2[attrStr2.runs.first!.range].runs)
+        XCTAssertEqual(attrStr[attrStr.runs.last!.range].runs, attrStr2[attrStr2.runs.last!.range].runs)
+        
+        let rangeA = attrStr.runs.first!.range.upperBound ..< attrStr.endIndex
+        let rangeB = attrStr2.runs.first!.range.upperBound ..< attrStr.endIndex
+        let rangeC = attrStr.startIndex ..< attrStr.runs.last!.range.lowerBound
+        let rangeD = attrStr.runs.first!.range
+        XCTAssertEqual(attrStr[rangeA].runs, attrStr2[rangeB].runs)
+        XCTAssertNotEqual(attrStr[rangeC].runs, attrStr2[rangeB].runs)
+        XCTAssertNotEqual(attrStr[rangeD].runs, attrStr2[rangeB].runs)
+        
+        // Test starting/ending runs that only differ outside of the range do not prevent equality
+        attrStr2[attrStr.runs.first!.range].testInt = 1
+        attrStr2.characters.insert(contentsOf: "123", at: attrStr.startIndex)
+        attrStr2.characters.append(contentsOf: "45")
+        let rangeE = attrStr.startIndex ..< attrStr.endIndex
+        let rangeF = attrStr2.characters.index(attrStr2.startIndex, offsetBy: 3) ..< attrStr2.characters.index(attrStr2.startIndex, offsetBy: 14)
+        XCTAssertEqual(attrStr[rangeE].runs, attrStr2[rangeF].runs)
+    }
+
+    // MARK: - Mutation Tests
+
+    func testDirectMutationCopyOnWrite() {
+        var attrStr = AttributedString("ABC")
+        let copy = attrStr
+        attrStr += "D"
+
+        XCTAssertEqual(copy, AttributedString("ABC"))
+        XCTAssertNotEqual(attrStr, copy)
+    }
+
+    func testAttributeMutationCopyOnWrite() {
+        var attrStr = AttributedString("ABC")
+        let copy = attrStr
+        attrStr.testInt = 1
+
+        XCTAssertNotEqual(attrStr, copy)
+    }
+
+    func testSliceAttributeMutation() {
+        let attr : Int = 42
+        let attr2 : Double = 1.0
+
+        var attrStr = AttributedString("Hello World", attributes: AttributeContainer().testInt(attr))
+        let copy = attrStr
+
+        let chars = attrStr.characters
+        let start = chars.startIndex
+        let end = chars.index(start, offsetBy: 5)
+        attrStr[start ..< end].testDouble = attr2
+
+        var expected = AttributedString("Hello", attributes: AttributeContainer().testInt(attr).testDouble(attr2))
+        expected += AttributedString(" World", attributes: AttributeContainer().testInt(attr))
+        XCTAssertEqual(attrStr, expected)
+
+        XCTAssertNotEqual(copy, attrStr)
+    }
+
+    func testEnumerationAttributeMutation() {
+        var attrStr = AttributedString("A", attributes: AttributeContainer().testInt(1))
+        attrStr += AttributedString("B", attributes: AttributeContainer().testDouble(2.0))
+        attrStr += AttributedString("C", attributes: AttributeContainer().testInt(3))
+
+        for (attr, range) in attrStr.runs[\.testInt] {
+            if let _ = attr {
+                attrStr[range].testInt = nil
+            }
+        }
+
+        var expected = AttributedString("A")
+        expected += AttributedString("B", attributes: AttributeContainer().testDouble(2.0))
+        expected += "C"
+        XCTAssertEqual(expected, attrStr)
+    }
+
+    func testMutateMultipleAttributes() {
+        var attrStr = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(true))
+        attrStr += AttributedString("B", attributes: AttributeContainer().testInt(1).testDouble(2))
+        attrStr += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(false))
+
+        // Test removal
+        let removal1 = attrStr.transformingAttributes(\.testInt, \.testDouble, \.testBool) {
+            $0.value = nil
+            $1.value = nil
+            $2.value = nil
+        }
+        let removal1expected = AttributedString("ABC")
+        XCTAssertEqual(removal1expected, removal1)
+
+        // Test change value, same attribute.
+        let changeSame1 = attrStr.transformingAttributes(\.testInt, \.testDouble, \.testBool) {
+            if let _ = $0.value {
+                $0.value = 42
+            }
+            if let _ = $1.value {
+                $1.value = 3
+            }
+            if let boolean = $2.value {
+                $2.value = !boolean
+            }
+        }
+        var changeSame1expected = AttributedString("A", attributes: AttributeContainer().testInt(42).testBool(false))
+        changeSame1expected += AttributedString("B", attributes: AttributeContainer().testInt(42).testDouble(3))
+        changeSame1expected += AttributedString("C", attributes: AttributeContainer().testDouble(3).testBool(true))
+        XCTAssertEqual(changeSame1expected, changeSame1)
+
+        // Test change value, different attribute
+        let changeDifferent1 = attrStr.transformingAttributes(\.testInt, \.testDouble, \.testBool) {
+            if let _ = $0.value {
+                $0.replace(with: AttributeScopes.TestAttributes.TestDoubleAttribute.self, value: 2)
+            }
+            if let _ = $1.value {
+                $1.replace(with: AttributeScopes.TestAttributes.TestBoolAttribute.self, value: false)
+            }
+            if let _ = $2.value {
+                $2.replace(with: AttributeScopes.TestAttributes.TestIntAttribute.self, value: 42)
+            }
+        }
+
+        var changeDifferent1expected = AttributedString("A", attributes: AttributeContainer().testDouble(2).testInt(42))
+        changeDifferent1expected += AttributedString("B", attributes: AttributeContainer().testDouble(2).testBool(false))
+        changeDifferent1expected += AttributedString("C", attributes: AttributeContainer().testBool(false).testInt(42))
+        XCTAssertEqual(changeDifferent1expected, changeDifferent1)
+
+        // Test change range
+        var changeRange1First = true
+        let changeRange1 = attrStr.transformingAttributes(\.testInt, \.testDouble, \.testBool) {
+            if changeRange1First {
+                let range = $0.range
+                let extendedRange = range.lowerBound ..< attrStr.characters.index(after: range.upperBound)
+                $0.range = extendedRange
+                $1.range = extendedRange
+                $2.range = extendedRange
+                changeRange1First = false
+            }
+        }
+        var changeRange1expected = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(true))
+        changeRange1expected += AttributedString("B", attributes: AttributeContainer().testInt(1).testBool(true))
+        changeRange1expected += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(false))
+        XCTAssertEqual(changeRange1expected, changeRange1)
+    }
+
+    func testMutateAttributes() {
+        var attrStr = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(true))
+        attrStr += AttributedString("B", attributes: AttributeContainer().testInt(1).testDouble(2))
+        attrStr += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(false))
+        
+        // Test removal
+        let removal1 = attrStr.transformingAttributes(\.testInt) {
+            $0.value = nil
+        }
+        var removal1expected = AttributedString("A", attributes: AttributeContainer().testBool(true))
+        removal1expected += AttributedString("B", attributes: AttributeContainer().testDouble(2))
+        removal1expected += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(false))
+        XCTAssertEqual(removal1expected, removal1)
+
+        // Test change value, same attribute.
+        let changeSame1 = attrStr.transformingAttributes(\.testBool) {
+            if let boolean = $0.value {
+                $0.value = !boolean
+            }
+        }
+        var changeSame1expected = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(false))
+        changeSame1expected += AttributedString("B", attributes: AttributeContainer().testInt(1).testDouble(2))
+        changeSame1expected += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(true))
+        XCTAssertEqual(changeSame1expected, changeSame1)
+
+        // Test change value, different attribute
+        let changeDifferent1 = attrStr.transformingAttributes(\.testBool) {
+            if let value = $0.value {
+                $0.replace(with: AttributeScopes.TestAttributes.TestDoubleAttribute.self, value: (value ? 42 : 43))
+            }
+        }
+        var changeDifferent1expected = AttributedString("A", attributes: AttributeContainer().testInt(1).testDouble(42))
+        changeDifferent1expected += AttributedString("B", attributes: AttributeContainer().testInt(1).testDouble(2))
+        changeDifferent1expected += AttributedString("C", attributes: AttributeContainer().testDouble(43))
+        XCTAssertEqual(changeDifferent1expected, changeDifferent1)
+
+        // Test change range
+        let changeRange1 = attrStr.transformingAttributes(\.testInt) {
+            if let _ = $0.value {
+                // Shorten the range by one.
+                $0.range = $0.range.lowerBound ..< attrStr.characters.index(before: $0.range.upperBound)
+            }
+        }
+        var changeRange1expected = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(true))
+        changeRange1expected += AttributedString("B", attributes: AttributeContainer().testDouble(2))
+        changeRange1expected += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(false))
+        XCTAssertEqual(changeRange1expected, changeRange1)
+
+        // Now try extending it
+        let changeRange2 = attrStr.transformingAttributes(\.testInt) {
+            if let _ = $0.value {
+                // Extend the range by one.
+                $0.range = $0.range.lowerBound ..< attrStr.characters.index(after: $0.range.upperBound)
+            }
+        }
+        var changeRange2expected = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(true))
+        changeRange2expected += AttributedString("B", attributes: AttributeContainer().testInt(1).testDouble(2))
+        changeRange2expected += AttributedString("C", attributes: AttributeContainer().testInt(1).testDouble(2).testBool(false))
+        XCTAssertEqual(changeRange2expected, changeRange2)
+    }
+
+    func testReplaceAttributes() {
+        var attrStr = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(true))
+        attrStr += AttributedString("B", attributes: AttributeContainer().testInt(1).testDouble(2))
+        attrStr += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(false))
+
+        // Test removal
+        let removal1Find = AttributeContainer().testInt(1)
+        let removal1Replace = AttributeContainer()
+        var removal1 = attrStr
+        removal1.replaceAttributes(removal1Find, with: removal1Replace)
+        
+        var removal1expected = AttributedString("A", attributes: AttributeContainer().testBool(true))
+        removal1expected += AttributedString("B", attributes: AttributeContainer().testDouble(2))
+        removal1expected += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(false))
+        XCTAssertEqual(removal1expected, removal1)
+        
+        // Test change value, same attribute.
+        let changeSame1Find = AttributeContainer().testBool(false)
+        let changeSame1Replace = AttributeContainer().testBool(true)
+        var changeSame1 = attrStr
+        changeSame1.replaceAttributes(changeSame1Find, with: changeSame1Replace)
+    
+        var changeSame1expected = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(true))
+        changeSame1expected += AttributedString("B", attributes: AttributeContainer().testInt(1).testDouble(2))
+        changeSame1expected += AttributedString("C", attributes: AttributeContainer().testDouble(2).testBool(true))
+        XCTAssertEqual(changeSame1expected, changeSame1)
+        
+        // Test change value, different attribute
+        let changeDifferent1Find = AttributeContainer().testBool(false)
+        let changeDifferent1Replace = AttributeContainer().testDouble(43)
+        var changeDifferent1 = attrStr
+        changeDifferent1.replaceAttributes(changeDifferent1Find, with: changeDifferent1Replace)
+        
+        var changeDifferent1expected = AttributedString("A", attributes: AttributeContainer().testInt(1).testBool(true))
+        changeDifferent1expected += AttributedString("B", attributes: AttributeContainer().testInt(1).testDouble(2))
+        changeDifferent1expected += AttributedString("C", attributes: AttributeContainer().testDouble(43))
+        XCTAssertEqual(changeDifferent1expected, changeDifferent1)
+    }
+ 
+    
+    func testSliceMutation() {
+        var attrStr = AttributedString("Hello World", attributes: AttributeContainer().testInt(1))
+        let start = attrStr.characters.index(attrStr.startIndex, offsetBy: 6)
+        attrStr.replaceSubrange(start ..< attrStr.characters.index(start, offsetBy:5), with: AttributedString("Goodbye", attributes: AttributeContainer().testInt(2)))
+
+        var expected = AttributedString("Hello ", attributes: AttributeContainer().testInt(1))
+        expected += AttributedString("Goodbye", attributes: AttributeContainer().testInt(2))
+        XCTAssertEqual(attrStr, expected)
+        XCTAssertNotEqual(attrStr, AttributedString("Hello Goodbye", attributes: AttributeContainer().testInt(1)))
+    }
+    
+    func testOverlappingSliceMutation() {
+        var attrStr = AttributedString("Hello, world!")
+        attrStr[attrStr.range(of: "Hello")!].testInt = 1
+        attrStr[attrStr.range(of: "world")!].testInt = 2
+        attrStr[attrStr.range(of: "o, wo")!].testBool = true
+        
+        var expected = AttributedString("Hell", attributes: AttributeContainer().testInt(1))
+        expected += AttributedString("o", attributes: AttributeContainer().testInt(1).testBool(true))
+        expected += AttributedString(", ", attributes: AttributeContainer().testBool(true))
+        expected += AttributedString("wo", attributes: AttributeContainer().testBool(true).testInt(2))
+        expected += AttributedString("rld", attributes: AttributeContainer().testInt(2))
+        expected += AttributedString("!")
+        XCTAssertEqual(attrStr, expected)
+    }
+
+    func testCharacters_replaceSubrange() {
+        var attrStr = AttributedString("Hello World", attributes: AttributeContainer().testInt(1))
+        attrStr.characters.replaceSubrange(attrStr.range(of: " ")!, with: " Good ")
+
+        let expected = AttributedString("Hello Good World", attributes: AttributeContainer().testInt(1))
+        XCTAssertEqual(expected, attrStr)
+    }
+
+    func testCharactersMutation_append() {
+        var attrStr = AttributedString("Hello World", attributes: AttributeContainer().testInt(1))
+        attrStr.characters.append(contentsOf: " Goodbye")
+
+        let expected = AttributedString("Hello World Goodbye", attributes: AttributeContainer().testInt(1))
+        XCTAssertEqual(expected, attrStr)
+    }
+
+    func testUnicodeScalars_replaceSubrange() {
+        var attrStr = AttributedString("La Cafe\u{301}", attributes: AttributeContainer().testInt(1))
+        let unicode = attrStr.unicodeScalars
+        attrStr.unicodeScalars.replaceSubrange(unicode.index(unicode.startIndex, offsetBy: 3) ..< unicode.index(unicode.startIndex, offsetBy: 7), with: "Ole".unicodeScalars)
+
+        let expected = AttributedString("La Ole\u{301}", attributes: AttributeContainer().testInt(1))
+        XCTAssertEqual(expected, attrStr)
+    }
+
+    func testUnicodeScalarsMutation_append() {
+        var attrStr = AttributedString("Cafe", attributes: AttributeContainer().testInt(1))
+        attrStr.unicodeScalars.append("\u{301}")
+
+        let expected = AttributedString("Cafe\u{301}", attributes: AttributeContainer().testInt(1))
+        XCTAssertEqual(expected, attrStr)
+    }
+
+    func testSubCharacterAttributeSetting() {
+        var attrStr = AttributedString("Cafe\u{301}", attributes: AttributeContainer().testInt(1))
+        let cafRange = attrStr.characters.startIndex ..< attrStr.characters.index(attrStr.characters.startIndex, offsetBy: 3)
+        let eRange = cafRange.upperBound ..< attrStr.unicodeScalars.index(after: cafRange.upperBound)
+        let accentRange = eRange.upperBound ..< attrStr.unicodeScalars.endIndex
+        attrStr[cafRange].testDouble = 1.5
+        attrStr[eRange].testDouble = 2.5
+        attrStr[accentRange].testDouble = 3.5
+
+        var expected = AttributedString("Caf", attributes: AttributeContainer().testInt(1).testDouble(1.5))
+        expected += AttributedString("e", attributes: AttributeContainer().testInt(1).testDouble(2.5))
+        expected += AttributedString("\u{301}", attributes: AttributeContainer().testInt(1).testDouble(3.5))
+        XCTAssertEqual(expected, attrStr)
+    }
+    
+    func testReplaceSubrange_rangeExpression() {
+        var attrStr = AttributedString("Hello World", attributes: AttributeContainer().testInt(1))
+        
+        // Test with PartialRange, which conforms to RangeExpression but is not a Range
+        let rangeOfHello = ...attrStr.characters.index(attrStr.startIndex, offsetBy: 4)
+        attrStr.replaceSubrange(rangeOfHello, with: AttributedString("Goodbye"))
+        
+        var expected = AttributedString("Goodbye")
+        expected += AttributedString(" World", attributes: AttributeContainer().testInt(1))
+        XCTAssertEqual(attrStr, expected)
+    }
+    
+    func testSettingAttributes() {
+        var attrStr = AttributedString("Hello World", attributes: .init().testInt(1))
+        attrStr += AttributedString(". My name is Foundation!", attributes: .init().testBool(true))
+        
+        let result = attrStr.settingAttributes(.init().testBool(false))
+        
+        let expected = AttributedString("Hello World. My name is Foundation!", attributes: .init().testBool(false))
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testAddAttributedString() {
+        let attrStr = AttributedString("Hello ", attributes: .init().testInt(1))
+        let attrStr2 = AttributedString("World", attributes: .init().testInt(2))
+        let original = AttributedString(attrStr)
+        let original2 = AttributedString(attrStr2)
+        
+        var concat = AttributedString("Hello ", attributes: .init().testInt(1))
+        concat += AttributedString("World", attributes: .init().testInt(2))
+        let combine = attrStr + attrStr2
+        XCTAssertEqual(attrStr, original)
+        XCTAssertEqual(attrStr2, original2)
+        XCTAssertEqual(String(combine.characters), "Hello World")
+        XCTAssertEqual(String(concat.characters), "Hello World")
+        
+        let testInts = [1, 2]
+        for str in [concat, combine] {
+            var i = 0
+            for run in str.runs {
+                XCTAssertEqual(run.testInt, testInts[i])
+                i += 1
+            }
+        }
+    }
+
+    func testReplaceSubrangeWithSubstrings() {
+        let baseString = AttributedString("A", attributes: .init().testInt(1))
+        + AttributedString("B", attributes: .init().testInt(2))
+        + AttributedString("C", attributes: .init().testInt(3))
+        + AttributedString("D", attributes: .init().testInt(4))
+        + AttributedString("E", attributes: .init().testInt(5))
+
+        let substring = baseString[ baseString.characters.index(after: baseString.startIndex) ..< baseString.characters.index(before: baseString.endIndex) ]
+
+        var targetString = AttributedString("XYZ", attributes: .init().testString("foo"))
+        targetString.replaceSubrange(targetString.characters.index(after: targetString.startIndex) ..< targetString.characters.index(before: targetString.endIndex), with: substring)
+
+        var expected = AttributedString("X", attributes: .init().testString("foo"))
+        + AttributedString("B", attributes: .init().testInt(2))
+        + AttributedString("C", attributes: .init().testInt(3))
+        + AttributedString("D", attributes: .init().testInt(4))
+        + AttributedString("Z", attributes: .init().testString("foo"))
+
+        XCTAssertEqual(targetString, expected)
+
+        targetString = AttributedString("XYZ", attributes: .init().testString("foo"))
+        targetString.append(substring)
+        expected = AttributedString("XYZ", attributes: .init().testString("foo"))
+        + AttributedString("B", attributes: .init().testInt(2))
+        + AttributedString("C", attributes: .init().testInt(3))
+        + AttributedString("D", attributes: .init().testInt(4))
+
+        XCTAssertEqual(targetString, expected)
+    }
+    
+    func assertStringIsCoalesced(_ str: AttributedString) {
+        var prev: AttributedString.Runs.Run?
+        for run in str.runs {
+            if let prev = prev {
+                XCTAssertNotEqual(prev._attributes, run._attributes)
+            }
+            prev = run
+        }
+    }
+    
+    func testCoalescing() {
+        let str = AttributedString("Hello", attributes: .init().testInt(1))
+        let appendSame = str + AttributedString("World", attributes: .init().testInt(1))
+        let appendDifferent = str + AttributedString("World", attributes: .init().testInt(2))
+        
+        assertStringIsCoalesced(str)
+        assertStringIsCoalesced(appendSame)
+        assertStringIsCoalesced(appendDifferent)
+        XCTAssertEqual(appendSame.runs.count, 1)
+        XCTAssertEqual(appendDifferent.runs.count, 2)
+        
+        // Ensure replacing whole string keeps coalesced
+        var str2 = str
+        str2.replaceSubrange(str2.startIndex ..< str2.endIndex, with: AttributedString("Hello", attributes: .init().testInt(2)))
+        assertStringIsCoalesced(str2)
+        XCTAssertEqual(str2.runs.count, 1)
+        
+        // Ensure replacing subranges splits runs and doesn't coalesce when not equal
+        var str3 = str
+        str3.replaceSubrange(str3.characters.index(after: str3.startIndex) ..< str3.endIndex, with: AttributedString("ello", attributes: .init().testInt(2)))
+        assertStringIsCoalesced(str3)
+        XCTAssertEqual(str3.runs.count, 2)
+        
+        var str4 = str
+        str4.replaceSubrange(str4.startIndex ..< str4.characters.index(before: str4.endIndex), with: AttributedString("Hell", attributes: .init().testInt(2)))
+        assertStringIsCoalesced(str4)
+        XCTAssertEqual(str4.runs.count, 2)
+        
+        var str5 = str
+        str5.replaceSubrange(str5.characters.index(after: str5.startIndex) ..< str5.characters.index(before: str4.endIndex), with: AttributedString("ell", attributes: .init().testInt(2)))
+        assertStringIsCoalesced(str5)
+        XCTAssertEqual(str5.runs.count, 3)
+        
+        // Ensure changing attributes back to match bordering runs coalesces with edge of subrange
+        var str6 = str5
+        str6.replaceSubrange(str6.characters.index(after: str6.startIndex) ..< str6.endIndex, with: AttributedString("ello", attributes: .init().testInt(1)))
+        assertStringIsCoalesced(str6)
+        XCTAssertEqual(str6.runs.count, 1)
+        
+        var str7 = str5
+        str7.replaceSubrange(str7.startIndex ..< str7.characters.index(before: str7.endIndex), with: AttributedString("Hell", attributes: .init().testInt(1)))
+        assertStringIsCoalesced(str7)
+        XCTAssertEqual(str7.runs.count, 1)
+        
+        var str8 = str5
+        str8.replaceSubrange(str8.characters.index(after: str8.startIndex) ..< str8.characters.index(before: str8.endIndex), with: AttributedString("ell", attributes: .init().testInt(1)))
+        assertStringIsCoalesced(str8)
+        XCTAssertEqual(str8.runs.count, 1)
+        
+        var str9 = str5
+        str9.testInt = 1
+        assertStringIsCoalesced(str9)
+        XCTAssertEqual(str9.runs.count, 1)
+        
+        var str10 = str5
+        str10[str10.characters.index(after: str10.startIndex) ..< str10.characters.index(before: str10.endIndex)].testInt = 1
+        assertStringIsCoalesced(str10)
+        XCTAssertEqual(str10.runs.count, 1)
+    }
+    
+    func testReplaceWithEmptyElements() {
+        var str = AttributedString("Hello, world")
+        let range = str.startIndex ..< str.characters.index(str.startIndex, offsetBy: 5)
+        str.characters.replaceSubrange(range, with: [])
+        
+        XCTAssertEqual(str, AttributedString(", world"))
+    }
+    
+    func testDescription() {
+        let string = AttributedString("A", attributes: .init().testInt(1))
+        + AttributedString("B", attributes: .init().testInt(2))
+        + AttributedString("C", attributes: .init().testInt(3))
+        + AttributedString("D", attributes: .init().testInt(4))
+        + AttributedString("E", attributes: .init().testInt(5))
+        
+        let desc = String(describing: string)
+        let expected = """
+A {
+\tTestInt = 1
+}
+B {
+\tTestInt = 2
+}
+C {
+\tTestInt = 3
+}
+D {
+\tTestInt = 4
+}
+E {
+\tTestInt = 5
+}
+"""
+        XCTAssertEqual(desc, expected)
+        
+        let runsDesc = String(describing: string.runs)
+        XCTAssertEqual(runsDesc, expected)
+    }
+    
+    func testContainerDescription() {
+        let cont = AttributeContainer().testBool(false).testInt(1).testDouble(2.0).testString("3")
+        
+        let desc = String(describing: cont)
+        
+        // Don't get bitten by any potential changes in the hashing algorithm.
+        XCTAssertTrue(desc.hasPrefix("{\n"))
+        XCTAssertTrue(desc.hasSuffix("\n}"))
+        XCTAssertTrue(desc.contains("\tTestDouble = 2.0\n"))
+        XCTAssertTrue(desc.contains("\tTestInt = 1\n"))
+        XCTAssertTrue(desc.contains("\tTestString = 3\n"))
+        XCTAssertTrue(desc.contains("\tTestBool = false\n"))
+    }
+    
+    func testRunAndSubstringDescription() {
+        let string = AttributedString("A", attributes: .init().testInt(1))
+        + AttributedString("B", attributes: .init().testInt(2))
+        + AttributedString("C", attributes: .init().testInt(3))
+        + AttributedString("D", attributes: .init().testInt(4))
+        + AttributedString("E", attributes: .init().testInt(5))
+        
+        print(string.runs)
+        
+        let runsDescs = string.runs.map() { String(describing: $0) }
+        let expected = [ """
+A {
+\tTestInt = 1
+}
+""", """
+B {
+\tTestInt = 2
+}
+""", """
+C {
+\tTestInt = 3
+}
+""", """
+D {
+\tTestInt = 4
+}
+""", """
+E {
+\tTestInt = 5
+}
+"""]
+        XCTAssertEqual(runsDescs, expected)
+        
+        let subDescs = string.runs.map() { String(describing: string[$0.range]) }
+        XCTAssertEqual(subDescs, expected)
+    }
+    
+    func testReplacingAttributes() {
+        var str = AttributedString("Hello", attributes: .init().testInt(2))
+        str += AttributedString("World", attributes: .init().testString("Test"))
+        
+        var result = str.replacingAttributes(.init().testInt(2).testString("NotTest"), with: .init().testBool(false))
+        XCTAssertEqual(result, str)
+        
+        result = str.replacingAttributes(.init().testInt(2), with: .init().testBool(false))
+        var expected = AttributedString("Hello", attributes: .init().testBool(false))
+        expected += AttributedString("World", attributes: .init().testString("Test"))
+        XCTAssertEqual(result, expected)
+    }
+    
+    func testScopedAttributeContainer() {
+        var str = AttributedString("Hello, world")
+        
+        XCTAssertNil(str.test.testInt)
+        XCTAssertNil(str.testInt)
+        str.test.testInt = 2
+        XCTAssertEqual(str.test.testInt, 2)
+        XCTAssertEqual(str.testInt, 2)
+        str.test.testInt = nil
+        XCTAssertNil(str.test.testInt)
+        XCTAssertNil(str.testInt)
+        
+        let range = str.startIndex ..< str.index(str.startIndex, offsetByCharacters: 5)
+        let otherRange = range.upperBound ..< str.endIndex
+        
+        str[range].test.testBool = true
+        XCTAssertEqual(str[range].test.testBool, true)
+        XCTAssertEqual(str[range].testBool, true)
+        XCTAssertNil(str.test.testBool)
+        XCTAssertNil(str.testBool)
+        str[range].test.testBool = nil
+        XCTAssertNil(str[range].test.testBool)
+        XCTAssertNil(str[range].testBool)
+        XCTAssertNil(str.test.testBool)
+        XCTAssertNil(str.testBool)
+        
+        str.test.testBool = true
+        str[range].test.testBool = nil
+        XCTAssertNil(str[range].test.testBool)
+        XCTAssertNil(str[range].testBool)
+        XCTAssertNil(str.test.testBool)
+        XCTAssertNil(str.testBool)
+        XCTAssertEqual(str[otherRange].test.testBool, true)
+        XCTAssertEqual(str[otherRange].testBool, true)
+    }
+    
+    func testMergeAttributes() {
+        let originalAttributes = AttributeContainer.testInt(2).testBool(true)
+        let newAttributes = AttributeContainer.testString("foo")
+        let overlappingAttributes = AttributeContainer.testInt(3).testDouble(4.3)
+        let str = AttributedString("Hello, world", attributes: originalAttributes)
+        
+        XCTAssertEqual(str.mergingAttributes(newAttributes, mergePolicy: .keepNew), AttributedString("Hello, world", attributes: newAttributes.testInt(2).testBool(true)))
+        XCTAssertEqual(str.mergingAttributes(newAttributes, mergePolicy: .keepCurrent), AttributedString("Hello, world", attributes: newAttributes.testInt(2).testBool(true)))
+        XCTAssertEqual(str.mergingAttributes(overlappingAttributes, mergePolicy: .keepNew), AttributedString("Hello, world", attributes: overlappingAttributes.testBool(true)))
+        XCTAssertEqual(str.mergingAttributes(overlappingAttributes, mergePolicy: .keepCurrent), AttributedString("Hello, world", attributes: originalAttributes.testDouble(4.3)))
+    }
+    
+    func testMergeAttributeContainers() {
+        let originalAttributes = AttributeContainer.testInt(2).testBool(true)
+        let newAttributes = AttributeContainer.testString("foo")
+        let overlappingAttributes = AttributeContainer.testInt(3).testDouble(4.3)
+        
+        XCTAssertEqual(originalAttributes.merging(newAttributes, mergePolicy: .keepNew), newAttributes.testInt(2).testBool(true))
+        XCTAssertEqual(originalAttributes.merging(newAttributes, mergePolicy: .keepCurrent), newAttributes.testInt(2).testBool(true))
+        XCTAssertEqual(originalAttributes.merging(overlappingAttributes, mergePolicy: .keepNew), overlappingAttributes.testBool(true))
+        XCTAssertEqual(originalAttributes.merging(overlappingAttributes, mergePolicy: .keepCurrent), originalAttributes.testDouble(4.3))
+    }
+    
+    func testChangingSingleCharacterUTF8Length() {
+        var attrstr = AttributedString("\u{1F3BA}\u{1F3BA}") // UTF-8 Length of 8
+        attrstr.characters[attrstr.startIndex] = "A" // Changes UTF-8 Length to 5
+        XCTAssertEqual(attrstr.runs.count, 1)
+        let runRange = attrstr.runs.first!.range
+        let substring = String(attrstr[runRange].characters)
+        XCTAssertEqual(substring, "A\u{1F3BA}")
+    }
+    
+    // MARK: - Substring Tests
+    
+    func testSubstringBase() {
+        let str = AttributedString("Hello World", attributes: .init().testInt(1))
+        var substr = str[str.startIndex ..< str.characters.index(str.startIndex, offsetBy: 5)]
+        XCTAssertEqual(substr.base, str)
+        substr.testInt = 3
+        XCTAssertNotEqual(substr.base, str)
+        
+        var str2 = AttributedString("Hello World", attributes: .init().testInt(1))
+        let range = str2.startIndex ..< str2.characters.index(str2.startIndex, offsetBy: 5)
+        XCTAssertEqual(str2[range].base, str2)
+        str2[range].testInt = 3
+        XCTAssertEqual(str2[range].base, str2)
+    }
+    
+    func testSubstringGetAttribute() {
+        let str = AttributedString("Hello World", attributes: .init().testInt(1))
+        let range = str.startIndex ..< str.characters.index(str.startIndex, offsetBy: 5)
+        XCTAssertEqual(str[range].testInt, 1)
+        XCTAssertNil(str[range].testString)
+        
+        var str2 = AttributedString("Hel", attributes: .init().testInt(1))
+        str2 += AttributedString("lo World", attributes: .init().testInt(2).testBool(true))
+        let range2 = str2.startIndex ..< str2.characters.index(str2.startIndex, offsetBy: 5)
+        XCTAssertNil(str2[range2].testInt)
+        XCTAssertNil(str2[range2].testBool)
+    }
+    
+    func testSubstringDescription() {
+        var str = AttributedString("Hello", attributes: .init().testInt(2))
+        str += " "
+        str += AttributedString("World", attributes: .init().testInt(3))
+        
+        for run in str.runs {
+            let desc = str[run.range].description
+            XCTAssertFalse(desc.isEmpty)
+        }
+    }
+
+    // MARK: - Coding Tests
+    
+    struct CodableType : Codable {
+        // One of potentially many different values being encoded:
+        @CodableConfiguration(from: \.test)
+        var attributedString = AttributedString()
+    }
+
+    func testJSONEncoding() throws {
+        let encoder = JSONEncoder()
+        var attrStr = AttributedString("Hello", attributes: AttributeContainer().testBool(true).testString("blue").testInt(1))
+        attrStr += AttributedString(" World", attributes: AttributeContainer().testInt(2).testDouble(3.0).testString("http://www.apple.com"))
+
+        let c = CodableType(attributedString: attrStr)
+        let json = try encoder.encode(c)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(CodableType.self, from: json)
+        XCTAssertEqual(decoded.attributedString, attrStr)
+    }
+    
+    func testDecodingThenConvertingToNSAttributedString() throws {
+        let encoder = JSONEncoder()
+        var attrStr = AttributedString("Hello", attributes: AttributeContainer().testBool(true))
+        attrStr += AttributedString(" World", attributes: AttributeContainer().testInt(2))
+        let c = CodableType(attributedString: attrStr)
+        let json = try encoder.encode(c)
+
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(CodableType.self, from: json)
+        let decodedns = try NSAttributedString(decoded.attributedString, including: AttributeScopes.TestAttributes.self)
+        let ns = try NSAttributedString(attrStr, including: AttributeScopes.TestAttributes.self)
+        XCTAssertEqual(ns, decodedns)
+    }
+    
+    func testCustomAttributeCoding() throws {
+        struct MyAttributes : AttributeScope {
+            var customCodable : AttributeScopes.TestAttributes.CustomCodableAttribute
+        }
+        
+        struct CodableType : Codable {
+            @CodableConfiguration(from: MyAttributes.self)
+            var attributedString = AttributedString()
+        }
+        
+        let encoder = JSONEncoder()
+        var attrStr = AttributedString("Hello")
+        attrStr[AttributeScopes.TestAttributes.CustomCodableAttribute.self] = .init(inner: 42)
+        
+        let c = CodableType(attributedString: attrStr)
+        let json = try encoder.encode(c)
+        
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(CodableType.self, from: json)
+        XCTAssertEqual(decoded.attributedString, attrStr)
+    }
+    
+    func testCustomCodableTypeWithCodableAttributedString() throws {
+        struct MyType : Codable, Equatable {
+            var other: NonCodableType
+            var str: AttributedString
+            
+            init(other: NonCodableType, str: AttributedString) {
+                self.other = other
+                self.str = str
+            }
+            
+            enum Keys : CodingKey {
+                case other
+                case str
+            }
+            
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: Keys.self)
+                other = NonCodableType(inner: try container.decode(Int.self, forKey: .other))
+                str = try container.decode(AttributedString.self, forKey: .str, configuration: AttributeScopes.TestAttributes.self)
+            }
+            
+            func encode(to encoder: Encoder) throws {
+                var container = encoder.container(keyedBy: Keys.self)
+                try container.encode(other.inner, forKey: .other)
+                try container.encode(str, forKey: .str, configuration: AttributeScopes.TestAttributes.self)
+            }
+        }
+        
+        var container = AttributeContainer()
+        container.testInt = 3
+        let type = MyType(other: NonCodableType(inner: 2), str: AttributedString("Hello World", attributes: container))
+        
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(type)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(MyType.self, from: data)
+        XCTAssertEqual(type, decoded)
+    }
+    
+    func testCodingErrorsPropogateUpToCallSite() {
+        enum CustomAttribute : CodableAttributedStringKey {
+            typealias Value = String
+            static var name = "CustomAttribute"
+            
+            static func encode(_ value: Value, to encoder: Encoder) throws {
+                throw TestError.encodingError
+            }
+            
+            static func decode(from decoder: Decoder) throws -> Value {
+                throw TestError.decodingError
+            }
+        }
+        
+        struct CustomScope : AttributeScope {
+            var custom: CustomAttribute
+        }
+        
+        struct Obj : Codable {
+            @CodableConfiguration(from: CustomScope.self) var str = AttributedString()
+        }
+        
+        var str = AttributedString("Hello, world")
+        str[CustomAttribute.self] = "test"
+        let encoder = JSONEncoder()
+        XCTAssertThrowsError(try encoder.encode(Obj(str: str)), "Attribute encoding error did not throw at call site") { err in
+            XCTAssert(err is TestError, "Encoding did not throw the proper error")
+        }
+    }
+    
+    func testEncodeWithPartiallyCodableScope() throws {
+        enum NonCodableAttribute : AttributedStringKey {
+            typealias Value = Int
+            static var name = "NonCodableAttributes"
+        }
+        struct PartialCodableScope : AttributeScope {
+            var codableAttr : AttributeScopes.TestAttributes.TestIntAttribute
+            var nonCodableAttr : NonCodableAttribute
+        }
+        struct Obj : Codable {
+            @CodableConfiguration(from: PartialCodableScope.self) var str = AttributedString()
+        }
+        
+        var str = AttributedString("Hello, world")
+        str[AttributeScopes.TestAttributes.TestIntAttribute.self] = 2
+        str[NonCodableAttribute.self] = 3
+        
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(Obj(str: str))
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Obj.self, from: data)
+        
+        var expected = str
+        expected[NonCodableAttribute.self] = nil
+        XCTAssertEqual(decoded.str, expected)
+    }
+
+    func testAutomaticCoding() throws {
+        struct Obj : Codable, Equatable {
+            @CodableConfiguration(from: AttributeScopes.TestAttributes.self) var attrStr = AttributedString()
+            @CodableConfiguration(from: AttributeScopes.TestAttributes.self) var optAttrStr : AttributedString? = nil
+            @CodableConfiguration(from: AttributeScopes.TestAttributes.self) var attrStrArr = [AttributedString]()
+            @CodableConfiguration(from: AttributeScopes.TestAttributes.self) var optAttrStrArr = [AttributedString?]()
+
+            public init(testValueWithNils: Bool) {
+                attrStr = AttributedString("Test")
+                attrStr.testString = "TestAttr"
+
+                attrStrArr = [attrStr, attrStr]
+                if testValueWithNils {
+                    optAttrStr = nil
+                    optAttrStrArr = [nil, attrStr, nil]
+                } else {
+                    optAttrStr = attrStr
+                    optAttrStrArr = [attrStr, attrStr]
+                }
+            }
+        }
+
+        // nil
+        do {
+            let val = Obj(testValueWithNils: true)
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(val)
+            print(String(data: data, encoding: .utf8)!)
+            let decoder = JSONDecoder()
+            let decoded = try decoder.decode(Obj.self, from: data)
+
+            XCTAssertEqual(decoded, val)
+        }
+
+        // non-nil
+        do {
+            let val = Obj(testValueWithNils: false)
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(val)
+            print(String(data: data, encoding: .utf8)!)
+            let decoder = JSONDecoder()
+            let decoded = try decoder.decode(Obj.self, from: data)
+
+            XCTAssertEqual(decoded, val)
+        }
+
+    }
+
+
+    func testManualCoding() throws {
+        struct Obj : Codable, Equatable {
+            var attrStr : AttributedString
+            var optAttrStr : AttributedString?
+            var attrStrArr : [AttributedString]
+            var optAttrStrArr : [AttributedString?]
+
+            public init(testValueWithNils: Bool) {
+                attrStr = AttributedString("Test")
+                attrStr.testString = "TestAttr"
+
+                attrStrArr = [attrStr, attrStr]
+                if testValueWithNils {
+                    optAttrStr = nil
+                    optAttrStrArr = [nil, attrStr, nil]
+                } else {
+                    optAttrStr = attrStr
+                    optAttrStrArr = [attrStr, attrStr]
+                }
+            }
+
+            enum Keys : CodingKey {
+                case attrStr
+                case optAttrStr
+                case attrStrArr
+                case optAttrStrArr
+            }
+
+            func encode(to encoder: Encoder) throws {
+                var c = encoder.container(keyedBy: Keys.self)
+                try c.encode(attrStr, forKey: .attrStr, configuration: AttributeScopes.TestAttributes.self)
+                try c.encodeIfPresent(optAttrStr, forKey: .optAttrStr, configuration: AttributeScopes.TestAttributes.self)
+                try c.encode(attrStrArr, forKey: .attrStrArr, configuration: AttributeScopes.TestAttributes.self)
+                try c.encode(optAttrStrArr, forKey: .optAttrStrArr, configuration: AttributeScopes.TestAttributes.self)
+            }
+
+            init(from decoder: Decoder) throws {
+                let c = try decoder.container(keyedBy: Keys.self)
+                attrStr = try c.decode(AttributedString.self, forKey: .attrStr, configuration: AttributeScopes.TestAttributes.self)
+                optAttrStr = try c.decodeIfPresent(AttributedString.self, forKey: .optAttrStr, configuration: AttributeScopes.TestAttributes.self)
+                attrStrArr = try c.decode([AttributedString].self, forKey: .attrStrArr, configuration: AttributeScopes.TestAttributes.self)
+                optAttrStrArr = try c.decode([AttributedString?].self, forKey: .optAttrStrArr, configuration: AttributeScopes.TestAttributes.self)
+            }
+        }
+
+        // nil
+        do {
+            let val = Obj(testValueWithNils: true)
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(val)
+            print(String(data: data, encoding: .utf8)!)
+            let decoder = JSONDecoder()
+            let decoded = try decoder.decode(Obj.self, from: data)
+
+            XCTAssertEqual(decoded, val)
+        }
+
+        // non-nil
+        do {
+            let val = Obj(testValueWithNils: false)
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(val)
+            print(String(data: data, encoding: .utf8)!)
+            let decoder = JSONDecoder()
+            let decoded = try decoder.decode(Obj.self, from: data)
+
+            XCTAssertEqual(decoded, val)
+        }
+        
+    }
+    
+    func testDecodingCorruptedData() throws {
+        let jsonStrings = [
+            "{\"attributedString\": 2}",
+            "{\"attributedString\": []}",
+            "{\"attributedString\": [\"Test\"]}",
+            "{\"attributedString\": [\"Test\", 0]}",
+            "{\"attributedString\": [\"\", {}, \"Test\", {}]}",
+            "{\"attributedString\": [\"Test\", {}, \"\", {}]}",
+            "{\"attributedString\": [\"\", {\"TestInt\": 1}]}",
+            "{\"attributedString\": {}}",
+            "{\"attributedString\": {\"attributeTable\": []}}",
+            "{\"attributedString\": {\"runs\": []}}",
+            "{\"attributedString\": {\"runs\": [], \"attributeTable\": []}}",
+            "{\"attributedString\": {\"runs\": [\"\"], \"attributeTable\": []}}",
+            "{\"attributedString\": {\"runs\": [\"\", 1], \"attributeTable\": []}}",
+            "{\"attributedString\": {\"runs\": [\"\", {}, \"Test\", {}], \"attributeTable\": []}}",
+            "{\"attributedString\": {\"runs\": \"Test\", {}, \"\", {}, \"attributeTable\": []}}",
+        ]
+        
+        let decoder = JSONDecoder()
+        for string in jsonStrings {
+            XCTAssertThrowsError(try decoder.decode(CodableType.self, from: string.data(using: .utf8)!), "Corrupt data did not throw error for json data: \(string)") { err in
+                XCTAssertTrue(err is DecodingError, "Decoding threw an error that was not a DecodingError")
+            }
+        }
+    }
+    
+    func testCodableRawRepresentableAttribute() throws {
+        struct Attribute : CodableAttributedStringKey {
+            static let name = "MyAttribute"
+            enum Value: String, Codable, Hashable {
+                case one = "one"
+                case two = "two"
+                case three = "three"
+            }
+        }
+        
+        struct Scope : AttributeScope {
+            let attribute: Attribute
+        }
+        
+        struct Object : Codable {
+            @CodableConfiguration(from: Scope.self)
+            var str = AttributedString()
+        }
+        
+        var str = AttributedString("Test")
+        str[Attribute.self] = .two
+        let encoder = JSONEncoder()
+        let encoded = try encoder.encode(Object(str: str))
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(Object.self, from: encoded)
+        XCTAssertEqual(decoded.str[Attribute.self], .two)
+    }
+
+    func testContainerEncoding() throws {
+        struct ContainerContainer : Codable {
+            @CodableConfiguration(from: AttributeScopes.TestAttributes.self) var container = AttributeContainer()
+        }
+        let obj = ContainerContainer(container: AttributeContainer().testInt(1).testBool(true))
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(obj)
+        print(String(data: data, encoding: .utf8)!)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(ContainerContainer.self, from: data)
+
+        XCTAssertEqual(obj.container, decoded.container)
+    }
+    
+    func testDefaultAttributesCoding() throws {
+        struct DefaultContainer : Codable, Equatable {
+            var str : AttributedString
+        }
+        
+        let cont = DefaultContainer(str: AttributedString("Hello", attributes: .init().link(URL(string: "http://apple.com")!)))
+        let encoder = JSONEncoder()
+        let encoded = try encoder.encode(cont)
+        let decoder = JSONDecoder()
+        let decoded = try decoder.decode(DefaultContainer.self, from: encoded)
+        XCTAssertEqual(cont, decoded)
+    }
+    
+    // MARK: - Conversion Tests
+    
+    func testConversionToObjC() throws {
+        var ourString = AttributedString("Hello", attributes: AttributeContainer().testInt(2))
+        ourString += AttributedString(" ")
+        ourString += AttributedString("World", attributes: AttributeContainer().testString("Courier"))
+        let ourObjCString = try NSAttributedString(ourString, including: AttributeScopes.TestAttributes.self)
+        let theirString = NSMutableAttributedString(string: "Hello World")
+        theirString.addAttributes([.testInt: NSNumber(value: 2)], range: NSMakeRange(0, 5))
+        theirString.addAttributes([.testString: "Courier"], range: NSMakeRange(6, 5))
+        XCTAssertEqual(theirString, ourObjCString)
+    }
+    
+    func testConversionFromObjC() throws {
+        let nsString = NSMutableAttributedString(string: "Hello!")
+        let rangeA = NSMakeRange(0, 3)
+        let rangeB = NSMakeRange(3, 3)
+        nsString.addAttribute(.testString, value: "Courier", range: rangeA)
+        nsString.addAttribute(.testBool, value: NSNumber(value: true), range: rangeB)
+        let convertedString = try AttributedString(nsString, including: AttributeScopes.TestAttributes.self)
+        var string = AttributedString("Hel")
+        string.testString = "Courier"
+        string += AttributedString("lo!", attributes: AttributeContainer().testBool(true))
+        XCTAssertEqual(string, convertedString)
+    }
+    
+    func testRoundTripConversion_boxed() throws {
+        struct MyCustomType : Hashable {
+            var num: Int
+            var str: String
+        }
+        
+        enum MyCustomAttribute : AttributedStringKey {
+            typealias Value = MyCustomType
+            static let name = "MyCustomAttribute"
+        }
+        
+        struct MyCustomScope : AttributeScope {
+            let attr : MyCustomAttribute
+        }
+        
+        let customVal = MyCustomType(num: 2, str: "test")
+        var attrString = AttributedString("Hello world")
+        attrString[MyCustomAttribute.self] = customVal
+        let nsString = try NSAttributedString(attrString, including: MyCustomScope.self)
+        let converted = try AttributedString(nsString, including: MyCustomScope.self)
+        
+        XCTAssertEqual(converted[MyCustomAttribute.self], customVal)
+    }
+
+    func testRoundTripConversion_customConversion() throws {
+        struct MyCustomType : Hashable { }
+
+        enum MyCustomAttribute : ObjectiveCConvertibleAttributedStringKey {
+            typealias Value = MyCustomType
+            static let name = "MyCustomAttribute"
+
+            static func objectiveCValue(for value: Value) throws -> NSUUID { NSUUID() }
+            static func value(for object: NSUUID) throws -> Value { MyCustomType() }
+        }
+
+        struct MyCustomScope : AttributeScope {
+            let attr : MyCustomAttribute
+        }
+
+        let customVal = MyCustomType()
+        var attrString = AttributedString("Hello world")
+        attrString[MyCustomAttribute.self] = customVal
+        let nsString = try NSAttributedString(attrString, including: MyCustomScope.self)
+
+        XCTAssertTrue(nsString.attribute(.init(MyCustomAttribute.name), at: 0, effectiveRange: nil) is NSUUID)
+
+        let converted = try AttributedString(nsString, including: MyCustomScope.self)
+        XCTAssertEqual(converted[MyCustomAttribute.self], customVal)
+    }
+
+    func testIncompleteConversionFromObjC() throws {
+        struct TestStringAttributeOnly : AttributeScope {
+            var testString: AttributeScopes.TestAttributes.TestStringAttribute // Missing TestBoolAttribute
+        }
+
+        let nsString = NSMutableAttributedString(string: "Hello!")
+        let rangeA = NSMakeRange(0, 3)
+        let rangeB = NSMakeRange(3, 3)
+        nsString.addAttribute(.testString, value: "Courier", range: rangeA)
+        nsString.addAttribute(.testBool, value: NSNumber(value: true), range: rangeB)
+        let converted = try AttributedString(nsString, including: TestStringAttributeOnly.self)
+        
+        var expected = AttributedString("Hel", attributes: AttributeContainer().testString("Courier"))
+        expected += AttributedString("lo!")
+        XCTAssertEqual(converted, expected)
+    }
+    
+    func testIncompleteConversionToObjC() throws {
+        struct TestStringAttributeOnly : AttributeScope {
+            var testString: AttributeScopes.TestAttributes.TestStringAttribute // Missing TestBoolAttribute
+        }
+
+        var attrStr = AttributedString("Hello ", attributes: .init().testBool(false))
+        attrStr += AttributedString("world", attributes: .init().testString("Testing"))
+        let converted = try NSAttributedString(attrStr, including: TestStringAttributeOnly.self)
+        
+        let attrs = converted.attributes(at: 0, effectiveRange: nil)
+        XCTAssertFalse(attrs.keys.contains(.testBool))
+    }
+    
+    func testConversionNestedScope() throws {
+        struct SuperScope : AttributeScope {
+            var subscope : SubScope
+            var testString: AttributeScopes.TestAttributes.TestStringAttribute
+        }
+        
+        struct SubScope : AttributeScope {
+            var testBool : AttributeScopes.TestAttributes.TestBoolAttribute
+        }
+        
+        let nsString = NSMutableAttributedString(string: "Hello!")
+        let rangeA = NSMakeRange(0, 3)
+        let rangeB = NSMakeRange(3, 3)
+        nsString.addAttribute(.testString, value: "Courier", range: rangeA)
+        nsString.addAttribute(.testBool, value: NSNumber(value: true), range: rangeB)
+        let converted = try AttributedString(nsString, including: SuperScope.self)
+        
+        var expected = AttributedString("Hel", attributes: AttributeContainer().testString("Courier"))
+        expected += AttributedString("lo!", attributes: AttributeContainer().testBool(true))
+        XCTAssertEqual(converted, expected)
+    }
+    
+    func testConversionAttributeContainers() throws {
+        let container = AttributeContainer.testInt(2).testDouble(3.1).testString("Hello")
+        
+        let dictionary = try Dictionary(container, including: \.test)
+        let expected: [NSAttributedString.Key: Any] = [
+                .testInt: 2,
+                .testDouble: 3.1,
+                .testString: "Hello"
+        ]
+        XCTAssertEqual(dictionary.keys, expected.keys)
+        for key in expected.keys {
+            XCTAssertTrue(__equalAttributes(dictionary[key], expected[key]))
+        }
+        
+        let container2 = try AttributeContainer(dictionary, including: \.test)
+        XCTAssertEqual(container, container2)
+    }
+    
+    func testConversionFromInvalidObjectiveCValueTypes() throws {
+        let nsStr = NSAttributedString(string: "Hello", attributes: [.testInt : "I am not an Int"])
+        XCTAssertThrowsError(try AttributedString(nsStr, including: AttributeScopes.TestAttributes.self))
+        
+        struct ConvertibleAttribute: ObjectiveCConvertibleAttributedStringKey {
+            struct Value : Hashable {
+                var subValue: String
+            }
+            typealias ObjectiveCValue = NSString
+            static var name = "Convertible"
+            
+            static func objectiveCValue(for value: Value) throws -> NSString {
+                return value.subValue as NSString
+            }
+            
+            static func value(for object: NSString) throws -> Value {
+                return Value(subValue: object as String)
+            }
+        }
+        struct Scope : AttributeScope {
+            let convertible: ConvertibleAttribute
+        }
+        
+        let nsStr2 = NSAttributedString(string: "Hello", attributes: [NSAttributedString.Key(ConvertibleAttribute.name) : 12345])
+        XCTAssertThrowsError(try AttributedString(nsStr2, including: Scope.self))
+    }
+    
+    func testConversionToUTF16() throws {
+        // Ensure that we're correctly using UTF16 offsets with NSAS and UTF8 offsets with AS without mixing the two
+        let multiByteCharacters = ["\u{2029}", "\u{1D11E}", "\u{1D122}", "\u{1F91A}\u{1F3FB}"]
+        
+        for str in multiByteCharacters {
+            let attrStr = AttributedString(str, attributes: .init().testInt(2))
+            let nsStr = NSAttributedString(string: str, attributes: [.testInt: 2])
+            
+            let convertedAttrStr = try AttributedString(nsStr, including: AttributeScopes.TestAttributes.self)
+            XCTAssertEqual(str.utf8.count, convertedAttrStr._guts.runs[0].length)
+            XCTAssertEqual(attrStr, convertedAttrStr)
+            
+            let convertedNSStr = try NSAttributedString(attrStr, including: AttributeScopes.TestAttributes.self)
+            XCTAssertEqual(nsStr, convertedNSStr)
+        }
+    }
+    
+    #if os(macOS)
+    func testConversionWithoutScope() throws {
+        // Ensure simple conversion works (no errors when loading AppKit/UIKit/SwiftUI)
+        let attrStr = AttributedString()
+        let nsStr = NSAttributedString(attrStr)
+        XCTAssertEqual(nsStr, NSAttributedString(string: ""))
+        let attrStrReverse = AttributedString(nsStr)
+        XCTAssertEqual(attrStrReverse, attrStr)
+        
+        // Ensure foundation attributes are converted
+        let attrStr2 = AttributedString("Hello", attributes: .init().link(URL(string: "http://apple.com")!))
+        let nsStr2 = NSAttributedString(attrStr2)
+        XCTAssertEqual(nsStr2, NSAttributedString(string: "Hello", attributes: [.link : URL(string: "http://apple.com")! as NSURL]))
+        let attrStr2Reverse = AttributedString(nsStr2)
+        XCTAssertEqual(attrStr2Reverse, attrStr2)
+        
+        // Ensure accessibility attributes are converted
+        if let handle = dlopen("/System/Library/Frameworks/Accessibility.framework/Accessibility", RTLD_FIRST) {
+            let attributedString = AttributedString("Hello")
+            #if os(macOS)
+            let attributeName = "AXIPANotation"
+            #else
+            let attributeName = "UIAccessibilitySpeechAttributeIPANotation"
+            #endif
+            attributedString._guts.runs[0].attributes.contents[attributeName] = "abc"
+            let nsAttributedString = NSAttributedString(attributedString)
+            XCTAssertEqual(nsAttributedString, NSAttributedString(string: "Hello", attributes: [NSAttributedString.Key(attributeName) : "abc"]))
+            let attributedStringReverse = AttributedString(nsAttributedString)
+            XCTAssertEqual(attributedStringReverse, attributedString)
+            dlclose(handle)
+        }
+        
+        #if (os(macOS) && !targetEnvironment(macCatalyst))
+        // Ensure AppKit attributes are converted
+        if let handle = dlopen("/var/lib/swift/libswiftAppKit.dylib", RTLD_FIRST) {
+            let attrStr3 = AttributedString("Hello")
+            attrStr3._guts.runs[0].attributes.contents["NSKern"] = CGFloat(2.3)
+            let nsStr3 = NSAttributedString(attrStr3)
+            XCTAssertEqual(nsStr3, NSAttributedString(string: "Hello", attributes: [NSAttributedString.Key("NSKern") : CGFloat(2.3)]))
+            let attrStr3Reverse = AttributedString(nsStr3)
+            XCTAssertEqual(attrStr3Reverse, attrStr3)
+            dlclose(handle)
+        }
+        #endif
+        
+        #if (!os(macOS) || targetEnvironment(macCatalyst))
+        // Ensure UIKit attributes are converted
+        #if !os(macOS)
+        let handle = dlopen("/usr/lib/swift/libswiftUIKit.dylib", RTLD_FIRST)
+        #else
+        let handle = dlopen("/System/iOSSupport/usr/lib/swift/libswiftUIKit.dylib", RTLD_FIRST)
+        #endif
+        if let loadedHandle = handle {
+            let attrStr4 = AttributedString("Hello")
+            attrStr4._guts.runs[0].attributes.contents["NSKern"] = CGFloat(2.3)
+            let nsStr4 = NSAttributedString(attrStr4)
+            XCTAssertEqual(nsStr4, NSAttributedString(string: "Hello", attributes: [NSAttributedString.Key("NSKern") : CGFloat(2.3)]))
+            let attrStr4Reverse = AttributedString(nsStr4)
+            XCTAssertEqual(attrStr4Reverse, attrStr4)
+            dlclose(loadedHandle)
+        }
+        #endif
+        
+        // Ensure SwiftUI attributes are converted
+        if let handle = dlopen("/System/Library/Frameworks/SwiftUI.framework/SwiftUI", RTLD_FIRST) {
+            let attrStr5 = AttributedString("Hello")
+            attrStr5._guts.runs[0].attributes.contents["SwiftUI.Kern"] = CGFloat(2.3)
+            let nsStr5 = NSAttributedString(attrStr5)
+            XCTAssertEqual(nsStr5, NSAttributedString(string: "Hello", attributes: [NSAttributedString.Key("SwiftUI.Kern") : CGFloat(2.3)]))
+            let attrStr5Reverse = AttributedString(nsStr5)
+            XCTAssertEqual(attrStr5Reverse, attrStr5)
+            dlclose(handle)
+        }
+        
+        // Ensure attributes that throw are dropped
+        enum Attribute : ObjectiveCConvertibleAttributedStringKey {
+            static var name = "TestAttribute"
+            typealias Value = Int
+            typealias ObjectiveCValue = NSString
+            
+            static func objectiveCValue(for value: Int) throws -> NSString {
+                throw TestError.conversionError
+            }
+            
+            static func value(for object: NSString) throws -> Int {
+                throw TestError.conversionError
+            }
+        }
+        
+        struct Scope : AttributeScope {
+            var test: Attribute
+            var other: AttributeScopes.TestAttributes
+        }
+        
+        var container = AttributeContainer()
+        container.testInt = 2
+        container[Attribute.self] = 3
+        let str = AttributedString("Hello", attributes: container)
+        let result = try? NSAttributedString(str, scope: Scope.self, options: .dropThrowingAttributes) // The same call that the no-scope initializer will make
+        XCTAssertEqual(result, NSAttributedString(string: "Hello", attributes: [NSAttributedString.Key("TestInt") : 2]))
+    }
+    #endif
+    
+    func testConversionIncludingOnly() throws {
+        let str = AttributedString("Hello, world", attributes: .init().testInt(2).link(URL(string: "http://apple.com")!))
+        let nsStr = try NSAttributedString(str, including: \.test)
+        XCTAssertEqual(nsStr, NSAttributedString(string: "Hello, world", attributes: [.testInt: 2]))
+    }
+    
+    func testConversionCoalescing() throws {
+        let nsStr = NSMutableAttributedString("Hello, world")
+        nsStr.setAttributes([.link : NSURL(string: "http://apple.com")!, .testInt : NSNumber(integerLiteral: 2)], range: NSRange(location: 0, length: 6))
+        nsStr.setAttributes([.testInt : NSNumber(integerLiteral: 2)], range: NSRange(location: 6, length: 6))
+        let attrStr = try AttributedString(nsStr, including: \.test)
+        XCTAssertEqual(attrStr.runs.count, 1)
+        XCTAssertEqual(attrStr.runs.first!.range, attrStr.startIndex ..< attrStr.endIndex)
+        XCTAssertEqual(attrStr.testInt, 2)
+        XCTAssertNil(attrStr.link)
+    }
+
+    // MARK: - View Tests
+
+    func testCharViewIndexing_backwardsFromEndIndex() {
+        let testString = AttributedString("abcdefghi")
+        let testChars = testString.characters
+        let testIndex = testChars.index(testChars.endIndex, offsetBy: -1)
+        XCTAssertEqual(testChars[testIndex], "i")
+    }
+
+    func testAttrViewIndexing() {
+        var attrStr = AttributedString("A")
+        attrStr += "B"
+        attrStr += "C"
+        attrStr += "D"
+
+        let attrStrRuns = attrStr.runs
+
+        var i = 0
+        var curIdx = attrStrRuns.startIndex
+        while curIdx < attrStrRuns.endIndex {
+            i += 1
+            curIdx = attrStrRuns.index(after: curIdx)
+        }
+        XCTAssertEqual(i, 1)
+        XCTAssertEqual(attrStrRuns.count, 1)
+    }
+    
+    func testUnicodeScalarsViewIndexing() {
+        let attrStr = AttributedString("Cafe\u{301}", attributes: AttributeContainer().testInt(1))
+        let unicode = attrStr.unicodeScalars
+        XCTAssertEqual(unicode[unicode.index(before: unicode.endIndex)], "\u{301}")
+        XCTAssertEqual(unicode[unicode.index(unicode.endIndex, offsetBy: -2)], "e")
+    }
+    
+    func testUnicodeScalarsSlicing() {
+        let attrStr = AttributedString("Cafe\u{301}", attributes: AttributeContainer().testInt(1))
+        let range = attrStr.startIndex ..< attrStr.endIndex
+        let substringScalars = attrStr[range].unicodeScalars
+        let slicedScalars = attrStr.unicodeScalars[range]
+        
+        let expected: [UnicodeScalar] = ["C", "a", "f", "e", "\u{301}"]
+        XCTAssertEqual(substringScalars.count, expected.count)
+        XCTAssertEqual(slicedScalars.count, expected.count)
+        var indexA = substringScalars.startIndex
+        var indexB = slicedScalars.startIndex
+        var indexExpect = expected.startIndex
+        while indexA != substringScalars.endIndex && indexB != slicedScalars.endIndex {
+            XCTAssertEqual(substringScalars[indexA], expected[indexExpect])
+            XCTAssertEqual(slicedScalars[indexB], expected[indexExpect])
+            indexA = substringScalars.index(after: indexA)
+            indexB = slicedScalars.index(after: indexB)
+            indexExpect = expected.index(after: indexExpect)
+        }
+    }
+
+    // MARK: - Other Tests
+    
+    func testInitWithSequence() {
+        let expected = AttributedString("Hello World", attributes: AttributeContainer().testInt(2))
+        let sequence: [Character] = ["H", "e", "l", "l", "o", " ", "W", "o", "r", "l", "d"]
+        
+        let container = AttributeContainer().testInt(2)
+        let attrStr = AttributedString(sequence, attributes: container)
+        XCTAssertEqual(attrStr, expected)
+        
+        let attrStr2 = AttributedString(sequence, attributes: AttributeContainer().testInt(2))
+        XCTAssertEqual(attrStr2, expected)
+        
+        let attrStr3 = AttributedString(sequence, attributes: AttributeContainer().testInt(2))
+        XCTAssertEqual(attrStr3, expected)
+    }
+    
+    func testLongestEffectiveRangeOfAttribute() {
+        var str = AttributedString("Abc")
+        str += AttributedString("def", attributes: AttributeContainer.testInt(2).testString("World"))
+        str += AttributedString("ghi", attributes: AttributeContainer.testInt(2).testBool(true))
+        str += AttributedString("jkl", attributes: AttributeContainer.testInt(2).testDouble(3.0))
+        str += AttributedString("mno", attributes: AttributeContainer.testString("Hello"))
+        
+        let idx = str.characters.index(str.startIndex, offsetBy: 7)
+        let expectedRange = str.characters.index(str.startIndex, offsetBy: 3) ..< str.characters.index(str.startIndex, offsetBy: 12)
+        let (value, range) = str.runs[\.testInt][idx]
+        
+        XCTAssertEqual(value, 2)
+        XCTAssertEqual(range, expectedRange)
+    }
+    
+    func testAttributeContainer() {
+        var container = AttributeContainer().testBool(true).testInt(1)
+        XCTAssertEqual(container.testBool, true)
+        XCTAssertNil(container.testString)
+
+        let attrString = AttributedString("Hello", attributes: container)
+        for run in attrString.runs {
+            XCTAssertEqual("Hello", String(attrString.characters[run.range]))
+            XCTAssertEqual(run.testBool, true)
+            XCTAssertEqual(run.testInt, 1)
+        }
+
+        container.testBool = nil
+        XCTAssertNil(container.testBool)
+    }
+    
+    func testAttributeContainerEquality() {
+        let containerA = AttributeContainer().testInt(2).testString("test")
+        let containerB = AttributeContainer().testInt(2).testString("test")
+        let containerC = AttributeContainer().testInt(3).testString("test")
+        let containerD = AttributeContainer.testInt(4)
+        var containerE = AttributeContainer()
+        containerE.testInt = 4
+        
+        XCTAssertEqual(containerA, containerB)
+        XCTAssertNotEqual(containerB, containerC)
+        XCTAssertNotEqual(containerC, containerD)
+        XCTAssertEqual(containerD, containerE)
+    }
+
+    func testAttributeContainerSetOnSubstring() {
+        let container = AttributeContainer().testBool(true).testInt(1)
+
+        var attrString = AttributedString("Hello world", attributes: container)
+
+        let container2 = AttributeContainer().testString("yellow")
+        attrString[attrString.startIndex..<attrString.characters.index(attrString.startIndex, offsetBy: 4)].setAttributes(container2)
+
+        let runs = attrString.runs
+        let run = runs[ runs.startIndex ]
+        XCTAssertEqual(String(attrString.characters[run.range]), "Hell")
+        XCTAssertEqual(run.testString, "yellow")
+    }
+
+    func testSlice() {
+        let attrStr = AttributedString("Hello World")
+        let chars = attrStr.characters
+        let start = chars.index(chars.startIndex, offsetBy: 6)
+        let slice = attrStr[start ..< chars.index(start, offsetBy:5)]
+        XCTAssertEqual(AttributedString(slice), AttributedString("World"))
+    }
+
+    func testCreateStringsFromCharactersWithUnicodeScalarIndexes() {
+        var attrStr = AttributedString("Caf", attributes: AttributeContainer().testString("a"))
+        attrStr += AttributedString("e", attributes: AttributeContainer().testString("b"))
+        attrStr += AttributedString("\u{301}", attributes: AttributeContainer().testString("c"))
+        let strs = attrStr.runs.map { String(attrStr.characters[$0.range]) }
+        XCTAssertEqual(strs, ["Caf", "e", "\u{301}"])
+    }
+
+    func testSettingAttributeOnSlice() throws {
+        var attrString = AttributedString("This is a string.")
+        var range = attrString.startIndex ..< attrString.characters.index(attrString.startIndex, offsetBy: 1)
+        var myInt = 1
+        while myInt < 6 {
+            // ???: Do we want .set(_: KeyValuePair)?
+            // Do it twice to force both the set and replace paths.
+            attrString[range].testInt = myInt
+            attrString[range].testInt = myInt + 7
+            myInt += 1
+            range = range.upperBound ..< attrString.characters.index(after: range.upperBound)
+        }
+
+        myInt = 8
+        for (attribute, _) in attrString.runs[\.testInt] {
+            if let value = attribute {
+                XCTAssertEqual(myInt, value)
+                myInt += 1
+            }
+        }
+
+        var newAttrString = attrString
+        newAttrString.testInt = nil
+
+        for (attribute, _) in newAttrString.runs[\.testInt] {
+            XCTAssertEqual(attribute, nil)
+        }
+
+        let startIndex = attrString.startIndex
+        attrString.characters[startIndex] = "D"
+        XCTAssertEqual(attrString.characters[startIndex], "D")
+    }
+
+    func testExpressibleByStringLiteral() {
+        let variable : AttributedString = "Test"
+        XCTAssertEqual(variable, AttributedString("Test"))
+
+        func takesAttrStr(_ str: AttributedString) {
+            XCTAssertEqual(str, AttributedString("Test"))
+        }
+        takesAttrStr("Test")
+    }
+    
+    func testHashing() {
+        let attrStr = AttributedString("Hello, world.", attributes: .init().testInt(2).testBool(false))
+        let attrStr2 = AttributedString("Hello, world.", attributes: .init().testInt(2).testBool(false))
+        
+        var dictionary = [
+            attrStr : 123
+        ]
+        
+        dictionary[attrStr2] = 456
+        
+        XCTAssertEqual(attrStr, attrStr2)
+        XCTAssertEqual(dictionary[attrStr], 456)
+        XCTAssertEqual(dictionary[attrStr2], 456)
+    }
+    
+    func testUTF16String() {
+        let multiByteCharacters = ["\u{2029}", "\u{1D11E}", "\u{1D122}", "\u{1F91A}\u{1F3FB}"]
+        
+        for str in multiByteCharacters {
+            var attrStr = AttributedString("A" + str)
+            attrStr += AttributedString("B", attributes: .init().testInt(2))
+            attrStr += AttributedString("C", attributes: .init().testInt(3))
+            XCTAssertTrue(attrStr == attrStr)
+            XCTAssertTrue(attrStr.runs == attrStr.runs)
+            XCTAssertEqual(attrStr._guts.runs[0].length, 1 + str.utf8.count)
+        }
+    }
+
+    func testPlusOperators() {
+        let ab = AttributedString("a") + AttributedString("b")
+        XCTAssertEqual(ab, AttributedString("ab"))
+
+        let ab_sub = AttributedString("a") + ab[ab.characters.index(before: ab.endIndex) ..< ab.endIndex]
+        XCTAssertEqual(ab_sub, ab)
+
+        let ab_lit = AttributedString("a") + "b"
+        XCTAssertEqual(ab_lit, ab)
+
+        var abc = ab
+        abc += AttributedString("c")
+        XCTAssertEqual(abc, AttributedString("abc"))
+
+        var abc_sub = ab
+        abc_sub += abc[abc.characters.index(before: abc.endIndex) ..< abc.endIndex]
+        XCTAssertEqual(abc_sub, abc)
+
+        var abc_lit = ab
+        abc_lit += "c"
+        XCTAssertEqual(abc_lit, abc)
+    }
+
+    func testSearch() {
+        let testString = AttributedString("abcdefghi")
+        XCTAssertNil(testString.range(of: "baba"))
+
+        let abc = testString.range(of: "abc")!
+        XCTAssertEqual(abc.lowerBound, testString.startIndex)
+        XCTAssertEqual(testString[abc].string, "abc")
+
+        let def = testString.range(of: "def")!
+        XCTAssertEqual(def.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 3))
+        XCTAssertEqual(testString[def].string, "def")
+
+        let ghi = testString.range(of: "ghi")!
+        XCTAssertEqual(ghi.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 6))
+        XCTAssertEqual(testString[ghi].string, "ghi")
+
+        XCTAssertNil(testString.range(of: "ghij"))
+
+        let substring = testString[testString.index(afterCharacter: testString.startIndex)..<testString.endIndex]
+        XCTAssertNil(substring.range(of: "abc"))
+
+        let BcD = testString.range(of: "BcD", options: [.caseInsensitive])!
+        XCTAssertEqual(BcD.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 1))
+        XCTAssertEqual(testString[BcD].string, "bcd");
+
+        let ghi_backwards = testString.range(of: "ghi", options: [.backwards])!
+        XCTAssertEqual(ghi_backwards.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 6))
+        XCTAssertEqual(testString[ghi_backwards].string, "ghi")
+
+        let abc_backwards = testString.range(of: "abc", options: [.backwards])!
+        XCTAssertEqual(abc_backwards.lowerBound, testString.startIndex)
+        XCTAssertEqual(testString[abc_backwards].string, "abc")
+
+        let abc_anchored = testString.range(of: "abc", options: [.anchored])!
+        XCTAssertEqual(abc_anchored.lowerBound, testString.startIndex)
+        XCTAssertEqual(testString[abc_anchored].string, "abc")
+
+        let ghi_anchored = testString.range(of: "ghi", options: [.backwards, .anchored])!
+        XCTAssertEqual(ghi_anchored.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 6))
+        XCTAssertEqual(testString[ghi_anchored].string, "ghi")
+
+        XCTAssertNil(testString.range(of: "bcd", options: [.anchored]))
+        XCTAssertNil(testString.range(of: "abc", options: [.anchored, .backwards]))
+    }
+
+    func testSubstringSearch() {
+        let fullString = AttributedString("___abcdefghi___")
+        let testString = fullString[ fullString.range(of: "abcdefghi")! ]
+        XCTAssertNil(testString.range(of: "baba"))
+
+        let abc = testString.range(of: "abc")!
+        XCTAssertEqual(abc.lowerBound, testString.startIndex)
+        XCTAssertEqual(testString[abc].string, "abc")
+
+        let def = testString.range(of: "def")!
+        XCTAssertEqual(def.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 3))
+        XCTAssertEqual(testString[def].string, "def")
+
+        let ghi = testString.range(of: "ghi")!
+        XCTAssertEqual(ghi.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 6))
+        XCTAssertEqual(testString[ghi].string, "ghi")
+
+        XCTAssertNil(testString.range(of: "ghij"))
+
+        let substring = testString[testString.index(afterCharacter: testString.startIndex)..<testString.endIndex]
+        XCTAssertNil(substring.range(of: "abc"))
+
+        let BcD = testString.range(of: "BcD", options: [.caseInsensitive])!
+        XCTAssertEqual(BcD.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 1))
+        XCTAssertEqual(testString[BcD].string, "bcd");
+
+        let ghi_backwards = testString.range(of: "ghi", options: [.backwards])!
+        XCTAssertEqual(ghi_backwards.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 6))
+        XCTAssertEqual(testString[ghi_backwards].string, "ghi")
+
+        let abc_backwards = testString.range(of: "abc", options: [.backwards])!
+        XCTAssertEqual(abc_backwards.lowerBound, testString.startIndex)
+        XCTAssertEqual(testString[abc_backwards].string, "abc")
+
+        let abc_anchored = testString.range(of: "abc", options: [.anchored])!
+        XCTAssertEqual(abc_anchored.lowerBound, testString.startIndex)
+        XCTAssertEqual(testString[abc_anchored].string, "abc")
+
+        let ghi_anchored = testString.range(of: "ghi", options: [.backwards, .anchored])!
+        XCTAssertEqual(ghi_anchored.lowerBound, testString.index(testString.startIndex, offsetByCharacters: 6))
+        XCTAssertEqual(testString[ghi_anchored].string, "ghi")
+
+        XCTAssertNil(testString.range(of: "bcd", options: [.anchored]))
+        XCTAssertNil(testString.range(of: "abc", options: [.anchored, .backwards]))
+    }
+
+    func testIndexConversion() {
+        let attrStr = AttributedString("ABCDE")
+        let str = "ABCDE"
+
+        let attrStrIdx = attrStr.index(attrStr.startIndex, offsetByCharacters: 2)
+        XCTAssertEqual(attrStr.characters[attrStrIdx], "C")
+
+        let strIdx = String.Index(attrStrIdx, within: str)!
+        XCTAssertEqual(str[strIdx], "C")
+
+        let reconvertedAttrStrIdex = AttributedString.Index(strIdx, within: attrStr)!
+        XCTAssertEqual(attrStr.characters[reconvertedAttrStrIdex], "C")
+    }
+
+    func testRangeConversion() {
+        let attrStr = AttributedString("ABCDE")
+        let nsAS = NSAttributedString("ABCDE")
+        let str = "ABCDE"
+
+        let attrStrR = attrStr.range(of: "BCD")!
+        let strR = Range(attrStrR, in: str)!
+        let nsASR = NSRange(attrStrR, in: attrStr)
+
+        XCTAssertEqual(nsAS.attributedSubstring(from: nsASR).string, "BCD")
+        XCTAssertEqual(str[strR], "BCD")
+
+        let attrStrR_reconverted1 = Range(strR, in: attrStr)!
+        let attrStrR_reconverted2 = Range(nsASR, in: attrStr)!
+        XCTAssertEqual(attrStr[attrStrR_reconverted1].string, "BCD")
+        XCTAssertEqual(attrStr[attrStrR_reconverted2].string, "BCD")
+    }
+    
+    func testScopedCopy() {
+        var str = AttributedString("A")
+        str += AttributedString("B", attributes: .init().testInt(2))
+        str += AttributedString("C", attributes: .init().link(URL(string: "http://apple.com")!))
+        str += AttributedString("D", attributes: .init().testInt(3).link(URL(string: "http://apple.com")!))
+        
+        struct FoundationAndTest : AttributeScope {
+            let foundation: AttributeScopes.FoundationAttributes
+            let test: AttributeScopes.TestAttributes
+        }
+        XCTAssertEqual(AttributedString(str, including: FoundationAndTest.self), str)
+        
+        struct None : AttributeScope {
+            
+        }
+        XCTAssertEqual(AttributedString(str, including: None.self), AttributedString("ABCD"))
+        
+        var expected = AttributedString("AB")
+        expected += AttributedString("CD", attributes: .init().link(URL(string: "http://apple.com")!))
+        XCTAssertEqual(AttributedString(str, including: \.foundation), expected)
+        
+        expected = AttributedString("A")
+        expected += AttributedString("B", attributes: .init().testInt(2))
+        expected += "C"
+        expected += AttributedString("D", attributes: .init().testInt(3))
+        XCTAssertEqual(AttributedString(str, including: \.test), expected)
+        
+        let range = str.index(afterCharacter: str.startIndex) ..< str.index(beforeCharacter: str.endIndex)
+        expected = AttributedString("B", attributes: .init().testInt(2)) + "C"
+        XCTAssertEqual(AttributedString(str[range], including: \.test), expected)
+        
+        expected = "B" + AttributedString("C", attributes: .init().link(URL(string: "http://apple.com")!))
+        XCTAssertEqual(AttributedString(str[range], including: \.foundation), expected)
+        
+        XCTAssertEqual(AttributedString(str[range], including: None.self), AttributedString("BC"))
+    }
+
+    func testAssignDifferentSubstring() {
+        var attrStr1 = AttributedString("ABCDE")
+        let attrStr2 = AttributedString("XYZ")
+
+        attrStr1[ attrStr1.range(of: "BCD")! ] = attrStr2[ attrStr2.range(of: "X")! ]
+
+        XCTAssertEqual(attrStr1, "AXE")
+    }
+
+    func testCOWDuringSubstringMutation() {
+        func frobnicate(_ sub: inout AttributedSubstring) {
+            var new = sub
+            new.foregroundColor = .blue
+            new.backgroundColor = .black
+            sub = new
+        }
+        var attrStr = AttributedString("ABCDE")
+        frobnicate(&attrStr[ attrStr.range(of: "BCD")! ])
+
+        let expected = AttributedString("A") + AttributedString("BCD", attributes: .init().foregroundColor(.blue).backgroundColor(.black)) + AttributedString("E")
+        XCTAssertEqual(attrStr, expected)
+    }
+
+#if false // This causes an intentional fatalError(), which we can't test for yet, so unfortunately this test can't be enabled.
+    func testReassignmentDuringMutation() {
+        func frobnicate(_ sub: inout AttributedSubstring) {
+            let other = AttributedString("XYZ")
+            sub = other[ other.range(of: "X")! ]
+        }
+        var attrStr = AttributedString("ABCDE")
+        frobnicate(&attrStr[ attrStr.range(of: "BCD")! ])
+
+        XCTAssertEqual(attrStr, "AXE")
+    }
+#endif
+
+    func testAssignDifferentCharacterView() {
+        var attrStr1 = AttributedString("ABC", attributes: .init().foregroundColor(.black)) + AttributedString("DE", attributes: .init().foregroundColor(.white))
+        let attrStr2 = AttributedString("XYZ", attributes: .init().foregroundColor(.blue))
+
+        attrStr1.characters = attrStr2.characters
+        XCTAssertEqual(attrStr1, AttributedString("XYZ", attributes: .init().foregroundColor(.black)))
+    }
+
+    func testCOWDuringCharactersMutation() {
+        func frobnicate(_ chars: inout AttributedString.CharacterView) {
+            var new = chars
+            new.replaceSubrange(chars.startIndex ..< chars.endIndex, with: "XYZ")
+            chars = new
+        }
+        var attrStr = AttributedString("ABCDE", attributes: .init().foregroundColor(.black))
+        frobnicate(&attrStr.characters)
+
+        XCTAssertEqual(attrStr, AttributedString("XYZ", attributes: .init().foregroundColor(.black)))
+    }
+
+    func testAssignDifferentUnicodeScalarView() {
+        var attrStr1 = AttributedString("ABC", attributes: .init().foregroundColor(.black)) + AttributedString("DE", attributes: .init().foregroundColor(.white))
+        let attrStr2 = AttributedString("XYZ", attributes: .init().foregroundColor(.blue))
+
+        attrStr1.unicodeScalars = attrStr2.unicodeScalars
+        XCTAssertEqual(attrStr1, AttributedString("XYZ", attributes: .init().foregroundColor(.black)))
+    }
+
+    func testCOWDuringUnicodeScalarsMutation() {
+        func frobnicate(_ chars: inout AttributedString.CharacterView) {
+            var new = chars
+            new.replaceSubrange(chars.startIndex ..< chars.endIndex, with: "XYZ")
+            chars = new
+        }
+        var attrStr = AttributedString("ABCDE", attributes: .init().foregroundColor(.black))
+        frobnicate(&attrStr.characters)
+
+        XCTAssertEqual(attrStr, AttributedString("XYZ", attributes: .init().foregroundColor(.black)))
+    }
+
+
+#if false
+    func testAttributeFixing() {
+        var str =
+            AttributedString("This is a mis") +
+            AttributedString("pel", attributes: AttributeContainer().misspelled(true)) +
+            AttributedString("led word")
+        
+        str.fixAttributes(in: AttributeScopes.TestAttributes.self)
+        
+        let expected =
+            AttributedString("This is a ") +
+            AttributedString("mispelled", attributes: AttributeContainer().misspelled(true)) +
+            AttributedString(" word")
+        XCTAssertEqual(str, expected)
+    }
+#endif
+    
+    static var allTests: [(String, (TestAttributedString) -> () throws -> Void)] {
+        var tests = [
+            ("testEmptyEnumeration", testEmptyEnumeration),
+            ("testSimpleEnumeration", testSimpleEnumeration),
+            ("testSliceEnumeration", testSliceEnumeration),
+            ("testSimpleAttribute", testSimpleAttribute),
+            ("testConstructorAttribute", testConstructorAttribute),
+            ("testAddAndRemoveAttribute", testAddAndRemoveAttribute),
+            ("testAddingAndRemovingAttribute", testAddingAndRemovingAttribute),
+            ("testScopedAttributes", testScopedAttributes),
+            ("testRunAttributes", testRunAttributes),
+            ("testAttributedStringEquality", testAttributedStringEquality),
+            ("testAttributedSubstringEquality", testAttributedSubstringEquality),
+            ("testRunEquality", testRunEquality),
+            ("testSubstringRunEquality", testSubstringRunEquality),
+            ("testDirectMutationCopyOnWrite", testDirectMutationCopyOnWrite),
+            ("testAttributeMutationCopyOnWrite", testAttributeMutationCopyOnWrite),
+            ("testSliceAttributeMutation", testSliceAttributeMutation),
+            ("testEnumerationAttributeMutation", testEnumerationAttributeMutation),
+            ("testMutateMultipleAttributes", testMutateMultipleAttributes),
+            ("testMutateAttributes", testMutateAttributes),
+            ("testReplaceAttributes", testReplaceAttributes),
+            ("testSliceMutation", testSliceMutation),
+            ("testOverlappingSliceMutation", testOverlappingSliceMutation),
+            ("testCharacters_replaceSubrange", testCharacters_replaceSubrange),
+            ("testCharactersMutation_append", testCharactersMutation_append),
+            ("testUnicodeScalars_replaceSubrange", testUnicodeScalars_replaceSubrange),
+            ("testUnicodeScalarsMutation_append", testUnicodeScalarsMutation_append),
+            ("testSubCharacterAttributeSetting", testSubCharacterAttributeSetting),
+            ("testReplaceSubrange_rangeExpression", testReplaceSubrange_rangeExpression),
+            ("testSettingAttributes", testSettingAttributes),
+            ("testAddAttributedString", testAddAttributedString),
+            ("testReplaceSubrangeWithSubstrings", testReplaceSubrangeWithSubstrings),
+            ("testCoalescing", testCoalescing),
+            ("testReplaceWithEmptyElements", testReplaceWithEmptyElements),
+            ("testDescription", testDescription),
+            ("testContainerDescription", testContainerDescription),
+            ("testRunAndSubstringDescription", testRunAndSubstringDescription),
+            ("testReplacingAttributes", testReplacingAttributes),
+            ("testScopedAttributeContainer", testScopedAttributeContainer),
+            ("testMergeAttributes", testMergeAttributes),
+            ("testMergeAttributeContainers", testMergeAttributeContainers),
+            ("testChangingSingleCharacterUTF8Length", testChangingSingleCharacterUTF8Length),
+            ("testSubstringBase", testSubstringBase),
+            ("testSubstringGetAttribute", testSubstringGetAttribute),
+            ("testSubstringDescription", testSubstringDescription),
+            ("testJSONEncoding", testJSONEncoding),
+            ("testDecodingThenConvertingToNSAttributedString", testDecodingThenConvertingToNSAttributedString),
+            ("testCustomAttributeCoding", testCustomAttributeCoding),
+            ("testCustomCodableTypeWithCodableAttributedString", testCustomCodableTypeWithCodableAttributedString),
+            ("testCodingErrorsPropogateUpToCallSite", testCodingErrorsPropogateUpToCallSite),
+            ("testEncodeWithPartiallyCodableScope", testEncodeWithPartiallyCodableScope),
+            ("testAutomaticCoding", testAutomaticCoding),
+            ("testManualCoding", testManualCoding),
+            ("testDecodingCorruptedData", testDecodingCorruptedData),
+            ("testCodableRawRepresentableAttribute", testCodableRawRepresentableAttribute),
+            ("testContainerEncoding", testContainerEncoding),
+            ("testDefaultAttributesCoding", testDefaultAttributesCoding),
+            ("testConversionToObjC", testConversionToObjC),
+            ("testConversionFromObjC", testConversionFromObjC),
+            ("testRoundTripConversion_boxed", testRoundTripConversion_boxed),
+            ("testRoundTripConversion_customConversion", testRoundTripConversion_customConversion),
+            ("testIncompleteConversionFromObjC", testIncompleteConversionFromObjC),
+            ("testIncompleteConversionToObjC", testIncompleteConversionToObjC),
+            ("testConversionNestedScope", testConversionNestedScope),
+            ("testConversionAttributeContainers", testConversionAttributeContainers),
+            ("testConversionFromInvalidObjectiveCValueTypes", testConversionFromInvalidObjectiveCValueTypes),
+            ("testConversionToUTF16", testConversionToUTF16),
+            ("testConversionIncludingOnly", testConversionIncludingOnly),
+            ("testConversionCoalescing", testConversionCoalescing),
+            ("testCharViewIndexing_backwardsFromEndIndex", testCharViewIndexing_backwardsFromEndIndex),
+            ("testAttrViewIndexing", testAttrViewIndexing),
+            ("testUnicodeScalarsViewIndexing", testUnicodeScalarsViewIndexing),
+            ("testUnicodeScalarsSlicing", testUnicodeScalarsSlicing),
+            ("testInitWithSequence", testInitWithSequence),
+            ("testLongestEffectiveRangeOfAttribute", testLongestEffectiveRangeOfAttribute),
+            ("testAttributeContainer", testAttributeContainer),
+            ("testAttributeContainerEquality", testAttributeContainerEquality),
+            ("testAttributeContainerSetOnSubstring", testAttributeContainerSetOnSubstring),
+            ("testSlice", testSlice),
+            ("testCreateStringsFromCharactersWithUnicodeScalarIndexes", testCreateStringsFromCharactersWithUnicodeScalarIndexes),
+            ("testSettingAttributeOnSlice", testSettingAttributeOnSlice),
+            ("testExpressibleByStringLiteral", testExpressibleByStringLiteral),
+            ("testHashing", testHashing),
+            ("testUTF16String", testUTF16String),
+            ("testPlusOperators", testPlusOperators),
+            ("testSearch", testSearch),
+            ("testSubstringSearch", testSubstringSearch),
+            ("testIndexConversion", testIndexConversion),
+            ("testRangeConversion", testRangeConversion),
+            ("testScopedCopy", testScopedCopy),
+            ("testAssignDifferentSubstring", testAssignDifferentSubstring),
+            ("testCOWDuringSubstringMutation", testCOWDuringSubstringMutation),
+            ("testAssignDifferentCharacterView", testAssignDifferentCharacterView),
+            ("testCOWDuringCharactersMutation", testCOWDuringCharactersMutation),
+            ("testAssignDifferentUnicodeScalarView", testAssignDifferentUnicodeScalarView),
+            ("testCOWDuringUnicodeScalarsMutation", testCOWDuringUnicodeScalarsMutation)
+        ]
+        
+        #if os(macOS)
+        tests.append(("testConversionWithoutScope", testConversionWithoutScope))
+        #endif
+
+        return tests
+    }
+
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+fileprivate extension AttributedString {
+    var string : String {
+        return _guts.string
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+fileprivate extension AttributedSubstring {
+    var string: Substring {
+        return _guts.string[_range._stringRange]
+    }
+}

--- a/Tests/Foundation/Tests/TestAttributedStringCOW.swift
+++ b/Tests/Foundation/Tests/TestAttributedStringCOW.swift
@@ -1,0 +1,182 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributedStringProtocol {
+    fileprivate mutating func genericSetAttribute() {
+        self.testInt = 3
+    }
+}
+
+/// Tests for `AttributedString` to confirm expected CoW behavior
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+final class TestAttributedStringCOW: XCTestCase {
+    
+    // MARK: - Utility Functions
+    
+    func createAttributedString() -> AttributedString {
+        var str = AttributedString("Hello", attributes: container)
+        str += AttributedString(" ")
+        str += AttributedString("World", attributes: containerB)
+        return str
+    }
+    
+    func assertCOWCopy(file: StaticString = #file, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
+        let str = createAttributedString()
+        var copy = str
+        operation(&copy)
+        XCTAssertNotEqual(str, copy, "Mutation operation did not copy when multiple references exist", file: file, line: line)
+    }
+    
+    func assertCOWNoCopy(file: StaticString = #file, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
+        var str = createAttributedString()
+        let gutsPtr = Unmanaged.passUnretained(str._guts)
+        operation(&str)
+        let newGutsPtr = Unmanaged.passUnretained(str._guts)
+        XCTAssertEqual(gutsPtr.toOpaque(), newGutsPtr.toOpaque(), "Mutation operation copied when only one reference exists", file: file, line: line)
+    }
+    
+    func assertCOWBehavior(file: StaticString = #file, line: UInt = #line, _ operation: (inout AttributedString) -> Void) {
+        assertCOWCopy(file: file, line: line, operation)
+        assertCOWNoCopy(file: file, line: line, operation)
+    }
+    
+    func makeSubrange(_ str: AttributedString) -> Range<AttributedString.Index> {
+        return str.characters.index(str.startIndex, offsetBy: 2)..<str.characters.index(str.endIndex, offsetBy: -2)
+    }
+    
+    lazy var container: AttributeContainer = {
+        var container = AttributeContainer()
+        container.testInt = 2
+        return container
+    }()
+    
+    lazy var containerB: AttributeContainer = {
+        var container = AttributeContainer()
+        container.testBool = true
+        return container
+    }()
+    
+    // MARK: - Tests
+    
+    func testTopLevelType() {
+        assertCOWBehavior { (str) in
+            str.setAttributes(container)
+        }
+        assertCOWBehavior { (str) in
+            str.mergeAttributes(container)
+        }
+        assertCOWBehavior { (str) in
+            str.replaceAttributes(container, with: containerB)
+        }
+        assertCOWBehavior { (str) in
+            str.append(AttributedString("b", attributes: containerB))
+        }
+        assertCOWBehavior { (str) in
+            str.insert(AttributedString("b", attributes: containerB), at: str.startIndex)
+        }
+        assertCOWBehavior { (str) in
+            str.removeSubrange(..<str.characters.index(str.startIndex, offsetBy: 3))
+        }
+        assertCOWBehavior { (str) in
+            str.replaceSubrange(..<str.characters.index(str.startIndex, offsetBy: 3), with: AttributedString("b", attributes: containerB))
+        }
+        assertCOWBehavior { (str) in
+            str[AttributeScopes.TestAttributes.TestIntAttribute.self] = 3
+        }
+        assertCOWBehavior { (str) in
+            str.testInt = 3
+        }
+        assertCOWBehavior { (str) in
+            str.test.testInt = 3
+        }
+    }
+    
+    func testSubstring() {
+        assertCOWBehavior { (str) in
+            str[makeSubrange(str)].setAttributes(container)
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubrange(str)].mergeAttributes(container)
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubrange(str)].replaceAttributes(container, with: containerB)
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubrange(str)][AttributeScopes.TestAttributes.TestIntAttribute.self] = 3
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubrange(str)].testInt = 3
+        }
+        assertCOWBehavior { (str) in
+            str[makeSubrange(str)].test.testInt = 3
+        }
+    }
+    
+    func testCharacters() {
+        let char: Character = "a"
+        
+        assertCOWBehavior { (str) in
+            str.characters.replaceSubrange(makeSubrange(str), with: "abc")
+        }
+        assertCOWBehavior { (str) in
+            str.characters.append(char)
+        }
+        assertCOWBehavior { (str) in
+            str.characters.append(contentsOf: "abc")
+        }
+        assertCOWBehavior { (str) in
+            str.characters.append(contentsOf: [char, char, char])
+        }
+        assertCOWBehavior { (str) in
+            str.characters[str.startIndex] = "A"
+        }
+        assertCOWBehavior { (str) in
+            str.characters[makeSubrange(str)].append("a")
+        }
+    }
+    
+    func testUnicodeScalars() {
+        let scalar: UnicodeScalar = "a"
+        
+        assertCOWBehavior { (str) in
+            str.unicodeScalars.replaceSubrange(makeSubrange(str), with: [scalar, scalar])
+        }
+    }
+    
+    func testGenericProtocol() {
+        assertCOWBehavior {
+            $0.genericSetAttribute()
+        }
+        assertCOWBehavior {
+            $0[makeSubrange($0)].genericSetAttribute()
+        }
+    }
+    
+    static var allTests: [(String, (TestAttributedStringCOW) -> () throws -> Void)] {
+        return [
+            ("testTopLevelType", testTopLevelType),
+            ("testSubstring", testSubstring),
+            ("testCharacters", testCharacters),
+            ("testUnicodeScalars", testUnicodeScalars),
+            ("testGenericProtocol", testGenericProtocol)
+        ]
+    }
+}

--- a/Tests/Foundation/Tests/TestAttributedStringPerformance.swift
+++ b/Tests/Foundation/Tests/TestAttributedStringPerformance.swift
@@ -1,0 +1,428 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
+
+/// Performance tests for `AttributedString` and its associated objects
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+final class TestAttributedStringPerformance: XCTestCase {
+    
+    /// Set to true to record a baseline for equivalent operations on `NSAttributedString`
+    static let runWithNSAttributedString = false
+    
+    func createLongString() -> AttributedString {
+        var str = AttributedString(String(repeating: "a", count: 10000), attributes: AttributeContainer().testInt(1))
+        str += AttributedString(String(repeating: "b", count: 10000), attributes: AttributeContainer().testInt(2))
+        str += AttributedString(String(repeating: "c", count: 10000), attributes: AttributeContainer().testInt(3))
+        return str
+    }
+    
+    func createManyAttributesString() -> AttributedString {
+        var str = AttributedString("a")
+        for i in 0..<10000 {
+            str += AttributedString("a", attributes: AttributeContainer().testInt(i))
+        }
+        return str
+    }
+    
+    func createLongNSString() -> NSMutableAttributedString {
+        let str = NSMutableAttributedString(string: String(repeating: "a", count: 10000), attributes: [.testInt: NSNumber(1)])
+        str.append(NSMutableAttributedString(string: String(repeating: "b", count: 10000), attributes: [.testInt: NSNumber(2)]))
+        str.append(NSMutableAttributedString(string: String(repeating: "c", count: 10000), attributes: [.testInt: NSNumber(3)]))
+        return str
+    }
+    
+    func createManyAttributesNSString() -> NSMutableAttributedString {
+        let str = NSMutableAttributedString(string: "a")
+        for i in 0..<10000 {
+            str.append(NSAttributedString(string: "a", attributes: [.testInt: NSNumber(value: i)]))
+        }
+        return str
+    }
+    
+    // MARK: - String Manipulation
+    
+    func testInsertIntoLongString() {
+        var str = createLongString()
+        let idx = str.characters.index(str.startIndex, offsetBy: str.characters.count / 2)
+        let toInsert = AttributedString(String(repeating: "c", count: str.characters.count))
+        
+        let strNS = createLongNSString()
+        let idxNS = str.characters.count / 2
+        let toInsertNS = NSAttributedString(string: String(repeating: "c", count: str.characters.count))
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.insert(toInsertNS, at: idxNS)
+            } else {
+                str.insert(toInsert, at: idx)
+            }
+        }
+    }
+    
+    func testReplaceSubrangeOfLongString() {
+        var str = createLongString()
+        let start = str.characters.index(str.startIndex, offsetBy: str.characters.count / 2)
+        let range = start ... str.characters.index(start, offsetBy: 10)
+        let toInsert = AttributedString(String(repeating: "d", count: str.characters.count / 2), attributes: AttributeContainer().testDouble(2.5))
+        
+        let strNS = createLongNSString()
+        let startNS = strNS.string.count / 2
+        let rangeNS = NSRange(location: startNS, length: 10)
+        let toInsertNS = NSAttributedString(string: String(repeating: "d", count: strNS.string.count / 2), attributes: [.testDouble: NSNumber(value: 2.5)])
+        
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.replaceCharacters(in: rangeNS, with: toInsertNS)
+            } else {
+                str.replaceSubrange(range, with: toInsert)
+            }
+        }
+    }
+    
+    // MARK: - Attribute Manipulation
+    
+    func testSetAttribute() {
+        var str = createManyAttributesString()
+        let strNS = createManyAttributesNSString()
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.addAttributes([.testDouble: NSNumber(value: 1.5)], range: NSRange(location: 0, length: strNS.string.count))
+            } else {
+                str.testDouble = 1.5
+            }
+        }
+    }
+    
+    func testGetAttribute() {
+        let str = createManyAttributesString()
+        let strNS = createManyAttributesNSString()
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.enumerateAttribute(.testDouble, in: NSRange(location: 0, length: strNS.string.count), options: []) { (attr, range, pointer) in
+                    let _ = attr
+                }
+            } else {
+                let _ = str.testDouble
+            }
+        }
+    }
+    
+    func testSetAttributeSubrange() {
+        var str = createManyAttributesString()
+        let range = str.characters.index(str.startIndex, offsetBy: str.characters.count / 2)...
+        
+        let strNS = createManyAttributesNSString()
+        let rangeNS = NSRange(location: 0, length: str.characters.count / 2)
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.addAttributes([.testDouble: NSNumber(value: 1.5)], range: rangeNS)
+            } else {
+                str[range].testDouble = 1.5
+            }
+        }
+    }
+    
+    func testGetAttributeSubrange() {
+        let str = createManyAttributesString()
+        let range = str.characters.index(str.startIndex, offsetBy: str.characters.count / 2)...
+        
+        let strNS = createManyAttributesNSString()
+        let rangeNS = NSRange(location: 0, length: str.characters.count / 2)
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.enumerateAttribute(.testDouble, in: rangeNS, options: []) { (attr, range, pointer) in
+                    let _ = attr
+                }
+            } else {
+                let _ = str[range].testDouble
+            }
+        }
+    }
+    
+    func testModifyAttributes() {
+        let str = createManyAttributesString()
+        let strNS = createManyAttributesNSString()
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.enumerateAttribute(.testInt, in: NSRange(location: 0, length: strNS.string.count), options: []) { (val, range, pointer) in
+                    if let value = val as? NSNumber {
+                        strNS.addAttributes([.testInt: NSNumber(value: value.intValue + 2)], range: range)
+                    }
+                }
+            } else {
+                let _ = str.transformingAttributes(\.testInt) { transformer in
+                    if let val = transformer.value {
+                        transformer.value = val + 2
+                    }
+                }
+            }
+        }
+    }
+    
+    func testReplaceAttributes() {
+        var str = createManyAttributesString()
+        let old = AttributeContainer().testInt(100)
+        let new = AttributeContainer().testDouble(100.5)
+        
+        let strNS = createManyAttributesNSString()
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.enumerateAttribute(.testInt, in: NSRange(location: 0, length: strNS.string.count), options: []) { (val, range, pointer) in
+                    if let value = val as? NSNumber, value == 100 {
+                        strNS.removeAttribute(.testInt, range: range)
+                        strNS.addAttribute(.testDouble, value: NSNumber(value: 100.5), range: range)
+                    }
+                }
+            } else {
+                str.replaceAttributes(old, with: new)
+            }
+        }
+    }
+    
+    func testMergeMultipleAttributes() throws {
+        var str = createManyAttributesString()
+        let new = AttributeContainer().testDouble(1.5).testString("test")
+        
+        let strNS = createManyAttributesNSString()
+        let newNS: [NSAttributedString.Key: Any] = [.testDouble: NSNumber(value: 1.5), .testString: "test"]
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.addAttributes(newNS, range: NSRange(location: 0, length: strNS.string.count))
+            } else {
+                str.mergeAttributes(new)
+            }
+        }
+    }
+    
+    func testSetMultipleAttributes() throws {
+        var str = createManyAttributesString()
+        let new = AttributeContainer().testDouble(1.5).testString("test")
+        
+        let strNS = createManyAttributesNSString()
+        let rangeNS = NSRange(location: 0, length: str.characters.count / 2)
+        let newNS: [NSAttributedString.Key: Any] = [.testDouble: NSNumber(value: 1.5), .testString: "test"]
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.setAttributes(newNS, range: rangeNS)
+            } else {
+                str.setAttributes(new)
+            }
+        }
+    }
+    
+    // MARK: - Attribute Enumeration
+    
+    func testEnumerateAttributes() {
+        let str = createManyAttributesString()
+        let strNS = createManyAttributesNSString()
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.enumerateAttributes(in: NSRange(location: 0, length: strNS.string.count), options: []) { (attrs, range, pointer) in
+                    
+                }
+            } else {
+                for _ in str.runs {
+                    
+                }
+            }
+        }
+    }
+    
+    func testEnumerateAttributesSlice() {
+        let str = createManyAttributesString()
+        let strNS = createManyAttributesNSString()
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                strNS.enumerateAttribute(.testInt, in: NSRange(location: 0, length: strNS.string.count), options: []) { (val, range, pointer) in
+                    
+                }
+            } else {
+                for (_, _) in str.runs[\.testInt] {
+                    
+                }
+            }
+        }
+    }
+    
+    // MARK: - NSAS Conversion
+    
+    func testConvertToNSAS() throws {
+        guard !TestAttributedStringPerformance.runWithNSAttributedString else {
+            throw XCTSkip("Test disabled for NSAS")
+        }
+        
+        let str = createManyAttributesString()
+        
+        self.measure {
+            let _ = try! NSAttributedString(str, including: AttributeScopes.TestAttributes.self)
+        }
+    }
+    
+    func testConvertFromNSAS() throws {
+        guard !TestAttributedStringPerformance.runWithNSAttributedString else {
+            throw XCTSkip("Test disabled for NSAS")
+        }
+        
+        let str = createManyAttributesString()
+        let ns = try NSAttributedString(str, including: AttributeScopes.TestAttributes.self)
+        
+        self.measure {
+            let _ = try! AttributedString(ns, including: AttributeScopes.TestAttributes.self)
+        }
+    }
+    
+    // MARK: - Encoding and Decoding
+    
+    func testEncode() throws {
+        struct CodableType: Codable {
+            @CodableConfiguration(from: AttributeScopes.TestAttributes.self)
+            var str = AttributedString()
+        }
+        
+        let str = createManyAttributesString()
+        let codableType = CodableType(str: str)
+        let encoder = JSONEncoder()
+        
+        let ns = createManyAttributesNSString()
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                let _ = try! NSKeyedArchiver.archivedData(withRootObject: ns, requiringSecureCoding: false)
+            } else {
+                let _ = try! encoder.encode(codableType)
+            }
+        }
+    }
+    
+    func testDecode() throws {
+        struct CodableType: Codable {
+            @CodableConfiguration(from: AttributeScopes.TestAttributes.self)
+            var str = AttributedString()
+        }
+        
+        let str = createManyAttributesString()
+        let codableType = CodableType(str: str)
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(codableType)
+        let decoder = JSONDecoder()
+        
+        let dataNS: Data
+        if TestAttributedStringPerformance.runWithNSAttributedString {
+            let ns = createManyAttributesNSString()
+            dataNS = try NSKeyedArchiver.archivedData(withRootObject: ns, requiringSecureCoding: false)
+        } else {
+            dataNS = Data()
+        }
+        
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                let _ = try! NSKeyedUnarchiver.unarchiveTopLevelObjectWithData(dataNS)
+            } else {
+                let _ = try! decoder.decode(CodableType.self, from: data)
+            }
+        }
+    }
+    
+    // MARK: - Other
+    
+    func testCreateLongString() {
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                let _ = createLongNSString()
+            } else {
+                let _ = createLongString()
+            }
+        }
+    }
+    
+    func testCreateManyAttributesString() {
+        self.measure {
+            if TestAttributedStringPerformance.runWithNSAttributedString {
+                let _ = createManyAttributesNSString()
+            } else {
+                let _ = createManyAttributesString()
+            }
+        }
+    }
+    
+    func testEquality() throws {
+        guard !TestAttributedStringPerformance.runWithNSAttributedString else {
+            throw XCTSkip("Test disabled for NSAS")
+        }
+        
+        let str = createManyAttributesString()
+        let str2 = createManyAttributesString()
+        
+        self.measure {
+            _ = str == str2
+        }
+    }
+    
+    func testSubstringEquality() throws {
+        guard !TestAttributedStringPerformance.runWithNSAttributedString else {
+            throw XCTSkip("Test disabled for NSAS")
+        }
+        
+        let str = createManyAttributesString()
+        let str2 = createManyAttributesString()
+        let range = str.characters.index(str.startIndex, offsetBy: str.characters.count / 2)...
+        let substring = str[range]
+        let substring2 = str2[range]
+        
+        self.measure {
+            _ = substring == substring2
+        }
+    }
+    
+    static var allTests: [(String, (TestAttributedStringPerformance) -> () throws -> Void)] {
+        return [
+            ("testInsertIntoLongString", testInsertIntoLongString),
+            ("testReplaceSubrangeOfLongString", testReplaceSubrangeOfLongString),
+            ("testSetAttribute", testSetAttribute),
+            ("testGetAttribute", testGetAttribute),
+            ("testSetAttributeSubrange", testSetAttributeSubrange),
+            ("testGetAttributeSubrange", testGetAttributeSubrange),
+            ("testModifyAttributes", testModifyAttributes),
+            ("testReplaceAttributes", testReplaceAttributes),
+            ("testMergeMultipleAttributes", testMergeMultipleAttributes),
+            ("testSetMultipleAttributes", testSetMultipleAttributes),
+            ("testEnumerateAttributes", testEnumerateAttributes),
+            ("testEnumerateAttributesSlice", testEnumerateAttributesSlice),
+            ("testConvertToNSAS", testConvertToNSAS),
+            ("testConvertFromNSAS", testConvertFromNSAS),
+            ("testEncode", testEncode),
+            ("testDecode", testDecode),
+            ("testCreateLongString", testCreateLongString),
+            ("testCreateManyAttributesString", testCreateManyAttributesString),
+            ("testEquality", testEquality),
+            ("testSubstringEquality", testSubstringEquality)
+        ]
+    }
+}

--- a/Tests/Foundation/Tests/TestAttributedStringSupport.swift
+++ b/Tests/Foundation/Tests/TestAttributedStringSupport.swift
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
+
+extension NSAttributedString.Key {
+    static let testInt = NSAttributedString.Key("TestInt")
+    static let testString = NSAttributedString.Key("TestString")
+    static let testDouble = NSAttributedString.Key("TestDouble")
+    static let testBool = NSAttributedString.Key("TestBool")
+    static let link: NSAttributedString.Key = .init(rawValue: "NSLink")
+}
+
+struct Color : Hashable, Codable {
+    let name: String
+    
+    static let black: Color = Color(name: "black")
+    static let blue: Color = Color(name: "black")
+    static let white: Color = Color(name: "white")
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributeScopes.TestAttributes {
+
+    enum TestIntAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        typealias Value = Int
+        static let name = "TestInt"
+    }
+
+    enum TestStringAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        typealias Value = String
+        static let name = "TestString"
+    }
+
+    enum TestDoubleAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        typealias Value = Double
+        static let name = "TestDouble"
+    }
+
+    enum TestBoolAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        typealias Value = Bool
+        static let name = "TestBool"
+    }
+    
+    enum TestForegroundColorAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        typealias Value = Color
+        static let name = "ForgroundColor"
+    }
+    
+    enum TestBackgroundColorAttribute: CodableAttributedStringKey, MarkdownDecodableAttributedStringKey {
+        typealias Value = Color
+        static let name = "BackgroundColor"
+    }
+
+    #if false
+    @frozen enum MisspelledAttribute : CodableAttributedStringKey, FixableAttribute {
+        typealias Value = Bool
+        static let name = "Misspelled"
+        
+        public static func fixAttribute(in string: inout AttributedString) {
+            let words = string.characters.subranges {
+                !$0.isWhitespace && !$0.isPunctuation
+            }
+            
+            // First make sure that no non-words are marked as misspelled
+            let nonWords = RangeSet(string.startIndex ..< string.endIndex).subtracting(words)
+            string[nonWords].misspelled = nil
+            
+            // Then make sure that any word ranges containing the attribute span the entire word
+            for (misspelled, range) in string.runs[\.misspelledAttribute] {
+                if let misspelled = misspelled, misspelled {
+                    let fullRange = words.ranges[words.ranges.firstIndex { $0.contains(range.lowerBound) }!]
+                    string[fullRange].misspelled = true
+                }
+            }
+        }
+    }
+    #endif
+
+    enum NonCodableAttribute : AttributedStringKey {
+        typealias Value = NonCodableType
+        static let name = "NonCodable"
+    }
+
+    enum CustomCodableAttribute : CodableAttributedStringKey {
+        typealias Value = NonCodableType
+        static let name = "NonCodableConvertible"
+        
+        static func encode(_ value: NonCodableType, to encoder: Encoder) throws {
+            var c = encoder.singleValueContainer()
+            try c.encode(value.inner)
+        }
+        
+        static func decode(from decoder: Decoder) throws -> NonCodableType {
+            let c = try decoder.singleValueContainer()
+            let inner = try c.decode(Int.self)
+            return NonCodableType(inner: inner)
+        }
+    }
+    
+}
+
+struct NonCodableType : Hashable {
+    var inner : Int
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributeScopes {
+    var test: TestAttributes.Type { TestAttributes.self }
+    
+    struct TestAttributes : AttributeScope {
+        var testInt : TestIntAttribute
+        var testString : TestStringAttribute
+        var testDouble : TestDoubleAttribute
+        var testBool : TestBoolAttribute
+        var foregroundColor: TestForegroundColorAttribute
+        var backgroundColor: TestBackgroundColorAttribute
+    #if false
+        var misspelled : MisspelledAttribute
+    #endif
+    }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+extension AttributeDynamicLookup {
+    subscript<T: AttributedStringKey>(dynamicMember keyPath: KeyPath<AttributeScopes.TestAttributes, T>) -> T {
+        get { self[T.self] }
+    }
+}

--- a/Tests/Foundation/Utilities.swift
+++ b/Tests/Foundation/Utilities.swift
@@ -136,6 +136,10 @@ func _checkHashing<Source: Hashable, Target: Hashable, S: Sequence>(
 enum TestError: Error {
     case unexpectedNil
     case fileCreationFailed
+    case encodingError
+    case decodingError
+    case conversionError
+    case markdownError
 }
 
 extension Optional {

--- a/Tests/Foundation/main.swift
+++ b/Tests/Foundation/main.swift
@@ -126,6 +126,14 @@ var allTestCases = [
     testCase(TestNSSortDescriptor.allTests),
 ]
 
+if #available(macOS 12, *) {
+    allTestCases.append(contentsOf: [
+        testCase(TestAttributedString.allTests),
+        testCase(TestAttributedStringCOW.allTests),
+        testCase(TestAttributedStringPerformance.allTests)
+    ])
+}
+
 #if !os(Windows)
 allTestCases.append(contentsOf: [
     testCase(TestURLSession.allTests),


### PR DESCRIPTION
This patch introduces struct `AttributedString` and tests. Markdown support is not included in this patch as it will be introduced in a separate package.

See Apple's [documentation](https://developer.apple.com/documentation/foundation/attributedstring/) for more information.
