### PR TITLE
Synchronize `Decimal` overlay and corelibs-foundation implementations

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -386,6 +386,13 @@ class TestDecimal : XCTestCase {
         XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN e4")
         XCTAssertNotEqual(.noError, NSDecimalMultiplyByPowerOf10(&result, &NaN, 5, .plain))
         XCTAssertTrue(NSDecimalIsNotANumber(&result), "NaN e5")
+
+        XCTAssertFalse(Double(truncating: NSDecimalNumber(decimal: Decimal(0))).isNaN)
+        XCTAssertTrue(Decimal(Double.leastNonzeroMagnitude).isNaN)
+        XCTAssertTrue(Decimal(Double.leastNormalMagnitude).isNaN)
+        XCTAssertTrue(Decimal(Double.greatestFiniteMagnitude).isNaN)
+        XCTAssertTrue(Decimal(Double("1e-129")!).isNaN)
+        XCTAssertTrue(Decimal(Double("0.1e-128")!).isNaN)
     }
 
     func test_NegativeAndZeroMultiplication() {
@@ -597,4 +604,95 @@ class TestDecimal : XCTestCase {
     func test_unconditionallyBridgeFromObjectiveC() {
         XCTAssertEqual(Decimal(), Decimal._unconditionallyBridgeFromObjectiveC(nil))
     }
+
+    func test_parseDouble() throws {
+        XCTAssertEqual(Decimal(Double(0.0)), Decimal(Int.zero))
+        XCTAssertEqual(Decimal(Double(-0.0)), Decimal(Int.zero))
+
+        // These values can only be represented as Decimal.nan
+        XCTAssertEqual(Decimal(Double.nan), Decimal.nan)
+        XCTAssertEqual(Decimal(Double.signalingNaN), Decimal.nan)
+
+        // These values are out out range for Decimal
+        XCTAssertEqual(Decimal(-Double.leastNonzeroMagnitude), Decimal.nan)
+        XCTAssertEqual(Decimal(Double.leastNonzeroMagnitude), Decimal.nan)
+        XCTAssertEqual(Decimal(-Double.leastNormalMagnitude), Decimal.nan)
+        XCTAssertEqual(Decimal(Double.leastNormalMagnitude), Decimal.nan)
+        XCTAssertEqual(Decimal(-Double.greatestFiniteMagnitude), Decimal.nan)
+        XCTAssertEqual(Decimal(Double.greatestFiniteMagnitude), Decimal.nan)
+
+        // SR-13837
+        let testDoubles: [(Double, String)] = [
+            (1.8446744073709550E18, "1844674407370954752"),
+            (1.8446744073709551E18, "1844674407370954752"),
+            (1.8446744073709552E18, "1844674407370955264"),
+            (1.8446744073709553E18, "1844674407370955264"),
+            (1.8446744073709554E18, "1844674407370955520"),
+            (1.8446744073709555E18, "1844674407370955520"),
+
+            (1.8446744073709550E19, "18446744073709547520"),
+            (1.8446744073709551E19, "18446744073709552640"),
+            (1.8446744073709552E19, "18446744073709552640"),
+            (1.8446744073709553E19, "18446744073709552640"),
+            (1.8446744073709554E19, "18446744073709555200"),
+            (1.8446744073709555E19, "18446744073709555200"),
+
+            (1.8446744073709550E20, "184467440737095526400"),
+            (1.8446744073709551E20, "184467440737095526400"),
+            (1.8446744073709552E20, "184467440737095526400"),
+            (1.8446744073709553E20, "184467440737095526400"),
+            (1.8446744073709554E20, "184467440737095552000"),
+            (1.8446744073709555E20, "184467440737095552000"),
+        ]
+
+        for (d, s) in testDoubles {
+            XCTAssertEqual(Decimal(d), Decimal(string: s))
+            XCTAssertEqual(Decimal(d).description, try XCTUnwrap(Decimal(string: s)).description)
+        }
+    }
+
+    func test_initExactly() {
+        // This really requires some tests using a BinaryInteger of bitwidth > 128 to test failures.
+        let d1 = Decimal(exactly: UInt64.max)
+        XCTAssertNotNil(d1)
+        XCTAssertEqual(d1?.description, UInt64.max.description)
+        XCTAssertEqual(d1?._length, 4)
+
+        let d2 = Decimal(exactly: Int64.min)
+        XCTAssertNotNil(d2)
+        XCTAssertEqual(d2?.description, Int64.min.description)
+        XCTAssertEqual(d2?._length, 4)
+
+        let d3 = Decimal(exactly: Int64.max)
+        XCTAssertNotNil(d3)
+        XCTAssertEqual(d3?.description, Int64.max.description)
+        XCTAssertEqual(d3?._length, 4)
+
+        let d4 = Decimal(exactly: Int32.min)
+        XCTAssertNotNil(d4)
+        XCTAssertEqual(d4?.description, Int32.min.description)
+        XCTAssertEqual(d4?._length, 2)
+
+        let d5 = Decimal(exactly: Int32.max)
+        XCTAssertNotNil(d5)
+        XCTAssertEqual(d5?.description, Int32.max.description)
+        XCTAssertEqual(d5?._length, 2)
+
+        let d6 = Decimal(exactly: 0)
+        XCTAssertNotNil(d6)
+        XCTAssertEqual(d6, Decimal.zero)
+        XCTAssertEqual(d6?.description, "0")
+        XCTAssertEqual(d6?._length, 0)
+
+        let d7 = Decimal(exactly: 1)
+        XCTAssertNotNil(d7)
+        XCTAssertEqual(d7?.description, "1")
+        XCTAssertEqual(d7?._length, 1)
+
+        let d8 = Decimal(exactly: -1)
+        XCTAssertNotNil(d8)
+        XCTAssertEqual(d8?.description, "-1")
+        XCTAssertEqual(d8?._length, 1)
+    }
+
 }

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -12,7 +12,6 @@
 
 @_exported import Foundation // Clang module
 @_implementationOnly import _CoreFoundationOverlayShims
-import AppKit
 
 extension Decimal {
     public typealias RoundingMode = NSDecimalNumber.RoundingMode

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -12,6 +12,7 @@
 
 @_exported import Foundation // Clang module
 @_implementationOnly import _CoreFoundationOverlayShims
+import AppKit
 
 extension Decimal {
     public typealias RoundingMode = NSDecimalNumber.RoundingMode
@@ -26,6 +27,7 @@ public func pow(_ x: Decimal, _ y: Int) -> Decimal {
 }
 
 extension Decimal : Hashable, Comparable {
+    // (Used by `doubleValue`.)
     private subscript(index: UInt32) -> UInt16 {
         get {
             switch index {
@@ -42,6 +44,7 @@ extension Decimal : Hashable, Comparable {
         }
     }
     
+    // (Used by `NSDecimalNumber` and `hash(into:)`.)
     internal var doubleValue: Double {
         if _length == 0 {
             return _isNegative == 1 ? Double.nan : 0
@@ -124,7 +127,7 @@ extension Decimal : Codable {
 
         var mantissaContainer = try container.nestedUnkeyedContainer(forKey: .mantissa)
         var mantissa: (CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort,
-                       CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort) = (0,0,0,0,0,0,0,0)
+            CUnsignedShort, CUnsignedShort, CUnsignedShort, CUnsignedShort) = (0,0,0,0,0,0,0,0)
         mantissa.0 = try mantissaContainer.decode(CUnsignedShort.self)
         mantissa.1 = try mantissaContainer.decode(CUnsignedShort.self)
         mantissa.2 = try mantissaContainer.decode(CUnsignedShort.self)
@@ -134,12 +137,12 @@ extension Decimal : Codable {
         mantissa.6 = try mantissaContainer.decode(CUnsignedShort.self)
         mantissa.7 = try mantissaContainer.decode(CUnsignedShort.self)
 
-        self = Decimal(_exponent: exponent,
-                       _length: length,
-                       _isNegative: CUnsignedInt(isNegative ? 1 : 0),
-                       _isCompact: CUnsignedInt(isCompact ? 1 : 0),
-                       _reserved: 0,
-                       _mantissa: mantissa)
+        self.init(_exponent: exponent,
+                  _length: length,
+                  _isNegative: CUnsignedInt(isNegative ? 1 : 0),
+                  _isCompact: CUnsignedInt(isCompact ? 1 : 0),
+                  _reserved: 0,
+                  _mantissa: mantissa)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -182,9 +185,50 @@ extension Decimal : SignedNumeric {
             _reserved: 0, _mantissa: self._mantissa)
     }
 
-    // FIXME(integers): implement properly
     public init?<T : BinaryInteger>(exactly source: T) {
-        fatalError()
+        let zero = 0 as T
+
+        if source == zero {
+            self = Decimal.zero
+            return
+        }
+
+        let negative: UInt32 = (T.isSigned && source < zero) ? 1 : 0
+        var mantissa = source.magnitude
+        var exponent: Int32 = 0
+
+        let maxExponent = Int8.max
+        while mantissa.isMultiple(of: 10) && (exponent < maxExponent) {
+            exponent += 1
+            mantissa /= 10
+        }
+
+        // If the mantissa still requires more than 128 bits of storage then it is too large.
+        if mantissa.bitWidth > 128 && (mantissa >> 128 != zero) { return nil }
+
+        let mantissaParts: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)
+        let loWord = UInt64(truncatingIfNeeded: mantissa)
+        var length = ((loWord.bitWidth - loWord.leadingZeroBitCount) + (UInt16.bitWidth - 1)) / UInt16.bitWidth
+        mantissaParts.0 = UInt16(truncatingIfNeeded: loWord >> 0)
+        mantissaParts.1 = UInt16(truncatingIfNeeded: loWord >> 16)
+        mantissaParts.2 = UInt16(truncatingIfNeeded: loWord >> 32)
+        mantissaParts.3 = UInt16(truncatingIfNeeded: loWord >> 48)
+
+        let hiWord = mantissa.bitWidth > 64 ? UInt64(truncatingIfNeeded: mantissa >> 64) : 0
+        if hiWord != 0 {
+            length = 4 + ((hiWord.bitWidth - hiWord.leadingZeroBitCount) + (UInt16.bitWidth - 1)) / UInt16.bitWidth
+            mantissaParts.4 = UInt16(truncatingIfNeeded: hiWord >> 0)
+            mantissaParts.5 = UInt16(truncatingIfNeeded: hiWord >> 16)
+            mantissaParts.6 = UInt16(truncatingIfNeeded: hiWord >> 32)
+            mantissaParts.7 = UInt16(truncatingIfNeeded: hiWord >> 48)
+        } else {
+            mantissaParts.4 = 0
+            mantissaParts.5 = 0
+            mantissaParts.6 = 0
+            mantissaParts.7 = 0
+        }
+
+        self = Decimal(_exponent: exponent, _length: UInt32(length), _isNegative: negative, _isCompact: 1, _reserved: 0, _mantissa: mantissaParts)
     }
 
     public static func +=(lhs: inout Decimal, rhs: Decimal) {
@@ -332,11 +376,11 @@ extension Decimal {
         _mantissa: (0x6623, 0x7d57, 0x16e7, 0xad0d, 0xaf52, 0x4641, 0xdfa7, 0xec58)
     )
 
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public static var infinity: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+    @available(*, unavailable, message: "Decimal does not fully adopt FloatingPoint.")
+    public static var infinity: Decimal { fatalError("Decimal does not fully adopt FloatingPoint") }
 
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public static var signalingNaN: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+    @available(*, unavailable, message: "Decimal does not fully adopt FloatingPoint.")
+    public static var signalingNaN: Decimal { fatalError("Decimal does not fully adopt FloatingPoint") }
 
     public static var quietNaN: Decimal {
         return Decimal(
@@ -411,7 +455,7 @@ extension Decimal {
     }
 
     public init(_ value: Double) {
-        precondition(!value.isInfinite, "Decimal does not yet fully adopt FloatingPoint")
+        precondition(!value.isInfinite, "Decimal does not fully adopt FloatingPoint")
         if value.isNaN {
             self = Decimal.nan
         } else if value == 0.0 {
@@ -420,16 +464,36 @@ extension Decimal {
             self = Decimal()
             let negative = value < 0
             var val = negative ? -1 * value : value
-            var exponent = 0
+            var exponent: Int8 = 0
+
+            // Try to get val as close to UInt64.max whilst adjusting the exponent
+            // to reduce the number of digits after the decimal point.
             while val < Double(UInt64.max - 1) {
+                guard exponent > Int8.min else {
+                    self = Decimal.nan
+                    return
+                }
                 val *= 10.0
                 exponent -= 1
             }
-            while Double(UInt64.max - 1) < val {
+            while Double(UInt64.max) <= val {
+                guard exponent < Int8.max else {
+                    self = Decimal.nan
+                    return
+                }
                 val /= 10.0
                 exponent += 1
             }
-            var mantissa = UInt64(val)
+
+            var mantissa: UInt64
+            let maxMantissa = Double(UInt64.max).nextDown
+            if val > maxMantissa {
+                // UInt64(Double(UInt64.max)) gives an overflow error; this is the largest
+                // mantissa that can be set.
+                mantissa = UInt64(maxMantissa)
+            } else {
+                mantissa = UInt64(val)
+            }
 
             var i: UInt32 = 0
             // This is a bit ugly but it is the closest approximation of the C
@@ -601,8 +665,8 @@ extension Decimal {
         return true
     }
 
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+    @available(*, unavailable, message: "Decimal does not fully adopt FloatingPoint.")
+    public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not fully adopt FloatingPoint") }
 }
 
 extension Decimal : _ObjectiveCBridgeable {

--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -107,7 +107,7 @@ public func pow(_ x: Decimal, _ y: Int) -> Decimal {
 }
 
 extension Decimal : Hashable, Comparable {
-    // (Used by VariableLengthNumber and doubleValue.)
+    // (Used by `VariableLengthNumber` and `doubleValue`.)
     fileprivate subscript(index: UInt32) -> UInt16 {
         get {
             switch index {
@@ -137,7 +137,7 @@ extension Decimal : Hashable, Comparable {
         }
     }
 
-    // (Used by NSDecimalNumber and hash(into:).)
+    // (Used by `NSDecimalNumber` and `hash(into:)`.)
     internal var doubleValue: Double {
         if _length == 0 {
             return _isNegative == 1 ? Double.nan : 0
@@ -160,7 +160,8 @@ extension Decimal : Hashable, Comparable {
         return _isNegative != 0 ? -d : d
     }
 
-    // The low 64 bits of the integer part. (Used by uint64Value and int64Value.)
+    // The low 64 bits of the integer part.
+    // (Used by `uint64Value` and `int64Value`.)
     private var _unsignedInt64Value: UInt64 {
         // Quick check if number if has too many zeros before decimal point or too many trailing zeros after decimal point.
         // Log10 (2^64) ~ 19, log10 (2^128) ~ 38
@@ -187,7 +188,8 @@ extension Decimal : Hashable, Comparable {
     }
 
     // A best-effort conversion of the integer value, trying to match Darwin for
-    // values outside of UInt64.min...UInt64.max. (Used by NSDecimalNumber.)
+    // values outside of UInt64.min...UInt64.max.
+    // (Used by `NSDecimalNumber`.)
     internal var uint64Value: UInt64 {
         let value = _unsignedInt64Value
         if !self.isNegative {
@@ -205,7 +207,8 @@ extension Decimal : Hashable, Comparable {
     }
 
     // A best-effort conversion of the integer value, trying to match Darwin for
-    // values outside of Int64.min...Int64.max. (Used by NSDecimalNumber.)
+    // values outside of Int64.min...Int64.max.
+    // (Used by `NSDecimalNumber`.)
     internal var int64Value: Int64 {
         let uint64Value = _unsignedInt64Value
         if self.isNegative {
@@ -362,13 +365,13 @@ extension Decimal : SignedNumeric {
         var mantissa = source.magnitude
         var exponent: Int32 = 0
 
-        let maxExponent = type(of: __exponent).max
+        let maxExponent = Int8.max
         while mantissa.isMultiple(of: 10) && (exponent < maxExponent) {
             exponent += 1
             mantissa /= 10
         }
 
-        // If the matinssa still requires more than 128bits of storage then it is too large.
+        // If the mantissa still requires more than 128 bits of storage then it is too large.
         if mantissa.bitWidth > 128 && (mantissa >> 128 != zero) { return nil }
 
         let mantissaParts: (UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16, UInt16)
@@ -540,11 +543,11 @@ extension Decimal {
         _mantissa: (0x6623, 0x7d57, 0x16e7, 0xad0d, 0xaf52, 0x4641, 0xdfa7, 0xec58)
     )
 
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public static var infinity: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+    @available(*, unavailable, message: "Decimal does not fully adopt FloatingPoint.")
+    public static var infinity: Decimal { fatalError("Decimal does not fully adopt FloatingPoint") }
 
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public static var signalingNaN: Decimal { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+    @available(*, unavailable, message: "Decimal does not fully adopt FloatingPoint.")
+    public static var signalingNaN: Decimal { fatalError("Decimal does not fully adopt FloatingPoint") }
 
     public static var quietNaN: Decimal {
         return Decimal(
@@ -619,7 +622,7 @@ extension Decimal {
     }
 
     public init(_ value: Double) {
-        precondition(!value.isInfinite, "Decimal does not yet fully adopt FloatingPoint")
+        precondition(!value.isInfinite, "Decimal does not fully adopt FloatingPoint")
         if value.isNaN {
             self = Decimal.nan
         } else if value == 0.0 {
@@ -634,7 +637,7 @@ extension Decimal {
             // to reduce the number of digits after the decimal point.
             while val < Double(UInt64.max - 1) {
                 guard exponent > Int8.min else {
-                    setNaN()
+                    self = Decimal.nan
                     return
                 }
                 val *= 10.0
@@ -642,7 +645,7 @@ extension Decimal {
             }
             while Double(UInt64.max) <= val {
                 guard exponent < Int8.max else {
-                    setNaN()
+                    self = Decimal.nan
                     return
                 }
                 val /= 10.0
@@ -652,14 +655,14 @@ extension Decimal {
             var mantissa: UInt64
             let maxMantissa = Double(UInt64.max).nextDown
             if val > maxMantissa {
-                // UInt64(Double(UInt64.max)) gives an overflow error, this is the largest
+                // UInt64(Double(UInt64.max)) gives an overflow error; this is the largest
                 // mantissa that can be set.
                 mantissa = UInt64(maxMantissa)
             } else {
-                 mantissa = UInt64(val)
+                mantissa = UInt64(val)
             }
 
-            var i: Int32 = 0
+            var i: UInt32 = 0
             // This is a bit ugly but it is the closest approximation of the C
             // initializer that can be expressed here.
             while mantissa != 0 && i < NSDecimalMaxSize {
@@ -686,7 +689,7 @@ extension Decimal {
                 mantissa = mantissa >> 16
                 i += 1
             }
-            _length = UInt32(i)
+            _length = i
             _isNegative = negative ? 1 : 0
             _isCompact = 0
             _exponent = Int32(exponent)
@@ -821,8 +824,8 @@ extension Decimal {
         return true
     }
 
-    @available(*, unavailable, message: "Decimal does not yet fully adopt FloatingPoint.")
-    public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not yet fully adopt FloatingPoint") }
+    @available(*, unavailable, message: "Decimal does not fully adopt FloatingPoint.")
+    public mutating func formTruncatingRemainder(dividingBy other: Decimal) { fatalError("Decimal does not fully adopt FloatingPoint") }
 }
 
 extension Decimal: _ObjectiveCBridgeable {


### PR DESCRIPTION
Several improvements were made to the corelibs implementation of `Decimal` over the years which have not been in sync with the overlay. Most evidently, #2926 resolving [SR-13837](https://bugs.swift.org/browse/SR-13837) and #2574 implementing `init?(exactly:)` are lacking from the overlay. Credit goes entirely to @spevans for actually implementing these fixes.

This PR re-aligns the two implementations. Only very minor adjustments are made to the corelibs implementation, mostly where it uses private APIs that do not exist in the overlay, to better keep the two implementations in sync.

A minor change is made to both implementations in terms of diagnostic messages: where we state that `Decimal` does not "yet" conform to `FloatingPoint`, the "yet" is deleted because it misleadingly suggests a conformance that is not the plan of record.