### PR TITLE
[5.4] SR-14933: Implement `copy()` in `ISO8601DateFormatter`.

### DIFF
--- a/Sources/Foundation/ISO8601DateFormatter.swift
+++ b/Sources/Foundation/ISO8601DateFormatter.swift
@@ -112,6 +112,13 @@ open class ISO8601DateFormatter : Formatter, NSSecureCoding {
             aCoder.encode(timeZone._nsObject, forKey: "NS.timeZone")
         }
     }
+
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copied = ISO8601DateFormatter()
+        copied.timeZone = timeZone
+        copied.formatOptions = formatOptions
+        return copied
+    }
     
     public static var supportsSecureCoding: Bool { return true }
     

--- a/Tests/Foundation/Tests/TestISO8601DateFormatter.swift
+++ b/Tests/Foundation/Tests/TestISO8601DateFormatter.swift
@@ -326,6 +326,28 @@ class TestISO8601DateFormatter: XCTestCase {
             try fixture.assertLoadedValuesMatch(areEqual(_:_:))
         }
     }
+
+    func test_copy() throws {
+        let original = ISO8601DateFormatter()
+        original.timeZone = try XCTUnwrap(TimeZone(identifier: "GMT"))
+        original.formatOptions = [
+            .withInternetDateTime,
+            .withDashSeparatorInDate,
+            .withColonSeparatorInTime,
+            .withColonSeparatorInTimeZone,
+        ]
+
+        let copied = try XCTUnwrap(original.copy() as? ISO8601DateFormatter)
+        XCTAssertEqual(copied.timeZone, original.timeZone)
+        XCTAssertEqual(copied.formatOptions, original.formatOptions)
+
+        copied.timeZone = try XCTUnwrap(TimeZone(identifier: "JST"))
+        copied.formatOptions.insert(.withFractionalSeconds)
+        XCTAssertNotEqual(copied.timeZone, original.timeZone)
+        XCTAssertNotEqual(copied.formatOptions, original.formatOptions)
+        XCTAssertFalse(original.formatOptions.contains(.withFractionalSeconds))
+        XCTAssertTrue(copied.formatOptions.contains(.withFractionalSeconds))
+    }
     
     static var allTests : [(String, (TestISO8601DateFormatter) -> () throws -> Void)] {
         
@@ -335,6 +357,7 @@ class TestISO8601DateFormatter: XCTestCase {
             ("test_stringFromDateClass", test_stringFromDateClass),
             ("test_codingRoundtrip", test_codingRoundtrip),
             ("test_loadingFixtures", test_loadingFixtures),
+            ("test_copy", test_copy),
         ]
     }
 }


### PR DESCRIPTION
Cherry-picks from #3009 for 5.4 branch.

> As with #3008, `ISO8601DateFormatter` should also implement its own override of `copy()`.
> 
> Resolves SR-14933.