### PR TITLE
[SR-6785] Fix `Decimal` conformance to `Strideable`

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -287,8 +287,6 @@ class TestDecimal : XCTestCase {
         XCTAssertEqual(Decimal(-9), Decimal(1) - Decimal(10))
         XCTAssertEqual(Decimal(3), Decimal(2).nextUp)
         XCTAssertEqual(Decimal(2), Decimal(3).nextDown)
-        XCTAssertEqual(Decimal(-476), Decimal(1024).distance(to: Decimal(1500)))
-        XCTAssertEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(1.234)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(-1.234)))
         if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
@@ -590,6 +588,9 @@ class TestDecimal : XCTestCase {
     }
 
     func test_Strideable() {
+        XCTAssertEqual(Decimal(476), Decimal(1024).distance(to: Decimal(1500)))
+        XCTAssertEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
+
         let x = 42 as Decimal
         XCTAssertEqual(x.distance(to: 43), 1)
         XCTAssertEqual(x.advanced(by: 1), 43)

--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -588,6 +588,14 @@ class TestDecimal : XCTestCase {
             }
         }
     }
+
+    func test_Strideable() {
+        let x = 42 as Decimal
+        XCTAssertEqual(x.distance(to: 43), 1)
+        XCTAssertEqual(x.advanced(by: 1), 43)
+        XCTAssertEqual(x.distance(to: 41), -1)
+        XCTAssertEqual(x.advanced(by: -1), 41)
+    }
     
     func test_ULP() {
         let x = 0.1 as Decimal

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -273,7 +273,7 @@ extension Decimal {
 
 extension Decimal : Strideable {
     public func distance(to other: Decimal) -> Decimal {
-        return self - other
+        return other - self
     }
 
     public func advanced(by n: Decimal) -> Decimal {

--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -482,7 +482,7 @@ extension Decimal {
 
 extension Decimal : Strideable {
     public func distance(to other: Decimal) -> Decimal {
-        return self - other
+        return other - self
     }
     public func advanced(by n: Decimal) -> Decimal {
         return self + n

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -378,7 +378,7 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(Decimal(-9), Decimal(1) - Decimal(10))
         XCTAssertEqual(Decimal(3), Decimal(2).nextUp)
         XCTAssertEqual(Decimal(2), Decimal(3).nextDown)
-        XCTAssertEqual(Decimal(-476), Decimal(1024).distance(to: Decimal(1500)))
+        XCTAssertEqual(Decimal(476), Decimal(1024).distance(to: Decimal(1500)))
         XCTAssertEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(1.234)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(-1.234)))
@@ -850,6 +850,14 @@ class TestDecimal: XCTestCase {
         XCTAssertTrue(number.boolValue, "Should have received true")
 
         XCTAssertEqual(100,number.objCType.pointee, "ObjC type for NSDecimalNumber is 'd'")
+    }
+
+    func test_Strideable() {
+        let x = 42 as Decimal
+        XCTAssertEqual(x.distance(to: 43), 1)
+        XCTAssertEqual(x.advanced(by: 1), 43)
+        XCTAssertEqual(x.distance(to: 41), -1)
+        XCTAssertEqual(x.advanced(by: -1), 41)
     }
     
     func test_ULP() {
@@ -1462,6 +1470,7 @@ class TestDecimal: XCTestCase {
             ("test_ScanDecimal", test_ScanDecimal),
             ("test_SimpleMultiplication", test_SimpleMultiplication),
             ("test_SmallerNumbers", test_SmallerNumbers),
+            ("test_Strideable", test_Strideable),
             ("test_ULP", test_ULP),
             ("test_ZeroPower", test_ZeroPower),
             ("test_parseDouble", test_parseDouble),

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -378,8 +378,6 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(Decimal(-9), Decimal(1) - Decimal(10))
         XCTAssertEqual(Decimal(3), Decimal(2).nextUp)
         XCTAssertEqual(Decimal(2), Decimal(3).nextDown)
-        XCTAssertEqual(Decimal(476), Decimal(1024).distance(to: Decimal(1500)))
-        XCTAssertEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(1.234)))
         XCTAssertEqual(Decimal(1.234), abs(Decimal(-1.234)))
         XCTAssertEqual((0 as Decimal).magnitude, 0 as Decimal)
@@ -853,6 +851,9 @@ class TestDecimal: XCTestCase {
     }
 
     func test_Strideable() {
+        XCTAssertEqual(Decimal(476), Decimal(1024).distance(to: Decimal(1500)))
+        XCTAssertEqual(Decimal(68040), Decimal(386).advanced(by: Decimal(67654)))
+
         let x = 42 as Decimal
         XCTAssertEqual(x.distance(to: 43), 1)
         XCTAssertEqual(x.advanced(by: 1), 43)


### PR DESCRIPTION
Consider the following discrepancy:

```swift
import Foundation

let x: Int = 42
x.distance(to: 43) // 1
let y: Decimal = 42
y.distance(to: 43) // -1 (oops!)
```

The implementation of `distance(to:)` is incorrect for `Decimal`. This PR corrects the implementation (for both the overlay and swift-corelibs) and adds corresponding tests.

Resolves [SR-6785](https://bugs.swift.org/browse/SR-6785).