### PR TITLE
[SR-15132][SR-15134] Fix `Decimal` implementation of significand APIs

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -558,6 +558,13 @@ class TestDecimal : XCTestCase {
         XCTAssertEqual(answer,num,"\(ones) / 9 = \(answer) \(num)")
     }
 
+    func test_Significand() {
+        let x = -42 as Decimal
+        XCTAssertEqual(x.significand.sign, .plus)
+        let y = Decimal(sign: .plus, exponent: 0, significand: x)
+        XCTAssertEqual(y.sign, .minus)
+    }
+
     func test_SimpleMultiplication() {
         var multiplicand = Decimal()
         multiplicand._isNegative = 0

--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -559,10 +559,19 @@ class TestDecimal : XCTestCase {
     }
 
     func test_Significand() {
-        let x = -42 as Decimal
+        var x = -42 as Decimal
         XCTAssertEqual(x.significand.sign, .plus)
-        let y = Decimal(sign: .plus, exponent: 0, significand: x)
-        XCTAssertEqual(y.sign, .minus)
+        var y = Decimal(sign: .plus, exponent: 0, significand: x)
+        XCTAssertEqual(y, -42)
+        y = Decimal(sign: .minus, exponent: 0, significand: x)
+        XCTAssertEqual(y, 42)
+
+        x = 42 as Decimal
+        XCTAssertEqual(x.significand.sign, .plus)
+        y = Decimal(sign: .plus, exponent: 0, significand: x)
+        XCTAssertEqual(y, 42)
+        y = Decimal(sign: .minus, exponent: 0, significand: x)
+        XCTAssertEqual(y, -42)
     }
 
     func test_SimpleMultiplication() {

--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -572,6 +572,11 @@ class TestDecimal : XCTestCase {
         XCTAssertEqual(y, 42)
         y = Decimal(sign: .minus, exponent: 0, significand: x)
         XCTAssertEqual(y, -42)
+
+        let a = Decimal.leastNonzeroMagnitude
+        XCTAssertEqual(Decimal(sign: .plus, exponent: -10, significand: a), 0)
+        let b = Decimal.greatestFiniteMagnitude
+        XCTAssertTrue(Decimal(sign: .plus, exponent: 10, significand: b).isNaN)
     }
 
     func test_SimpleMultiplication() {

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -470,7 +470,7 @@ extension Decimal {
         self.init(
             _exponent: Int32(exponent) + significand._exponent,
             _length: significand._length,
-            _isNegative: sign == .plus ? 0 : 1,
+            _isNegative: sign == significand.sign ? 0 : 1,
             _isCompact: significand._isCompact,
             _reserved: 0,
             _mantissa: significand._mantissa)
@@ -492,7 +492,7 @@ extension Decimal {
 
     public var significand: Decimal {
         return Decimal(
-            _exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact,
+            _exponent: 0, _length: _length, _isNegative: 0, _isCompact: _isCompact,
             _reserved: 0, _mantissa: _mantissa)
     }
 

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -467,13 +467,13 @@ extension Decimal {
     }
 
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
-        self.init(
-            _exponent: Int32(exponent) + significand._exponent,
-            _length: significand._length,
-            _isNegative: sign == significand.sign ? 0 : 1,
-            _isCompact: significand._isCompact,
-            _reserved: 0,
-            _mantissa: significand._mantissa)
+        self = significand
+        let error = withUnsafeMutablePointer(to: &self) {
+            NSDecimalMultiplyByPowerOf10($0, $0, Int16(exponent), .plain)
+        }
+        if error == .underflow { self = 0 }
+        // We don't need to check for overflow because `Decimal` cannot represent infinity.
+        if sign == .minus { negate() }
     }
 
     public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {

--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -698,7 +698,7 @@ extension Decimal {
         self.init(
             _exponent: Int32(exponent) + significand._exponent,
             _length: significand._length,
-            _isNegative: sign == .plus ? 0 : 1,
+            _isNegative: sign == significand.sign ? 0 : 1,
             _isCompact: significand._isCompact,
             _reserved: 0,
             _mantissa: significand._mantissa)
@@ -720,7 +720,7 @@ extension Decimal {
 
     public var significand: Decimal {
         return Decimal(
-            _exponent: 0, _length: _length, _isNegative: _isNegative, _isCompact: _isCompact,
+            _exponent: 0, _length: _length, _isNegative: 0, _isCompact: _isCompact,
             _reserved: 0, _mantissa: _mantissa)
     }
 

--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -695,13 +695,13 @@ extension Decimal {
     }
 
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
-        self.init(
-            _exponent: Int32(exponent) + significand._exponent,
-            _length: significand._length,
-            _isNegative: sign == significand.sign ? 0 : 1,
-            _isCompact: significand._isCompact,
-            _reserved: 0,
-            _mantissa: significand._mantissa)
+        self = significand
+        let error = withUnsafeMutablePointer(to: &self) {
+            NSDecimalMultiplyByPowerOf10($0, $0, Int16(exponent), .plain)
+        }
+        if error == .underflow { self = 0 }
+        // We don't need to check for overflow because `Decimal` cannot represent infinity.
+        if sign == .minus { negate() }
     }
 
     public init(signOf: Decimal, magnitudeOf magnitude: Decimal) {

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -7,6 +7,9 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
+import Foundation
+import XCTest
+
 class TestDecimal: XCTestCase {
 
     func test_NSDecimalNumberInit() {
@@ -809,10 +812,19 @@ class TestDecimal: XCTestCase {
     }
 
     func test_Significand() {
-        let x = -42 as Decimal
+        var x = -42 as Decimal
         XCTAssertEqual(x.significand.sign, .plus)
-        let y = Decimal(sign: .plus, exponent: 0, significand: x)
-        XCTAssertEqual(y.sign, .minus)
+        var y = Decimal(sign: .plus, exponent: 0, significand: x)
+        XCTAssertEqual(y, -42)
+        y = Decimal(sign: .minus, exponent: 0, significand: x)
+        XCTAssertEqual(y, 42)
+
+        x = 42 as Decimal
+        XCTAssertEqual(x.significand.sign, .plus)
+        y = Decimal(sign: .plus, exponent: 0, significand: x)
+        XCTAssertEqual(y, 42)
+        y = Decimal(sign: .minus, exponent: 0, significand: x)
+        XCTAssertEqual(y, -42)
     }
 
     func test_SimpleMultiplication() {

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -825,6 +825,11 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(y, 42)
         y = Decimal(sign: .minus, exponent: 0, significand: x)
         XCTAssertEqual(y, -42)
+
+        let a = Decimal.leastNonzeroMagnitude
+        XCTAssertEqual(Decimal(sign: .plus, exponent: -10, significand: a), 0)
+        let b = Decimal.greatestFiniteMagnitude
+        XCTAssertTrue(Decimal(sign: .plus, exponent: 10, significand: b).isNaN)
     }
 
     func test_SimpleMultiplication() {

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -808,6 +808,13 @@ class TestDecimal: XCTestCase {
         XCTAssertEqual(zero3.description, "0")
     }
 
+    func test_Significand() {
+        let x = -42 as Decimal
+        XCTAssertEqual(x.significand.sign, .plus)
+        let y = Decimal(sign: .plus, exponent: 0, significand: x)
+        XCTAssertEqual(y.sign, .minus)
+    }
+
     func test_SimpleMultiplication() {
         var multiplicand = Decimal()
         multiplicand._isNegative = 0
@@ -1460,6 +1467,7 @@ class TestDecimal: XCTestCase {
             ("test_RepeatingDivision", test_RepeatingDivision),
             ("test_Round", test_Round),
             ("test_ScanDecimal", test_ScanDecimal),
+            ("test_Significand", test_Significand),
             ("test_SimpleMultiplication", test_SimpleMultiplication),
             ("test_SmallerNumbers", test_SmallerNumbers),
             ("test_ULP", test_ULP),


### PR DESCRIPTION
This PR fixes <strike>two</strike> three newly discovered issues with `Decimal` implementations of APIs that deliberately mimic those of `FloatingPoint`.

First, as reported in SR-15132, `significand` shouldn't be negative, but `Decimal` returns a negative "significand" for a negative value:

```swift
import Foundation

let x = -42 as Double
x.significand.sign // plus
let y = -42 as Decimal
y.significand.sign // minus (!)
```

Second and not reported in a separate bug, for types conforming to `FloatingPoint`, the initializer `init(sign:exponent:significand:)` returns a value where the sign is determined by the following notional calculation:

```swift
(sign == .minus ? -1 : 1) * significand * radix ** exponent
```

In other words, the sign of the result is not determined by `sign` alone, but rather the result is negative if and only if `sign` and `significand.sign` are of _opposite_ signs. This is not respected by `Decimal`:

```swift
import Foundation

let x = -42 as Double
Double(sign: .plus, exponent: 0, significand: x) // -42
let y = -42 as Decimal
Decimal(sign: .plus, exponent: 0, significand: y) // 42 (!)
```

Third, now reported in SR-15134, `init(sign:exponent:significand:)` currently barfs when exponent is incremented out of range:

```swift
import Foundation
let a = Decimal.leastNonzeroMagnitude
print(Decimal(sign: .plus, exponent: -10, significand: a))
// 100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
let b = Decimal.greatestFiniteMagnitude
print(Decimal(sign: .plus, exponent: 10, significand: b))
// 0.00000000000000000000000000000000000000000000000000000000000000000000000000000000340282366920938463463374607431768211455
```

Instead, the value should properly underflow or overflow (to NaN since `Decimal` has no representation of infinity), respectively, in line with the behavior of binary floating-point types:

```swift
let x = Double.leastNonzeroMagnitude
print(Double(sign: .plus, exponent: -10, significand: x)) // 0.0
let y = Double.greatestFiniteMagnitude
print(Double(sign: .plus, exponent: 10, significand: y)) // inf
```

To fix this, delegate the work of increasing or decreasing the exponent to `NSDecimalMultiplyByPowerOf10`.

These issues are addressed for both the overlay and the swift-corelibs implementation; tests are added.