### PR TITLE
[SR-15156] Another fix for `Decimal(sign:exponent:significand:)`.

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDecimal.swift
@@ -580,8 +580,10 @@ class TestDecimal : XCTestCase {
 
         let a = Decimal.leastNonzeroMagnitude
         XCTAssertEqual(Decimal(sign: .plus, exponent: -10, significand: a), 0)
+        XCTAssertEqual(Decimal(sign: .plus, exponent: .min, significand: a), 0)
         let b = Decimal.greatestFiniteMagnitude
         XCTAssertTrue(Decimal(sign: .plus, exponent: 10, significand: b).isNaN)
+        XCTAssertTrue(Decimal(sign: .plus, exponent: .max, significand: b).isNaN)
     }
 
     func test_SimpleMultiplication() {

--- a/Darwin/Foundation-swiftoverlay/Decimal.swift
+++ b/Darwin/Foundation-swiftoverlay/Decimal.swift
@@ -519,7 +519,7 @@ extension Decimal {
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
         self = significand
         let error = withUnsafeMutablePointer(to: &self) {
-            NSDecimalMultiplyByPowerOf10($0, $0, Int16(exponent), .plain)
+            NSDecimalMultiplyByPowerOf10($0, $0, Int16(clamping: exponent), .plain)
         }
         if error == .underflow { self = 0 }
         // We don't need to check for overflow because `Decimal` cannot represent infinity.

--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -687,7 +687,7 @@ extension Decimal {
     public init(sign: FloatingPointSign, exponent: Int, significand: Decimal) {
         self = significand
         let error = withUnsafeMutablePointer(to: &self) {
-            NSDecimalMultiplyByPowerOf10($0, $0, Int16(exponent), .plain)
+            NSDecimalMultiplyByPowerOf10($0, $0, Int16(clamping: exponent), .plain)
         }
         if error == .underflow { self = 0 }
         // We don't need to check for overflow because `Decimal` cannot represent infinity.

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -821,8 +821,10 @@ class TestDecimal: XCTestCase {
 
         let a = Decimal.leastNonzeroMagnitude
         XCTAssertEqual(Decimal(sign: .plus, exponent: -10, significand: a), 0)
+        XCTAssertEqual(Decimal(sign: .plus, exponent: .min, significand: a), 0)
         let b = Decimal.greatestFiniteMagnitude
         XCTAssertTrue(Decimal(sign: .plus, exponent: 10, significand: b).isNaN)
+        XCTAssertTrue(Decimal(sign: .plus, exponent: .max, significand: b).isNaN)
     }
 
     func test_SimpleMultiplication() {


### PR DESCRIPTION
This issue has been present all along, and my previous fix in #3068 didn't address it because I didn't know of the problem--and (perhaps unsurprisingly) reproduced the same problem despite a totally new implementation of the initializer. Consider the following:

```swift
import Foundation

let x = Double.greatestFiniteMagnitude
Double(sign: .plus, exponent: 10, significand: x)
// +inf
Double(sign: .plus, exponent: .max, significand: x)
// +inf

let y = Decimal.greatestFiniteMagnitude
Decimal(sign: .plus, exponent: 10, significand: y)
// nan (correct, since `Decimal` has no representation of infinity)
Decimal(sign: .plus, exponent: .max, significand: y)
// runtime error (!)
```

This is because the implementation of `Decimal(sign:exponent:significand:)` converts between `Int` and an integer type of smaller bit width (but still plenty wide enough to represent more than twice the largest possible exponent) using a trapping initializer instead of clamping.

The present PR fixes that oversight now (in both the corelibs and overlay implementations) and adds tests.