### PR TITLE
[Build Fix] CoreFoundation: use `#include`

### DIFF
--- a/CoreFoundation/Locale.subproj/CFListFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFListFormatter.c
@@ -7,12 +7,12 @@
     See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
  */
 
-#import "CFListFormatter.h"
+#include "CFListFormatter.h"
 
-#import "CFICULogging.h"
-#import "CFInternal.h"
-#import "CFRuntime_Internal.h"
-#import <assert.h>
+#include "CFICULogging.h"
+#include "CFInternal.h"
+#include "CFRuntime_Internal.h"
+#include <assert.h>
 
 #define BUFFER_SIZE 256
 #define RESULT_BUFFER_SIZE 768

--- a/CoreFoundation/Locale.subproj/CFRelativeDateTimeFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFRelativeDateTimeFormatter.c
@@ -8,12 +8,12 @@
     Responsibility: I-Ting Liu
  */
 
-#import "CFRelativeDateTimeFormatter.h"
+#include "CFRelativeDateTimeFormatter.h"
 
-#import <assert.h>
-#import "CFICULogging.h"
-#import "CFInternal.h"
-#import "CFRuntime_Internal.h"
+#include <assert.h>
+#include "CFICULogging.h"
+#include "CFInternal.h"
+#include "CFRuntime_Internal.h"
 
 struct __CFRelativeDateTimeFormatter {
     CFRuntimeBase _base;

--- a/CoreFoundation/String.subproj/CFAttributedString.c
+++ b/CoreFoundation/String.subproj/CFAttributedString.c
@@ -17,7 +17,7 @@
 #include "CFRuntime_Internal.h"
 
 #if (TARGET_OS_MAC || TARGET_OS_WIN32) && DEPLOYMENT_RUNTIME_OBJC
-#import <Foundation/NSAttributedString.h>
+#include <Foundation/NSAttributedString.h>
 @interface NSAttributedString (NSPrivate)
 - (NSAttributedString *)_createAttributedSubstringWithRange:(NSRange)range NS_RETURNS_RETAINED;
 @end


### PR DESCRIPTION
`#import` is an ObjC extension, and unportable (`#import` imports a type
library on Windows).  Use the standard include directive.