### PR TITLE
RunLoop: `typeinfo.h` was removed in VS2019 16.3

### DIFF
--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -35,7 +35,10 @@ extern void objc_terminate(void);
 
 
 #if TARGET_OS_WIN32
+// typeinfo.h has been removed in VS2019 16.3
+#if __has_include(<typeinfo.h>)
 #include <typeinfo.h>
+#endif
 #endif
 #include "CFOverflow.h"
 


### PR DESCRIPTION
`typeinfo.h` is a non-standard header and not always available.  Guard
the inclusion with an availability check.