### PR TITLE
URL: correct header inclusion

### DIFF
--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -17,6 +17,7 @@
 #include <stdatomic.h>
 #include <CoreFoundation/CFStringEncodingConverter.h>
 #include <stdatomic.h>
+#include <assert.h>
 #include <limits.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -25,7 +26,6 @@
 #if TARGET_OS_OSX
 #include <CoreFoundation/CFNumberFormatter.h>
 #endif
-#include <assert.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
`assert.h` is universally available and required for the use of
`assert`.