### PR TITLE
Plugin: fix calling readlink() with a larger PATH_MAX

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
@@ -359,7 +359,7 @@ CF_PRIVATE _CFBundleVersion _CFBundleGetBundleVersionForURL(CFURLRef url) {
         if (CFStringGetFileSystemRepresentation(linkPath, linkPathCString, PATH_MAX) &&
             CFStringGetFileSystemRepresentation(bundlePath, bundlePathCString, PATH_MAX)) {
             // Leave room for a null terminator
-            ssize_t len = readlink(linkPathCString, linkContentsCString, PATH_MAX - 1);
+            ssize_t len = readlink(linkPathCString, linkContentsCString, CFMaxPathLength);
             // Make sure this is not an absolute link but a relative one
             if (len < 2 || (len > 1 && linkContentsCString[0] == '/')) {
                 os_log_error(_CFBundleResourceLogger(), "`WrappedBundle` link too short or pointed outside bundle at %{public}@", url);


### PR DESCRIPTION
The unmodified line built fine for Android with CMake 3.19.7, but recent versions of CMake and the Android NDK enable `-D_FORTIFY_SOURCE=2`, which [errors because `PATH_MAX` on linux is 4096](https://github.com/buttaface/swift-android-sdk/runs/3619410286?check_suite_focus=true#step:7:2574). [Since `CFMaxPathSize` is set much smaller](https://github.com/apple/swift-corelibs-foundation/blob/6634ee3421bcd3e2c1a7502088cb5c26f441106f/CoreFoundation/Base.subproj/CFInternal.h#L1101), that recently enabled compile-time checker errors.

Alternately, we could set `CFMaxPathSize/Length` based on `PATH_MAX` explicitly, rather than implicitly for win32/macOS right now. @millenomi, let me know what you prefer.