### PR TITLE
CoreFoundation: add a workaround for Linux with the rebranch

### DIFF
--- a/CoreFoundation/String.subproj/CFAttributedString.c
+++ b/CoreFoundation/String.subproj/CFAttributedString.c
@@ -23,6 +23,10 @@
 @end
 #endif
 
+#if defined(__linux__)
+#pragma clang optimize off
+#endif
+
 struct __CFAttributedString {
     CFRuntimeBase base;
     CFStringRef string;


### PR DESCRIPTION
This adds an optimization barrier in the loop that is potentially
getting mis-optimized with the rebranch on Linux.  This should allow us
to rebranch and follow up with a proper fix subsequently.

Thanks to @etcwilde for tracking down this issue!