### PR TITLE
Bundle: avoid second chance bundle loading on Windows

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle.c
@@ -784,7 +784,7 @@ static CFBundleRef _CFBundleCreate(CFAllocatorRef allocator, CFURLRef bundleURL,
         Boolean exists = false;
         SInt32 mode = 0;
         SInt32 res = _CFGetPathProperties(allocator, (char *)buff, &exists, &mode, NULL, NULL, NULL, NULL);
-#if TARGET_OS_WIN32
+#if DEPLOYMENT_RUNTIME_OBJC && TARGET_OS_WIN32
         if (!(res == 0 && exists && ((mode & S_IFMT) == S_IFDIR))) {
             // 2nd chance at finding a bundle path - remove the last path component (e.g., mybundle.resources) and try again
             CFURLRef shorterPath = CFURLCreateCopyDeletingLastPathComponent(allocator, newURL);


### PR DESCRIPTION
When non-ObjC deployment targets, do not support the second-chance
bundle loading recovery for flat-style bundles on Windows.  No one is
currently using this style and this causes a potentially spurious Bundle
creation rather than a failure to create the bundle as expected with a
Swift runtime.  This repairs the last test failure on Windows after the
last CoreFoundation merge.