### PR TITLE
Re-enable string Optimizations

### DIFF
--- a/CoreFoundation/String.subproj/CFAttributedString.c
+++ b/CoreFoundation/String.subproj/CFAttributedString.c
@@ -23,10 +23,6 @@
 @end
 #endif
 
-#if defined(__linux__)
-#pragma clang optimize off
-#endif
-
 struct __CFAttributedString {
     CFRuntimeBase base;
     CFStringRef string;

--- a/CoreFoundation/String.subproj/CFAttributedString.c
+++ b/CoreFoundation/String.subproj/CFAttributedString.c
@@ -24,7 +24,6 @@
 #endif
 
 #if defined(__linux__)
-// SR-15302: clang mis-optimizes `CFAttributedStringGetAttributesAndLongestEffectiveRange`
 #pragma clang optimize off
 #endif
 


### PR DESCRIPTION
I think I've found the fix for the failing optimization on the main swift branch.
We should be able to re-enable optimizations once that merges.

The fixing merge is: https://github.com/apple/llvm-project/pull/3439