### PR TITLE
Revert "CoreFoundation: add a workaround for Linux with the rebranch"

### DIFF
--- a/CoreFoundation/String.subproj/CFAttributedString.c
+++ b/CoreFoundation/String.subproj/CFAttributedString.c
@@ -23,11 +23,6 @@
 @end
 #endif
 
-#if defined(__linux__)
-// SR-15302: clang mis-optimizes `CFAttributedStringGetAttributesAndLongestEffectiveRange`
-#pragma clang optimize off
-#endif
-
 struct __CFAttributedString {
     CFRuntimeBase base;
     CFStringRef string;


### PR DESCRIPTION
This reverts commit 67eb2235684a6b31bdc30aa02995946ab5a3d663.  @etcwilde
has identified the upstream fix for fixing the miscompilation.  This
reverts the changes.