### PR TITLE
Annotate CFPreferencesCopyMultiple as having a _Nullable return value

### DIFF
--- a/CoreFoundation/Preferences.subproj/CFPreferences.h
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.h
@@ -93,7 +93,7 @@ keysToFetch that are not present in the returned dictionary
 are not present in the domain.  If keysToFetch is NULL, all
 keys are fetched. */
 CF_EXPORT
-CFDictionaryRef CFPreferencesCopyMultiple(_Nullable CFArrayRef keysToFetch, CFStringRef applicationID, CFStringRef userName, CFStringRef hostName);
+_Nullable CFDictionaryRef CFPreferencesCopyMultiple(_Nullable CFArrayRef keysToFetch, CFStringRef applicationID, CFStringRef userName, CFStringRef hostName);
 
 /* The primitive set function; all arguments except value must be
 non-NULL.  If value is NULL, the given key is removed */


### PR DESCRIPTION
Especially since the function can return NULL. It seems that the original author forgot to annotate it as such.