### PR TITLE
XFail `test_concurrentGetItemReplacementDirectory` and `test_concurrentRequests`

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -2026,7 +2026,7 @@ VIDEOS=StopgapVideos
             ("test_contentsEqual", test_contentsEqual),
             /* ⚠️  */ ("test_replacement", testExpectedToFail(test_replacement,
             /* ⚠️  */     "<https://bugs.swift.org/browse/SR-10819> Re-enable Foundation test TestFileManager.test_replacement")),
-            ("test_concurrentGetItemReplacementDirectory", test_concurrentGetItemReplacementDirectory),
+            /* ⚠️  */("test_concurrentGetItemReplacementDirectory", testExpectedToFail(test_concurrentGetItemReplacementDirectory, "Intermittent SEGFAULT: rdar://84519512")),
             ("test_NSTemporaryDirectory", test_NSTemporaryDirectory),
         ]
         

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -1848,7 +1848,7 @@ class TestURLSession: LoopbackServerTest {
             ("test_simpleUploadWithDelegate", test_simpleUploadWithDelegate),
             ("test_requestWithEmptyBody", test_requestWithEmptyBody),
             /* ⚠️ */ ("test_requestWithNonEmptyBody", testExpectedToFail(test_requestWithNonEmptyBody, "Started failing for no readily available reason.")),
-            ("test_concurrentRequests", test_concurrentRequests),
+            /* ⚠️ */ ("test_concurrentRequests", testExpectedToFail(test_concurrentRequests, "Intermittent SEGFAULT: rdar://84519512")),
             ("test_disableCookiesStorage", test_disableCookiesStorage),
             ("test_cookiesStorage", test_cookiesStorage),
             ("test_cookieStorageForEphemeralConfiguration", test_cookieStorageForEphemeralConfiguration),


### PR DESCRIPTION
Failing in the package bots:
e.g. https://ci.swift.org/job/oss-swift-package-amazon-linux-2-aarch64/360/console