### PR TITLE
NFC: Fix Xcode prototype warnings

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -733,7 +733,7 @@ static _CFThreadSpecificKey __CFTSDIndexKey;
 static void *__CFThreadSpecificData;
 #endif
 
-CF_PRIVATE void __CFTSDInitialize() {
+CF_PRIVATE void __CFTSDInitialize(void) {
 #if !TARGET_OS_WASI
     static dispatch_once_t once;
     dispatch_once(&once, ^{

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -1663,8 +1663,7 @@ CF_EXPORT Boolean _CFExtensionIsValidToAppend(CFStringRef extension) {
 
 
 #if DEPLOYMENT_RUNTIME_SWIFT && !TARGET_OS_WASI
-
-CFDictionaryRef __CFGetEnvironment() {
+CFDictionaryRef __CFGetEnvironment(void) {
     static dispatch_once_t once = 0L;
     static CFMutableDictionaryRef envDict = NULL;
     dispatch_once(&once, ^{
@@ -1719,7 +1718,7 @@ CFDictionaryRef __CFGetEnvironment() {
     return envDict;
 }
 
-int32_t __CFGetPid() {
+int32_t __CFGetPid(void) {
     return getpid();
 }
 

--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -806,7 +806,7 @@ static CFStringRef __CFRunLoopCopyDescription(CFTypeRef cf) {
     return result;
 }
 
-CF_PRIVATE void __CFRunLoopDump() { // __private_extern__ to keep the compiler from discarding it
+CF_PRIVATE void __CFRunLoopDump(void) { // __private_extern__ to keep the compiler from discarding it
     CFStringRef desc = CFCopyDescription(CFRunLoopGetCurrent());
     CFShow(desc);
     CFRelease(desc);


### PR DESCRIPTION
Xcode warns that "old style functions have no prototypes." Having (void) as the parameter list fixes these warnings. No functional change.