### PR TITLE
[5.5] Url components.percent encoded query items

### DIFF
--- a/Sources/Foundation/URLComponents.swift
+++ b/Sources/Foundation/URLComponents.swift
@@ -271,7 +271,6 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
     /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string. Any percent-encoding in a query item name or value is retained
     ///
     /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. This property assumes the query item names and values are already correctly percent-encoded, and that the query item names do not contain the query item delimiter characters '&' and '='. Attempting to set an incorrectly percent-encoded query item or a query item name with the query item delimiter characters '&' and '=' will cause a `fatalError`.
-    @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
     public var percentEncodedQueryItems: [URLQueryItem]? {
         get { return _handle.map { $0.percentEncodedQueryItems } }
         set { _applyMutation { $0.percentEncodedQueryItems = newValue } }

--- a/Sources/Foundation/URLComponents.swift
+++ b/Sources/Foundation/URLComponents.swift
@@ -268,7 +268,16 @@ public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _Mutabl
         set { _applyMutation { $0.queryItems = newValue } }
     }
     
-    public func hash(into hasher: inout Hasher) {
+    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string. Any percent-encoding in a query item name or value is retained
+    ///
+    /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. This property assumes the query item names and values are already correctly percent-encoded, and that the query item names do not contain the query item delimiter characters '&' and '='. Attempting to set an incorrectly percent-encoded query item or a query item name with the query item delimiter characters '&' and '=' will cause a `fatalError`.
+    @available(macOS 10.13, iOS 11.0, tvOS 11.0, watchOS 4.0, *)
+    public var percentEncodedQueryItems: [URLQueryItem]? {
+        get { return _handle.map { $0.percentEncodedQueryItems } }
+        set { _applyMutation { $0.percentEncodedQueryItems = newValue } }
+    }
+
+public func hash(into hasher: inout Hasher) {
         hasher.combine(_handle.map { $0 })
     }
 

--- a/Tests/Foundation/Tests/TestURLComponents.swift
+++ b/Tests/Foundation/Tests/TestURLComponents.swift
@@ -41,6 +41,20 @@ class TestURLComponents: XCTestCase {
         XCTAssertEqual(["bar": "baz"], query)
     }
 
+    func test_percentEncodedQueryItems() {
+        let urlString = "http://localhost:8080/foo?feed%20me=feed%20me"
+        let url = URL(string: urlString)!
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+
+        var query = [String: String]()
+        components?.percentEncodedQueryItems?.forEach {
+            query[$0.name] = $0.value ?? ""
+        }
+        XCTAssertEqual(["feed%20me": "feed%20me"], query)
+    }
+
+
     func test_string() {
         for obj in getTestData()! {
             let testDict = obj as! [String: Any]
@@ -207,6 +221,24 @@ class TestURLComponents: XCTestCase {
         XCTAssertEqual(urlComponents.queryItems?.count, 4)
     }
 
+    func test_createURLWithComponentsPercentEncoded() {
+        let urlComponents = NSURLComponents()
+        urlComponents.scheme = "https";
+        urlComponents.host = "com.test.swift";
+        urlComponents.path = "/test/path";
+        let query = URLQueryItem(name: "simple%20string", value: "true%20is%20false")
+        urlComponents.percentEncodedQueryItems = [query]
+        XCTAssertNotNil(urlComponents.url?.query)
+        XCTAssertEqual(urlComponents.queryItems?.count, 1)
+        XCTAssertEqual(urlComponents.percentEncodedQueryItems?.count, 1)
+        guard let item = urlComponents.percentEncodedQueryItems?[0] else {
+            XCTFail("first element is missing")
+            return
+        }
+        XCTAssertEqual(item.name, "simple%20string")
+        XCTAssertEqual(item.value, "true%20is%20false")
+    }
+
     func test_path() {
         let c1 = URLComponents()
         XCTAssertEqual(c1.path, "")
@@ -250,12 +282,14 @@ class TestURLComponents: XCTestCase {
     static var allTests: [(String, (TestURLComponents) -> () throws -> Void)] {
         return [
             ("test_queryItems", test_queryItems),
+            ("test_percentEncodedQueryItems", test_percentEncodedQueryItems),
             ("test_string", test_string),
             ("test_port", test_portSetter),
             ("test_url", test_url),
             ("test_copy", test_copy),
             ("test_hash", test_hash),
             ("test_createURLWithComponents", test_createURLWithComponents),
+            ("test_createURLWithComponentsPercentEncoded", test_createURLWithComponentsPercentEncoded),
             ("test_path", test_path),
             ("test_percentEncodedPath", test_percentEncodedPath),
         ]


### PR DESCRIPTION
Fixes SR-12340

fixed on main with https://github.com/apple/swift-corelibs-foundation/pull/3096

Please consider for including in an upcoming 5.5 bug fix release for platform using swift-corelibs-foundation.

cc @millenomi @tomerd 