### PR TITLE
Specify variable type in CUserNotifications

### DIFF
--- a/CoreFoundation/AppServices.subproj/CFUserNotification.c
+++ b/CoreFoundation/AppServices.subproj/CFUserNotification.c
@@ -190,10 +190,10 @@ static SInt32 _CFUserNotificationSendRequest(CFAllocatorRef allocator, CFStringR
     
 #if TARGET_OS_OSX
     const char *namebuffer = NOTIFICATION_PORT_NAME_MAC;
-    const nameLen = sizeof(NOTIFICATION_PORT_NAME_MAC);
+    const CFIndex nameLen = sizeof(NOTIFICATION_PORT_NAME_MAC);
 #else
     const char *namebuffer = NOTIFICATION_PORT_NAME_IOS;
-    const nameLen = sizeof(NOTIFICATION_PORT_NAME_IOS);
+    const CFIndex nameLen = sizeof(NOTIFICATION_PORT_NAME_IOS);
 #endif
     
     if (sessionID) {


### PR DESCRIPTION
Specifying a variable without a type is not Standard C, even for sizeof