### PR TITLE
Remove unneeded check in CFRelease and CFRetain.

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -786,7 +786,7 @@ CFTypeRef _CFNonObjCRetain(CFTypeRef cf) {
 
 CFTypeRef CFRetain(CFTypeRef cf) {
     if (NULL == cf) { CRSetCrashLogMessage("*** CFRetain() called with NULL ***"); HALT; }
-    if (cf) __CFGenericAssertIsCF(cf);
+    __CFGenericAssertIsCF(cf);
     return _CFRetain(cf, false);
 }
 
@@ -804,7 +804,7 @@ void _CFNonObjCRelease(CFTypeRef cf) {
 
 void CFRelease(CFTypeRef cf) {
     if (NULL == cf) { CRSetCrashLogMessage("*** CFRelease() called with NULL ***"); HALT; }
-    if (cf) __CFGenericAssertIsCF(cf);
+    __CFGenericAssertIsCF(cf);
     _CFRelease(cf);
 }
 


### PR DESCRIPTION
If they were NULL, the program would just exit so this check is not needed.