### PR TITLE
Prefer the pthread types from CDispatch

### DIFF
--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -22,11 +22,6 @@ public protocol NSLocking {
     func unlock()
 }
 
-#if canImport(Glibc)
-typealias pthread_mutex_t = Glibc.pthread_mutex_t
-typealias pthread_cond_t = Glibc.pthread_cond_t
-#endif
-
 #if os(Windows)
 private typealias _MutexPointer = UnsafeMutablePointer<SRWLOCK>
 private typealias _RecursiveMutexPointer = UnsafeMutablePointer<CRITICAL_SECTION>


### PR DESCRIPTION
The types `pthread_mutex_t` and `pthread_cond_t` were defined via both `SwiftGlibc` and `CDistpatch` but a clang fix should merge these decls and consider `CDispatch` as the true origin.

Let's first see if we still need the explicit reference to `Glibc` when referring to those types.

rdar://84677782