### PR TITLE
[5.5] Check for invalid plist error

### DIFF
--- a/Sources/Foundation/PropertyListSerialization.swift
+++ b/Sources/Foundation/PropertyListSerialization.swift
@@ -63,7 +63,8 @@ open class PropertyListSerialization : NSObject {
         var error: Unmanaged<CFError>? = nil
         let decoded = withUnsafeMutablePointer(to: &fmt) { (outFmt: UnsafeMutablePointer<CFPropertyListFormat>) -> AnyObject? in
             withUnsafeMutablePointer(to: &error) { (outErr: UnsafeMutablePointer<Unmanaged<CFError>?>) -> AnyObject? in
-                return CFPropertyListCreateWithData(kCFAllocatorSystemDefault, data._cfObject, CFOptionFlags(CFIndex(opt.rawValue)), outFmt, outErr).takeRetainedValue()
+                let d = CFPropertyListCreateWithData(kCFAllocatorSystemDefault, data._cfObject, CFOptionFlags(CFIndex(opt.rawValue)), outFmt, outErr)
+		return d?.takeRetainedValue()
             }
         }
         format?.pointee = PropertyListFormat(rawValue: UInt(fmt.rawValue))!

--- a/Tests/Foundation/Tests/TestPropertyListSerialization.swift
+++ b/Tests/Foundation/Tests/TestPropertyListSerialization.swift
@@ -13,6 +13,7 @@ class TestPropertyListSerialization : XCTestCase {
             ("test_BasicConstruction", test_BasicConstruction),
             ("test_decodeData", test_decodeData),
             ("test_decodeStream", test_decodeStream),
+	    ("test_decodeEmptyData", test_decodeEmptyData),
         ]
     }
     
@@ -78,5 +79,15 @@ class TestPropertyListSerialization : XCTestCase {
         } else {
             XCTFail("value stored is not a string")
         }
+    }
+
+    func test_decodeEmptyData() {
+        XCTAssertThrowsError(try PropertyListSerialization.propertyList(from: Data(), format: nil)) { error in
+            let nserror = error as NSError
+            XCTAssertEqual(nserror.domain, NSCocoaErrorDomain)
+            XCTAssertEqual(CocoaError(_nsError: nserror).code, .propertyListReadCorrupt)
+            XCTAssertEqual(nserror.userInfo[NSDebugDescriptionErrorKey] as? String, "Cannot parse a NULL or zero-length data")
+	}
+
     }
 }


### PR DESCRIPTION
[5.5] Handle where the plist is empty, and CFPropertyListCreateWithData() failed to parse the entry and return NULL.

@millenomi @tomerd 