### PR TITLE
[test] Disable flaky test TestThread.test_sleepUntilDate

### DIFF
--- a/Tests/Foundation/Tests/TestThread.swift
+++ b/Tests/Foundation/Tests/TestThread.swift
@@ -174,7 +174,8 @@ class TestThread : XCTestCase {
                     "Android doesn't support backtraces at the moment."),
 		"And not currently on OpenBSD.")),
             ("test_sleepForTimeInterval", test_sleepForTimeInterval),
-            ("test_sleepUntilDate", test_sleepUntilDate),
+            ("test_sleepUntilDate",
+                testExpectedToFail(test_sleepUntilDate, "https://bugs.swift.org/browse/SR-15489")),
             ("test_threadName", test_threadName),
         ]
 


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-15489