### PR TITLE
build: allow building on Linux without Swift_FLAGS

### DIFF
--- a/Sources/Tools/plutil/CMakeLists.txt
+++ b/Sources/Tools/plutil/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(plutil PRIVATE
 if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
   target_link_options(plutil PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
 
-  string(REPLACE " " ";" ARGS_LIST ${CMAKE_Swift_FLAGS})
+  string(REPLACE " " ";" ARGS_LIST "${CMAKE_Swift_FLAGS}")
   execute_process(
     COMMAND ${CMAKE_Swift_COMPILER} ${ARGS_LIST} -print-target-info
     OUTPUT_VARIABLE output


### PR DESCRIPTION
When CMAKE_Swift_FLAGS is empty, the string substitution will be empty,
resulting in insufficient parameters to the REPLACE operation.  The
quoting ensures that an empty string does not cause that failure.