### PR TITLE
[build] Explicitly link against icudata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(HAS_LIBDISPATCH_API)
   find_package(dispatch CONFIG REQUIRED)
 endif()
 
-find_package(ICU COMPONENTS uc i18n REQUIRED)
+find_package(ICU COMPONENTS uc i18n data REQUIRED)
 
 include(SwiftSupport)
 include(GNUInstallDirs)

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -396,7 +396,8 @@ endif()
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation PRIVATE
     ICU::uc
-    ICU::i18n)
+    ICU::i18n
+    ICU::data)
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)


### PR DESCRIPTION
In preparation for https://github.com/apple/swift/pull/40340, explicitly link against icudata.