### PR TITLE
Process: handle `HRESULT` exit codes properly

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -631,8 +631,9 @@ open class Process: NSObject {
             // 3 to be an abnormal exit.
             var dwExitCode: DWORD = 0
             GetExitCodeProcess(process.processHandle, &dwExitCode)
-            if (dwExitCode & 0xF0000000) == 0xC0000000
-            || (dwExitCode & 0xF0000000) == 0xE0000000
+            if (dwExitCode & 0xF0000000) == 0x80000000      // HRESULT
+            || (dwExitCode & 0xF0000000) == 0xC0000000      // NTSTATUS
+            || (dwExitCode & 0xF0000000) == 0xE0000000      // NTSTATUS (Customer)
             || dwExitCode == 3 {
                 process._terminationStatus = Int32(dwExitCode & 0x3FFFFFFF)
                 process._terminationReason = .uncaughtSignal


### PR DESCRIPTION
When a process terminates due to an unhandled exception via a `HRESULT`,
the process termination status will not have `0xC000_0000` or
`0xE000_0000` but rather `0x8000_0000` set.  This accounts for that and
properly classifies the exit as an abnormal exit.  This was identified
by the swift-driver test suite not properly detecting an abnormal exit
of the frontend.