### PR TITLE
Remove additional/redundant case let as Date.

### DIFF
--- a/Sources/Foundation/JSONEncoder.swift
+++ b/Sources/Foundation/JSONEncoder.swift
@@ -448,8 +448,6 @@ extension JSONEncoderImpl: _SpecialTreatmentEncoder {
             return .number(decimal.description)
         case let object as [String: Encodable]: // this emits a warning, but it works perfectly
             return try self.wrapObject(object, for: nil)
-        case let date as Date:
-            return try self.wrapDate(date, for: nil)
         default:
             try encodable.encode(to: self)
             return self.value ?? .object([:])


### PR DESCRIPTION
Case accidentally included twice, remove a copy.