### PR TITLE
build: allow static linking against ICU data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(HAS_LIBDISPATCH_API)
   find_package(dispatch CONFIG REQUIRED)
 endif()
 
-find_package(ICU COMPONENTS uc i18n REQUIRED)
+find_package(ICU COMPONENTS uc i18n REQUIRED OPTIONAL_COMPONENTS data)
 
 include(SwiftSupport)
 include(GNUInstallDirs)

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -397,6 +397,10 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation PRIVATE
     ICU::uc
     ICU::i18n)
+  if(ICU_DATA_FOUND)
+    target_link_libraries(CoreFoundation PRIVATE
+      ICU::data)
+  endif()
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)


### PR DESCRIPTION
With the removal of the ICU data dependency in swiftCore, it is now
possible to statically link to the ICU, with static linking to the
ICU data as well.  This would allow us to remove the ICU dependency
from leaking into distributions which was previously required due to
the oversized cost of the ICU data.  With the single use now, it is
possible to statically link the data to avoid the distribution and
packaging.  In order to provide a migration path, this needs to be
optionalised, and as such, we only link the data if it is found (and
can be controlled through `-D ICU_DATA_LIBRARY_RELEASE=`