### PR TITLE
Fix TimeZone does not conforms to _ObjectiveCBridgeable

### DIFF
--- a/Sources/Foundation/TimeZone.swift
+++ b/Sources/Foundation/TimeZone.swift
@@ -255,7 +255,7 @@ extension TimeZone : CustomStringConvertible, CustomDebugStringConvertible, Cust
     }
 }
 
-extension TimeZone {
+extension TimeZone : _ObjectiveCBridgeable {
     public static func _isBridgedToObjectiveC() -> Bool {
         return true
     }


### PR DESCRIPTION
### PR description
This PR fix the missing `_ObjectiveCBridgeable` protocol conformance on `TimeZone` struct.

The API in Apple's Foundation declares `TimeZone` is marked as here:

![image](https://user-images.githubusercontent.com/6919743/149944679-a02364a1-7138-4187-b80b-8bfba77e87f1.png)

So this seems a typo, not designed behavior.

### Environment
Platform: Linux
Docker Image: swift/latest [d8708e4f244e2fa11eb9d1f4d718ee0a8481807f0070a7c5f9da5c2f853a94e5](https://hub.docker.com/layers/swift/library/swift/latest/images/sha256-d8708e4f244e2fa11eb9d1f4d718ee0a8481807f0070a7c5f9da5c2f853a94e5)
Swift Version: Swift version 5.5.2 (swift-5.5.2-RELEASE)

### Demo Code

```
public protocol NSObjectBridgeable : _ObjectiveCBridgeable {}
extension TimeZone : NSObjectBridgeable {}
```

### Excepted Result
Build Success.

### Actual Result
Build Failure. Showing:

```
error: conformance of 'TimeZone' to '_ObjectiveCBridgeable' can only be written in module 'Foundation'
extension TimeZone : NSObjectBridgeable {}
^
```