### PR TITLE
Foundation: `final`-ize many bridgeable interfaces

### DIFF
--- a/Sources/Foundation/Bundle.swift
+++ b/Sources/Foundation/Bundle.swift
@@ -14,7 +14,7 @@ private func _getTypeContextDescriptor(of cls: AnyClass) -> UnsafeRawPointer
 
 open class Bundle: NSObject {
     private var _bundleStorage: AnyObject!
-    private var _bundle: CFBundle! {
+    private final var _bundle: CFBundle! {
         get { unsafeBitCast(_bundleStorage, to: CFBundle?.self) }
         set { _bundleStorage = newValue }
     }

--- a/Sources/Foundation/DateFormatter.swift
+++ b/Sources/Foundation/DateFormatter.swift
@@ -11,8 +11,8 @@
 
 open class DateFormatter : Formatter {
     typealias CFType = CFDateFormatter
-    private var __cfObject: CFType?
-    private var _cfObject: CFType {
+    private final var __cfObject: CFType?
+    private final var _cfObject: CFType {
         guard let obj = __cfObject else {
             let dateStyle = CFDateFormatterStyle(rawValue: CFIndex(self.dateStyle.rawValue))!
             let timeStyle = CFDateFormatterStyle(rawValue: CFIndex(self.timeStyle.rawValue))!
@@ -147,7 +147,7 @@ open class DateFormatter : Formatter {
         __cfObject = nil
     }
 
-    internal func _setFormatterAttributes(_ formatter: CFDateFormatter) {
+    internal final func _setFormatterAttributes(_ formatter: CFDateFormatter) {
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterIsLenient, value: isLenient._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterTimeZone, value: _timeZone?._cfObject)
         if let ident = _calendar?.identifier {
@@ -181,7 +181,7 @@ open class DateFormatter : Formatter {
         _setFormatterAttribute(formatter, attributeName: kCFDateFormatterGregorianStartDate, value: _gregorianStartDate?._cfObject)
     }
 
-    internal func _setFormatterAttribute(_ formatter: CFDateFormatter, attributeName: CFString, value: AnyObject?) {
+    internal final func _setFormatterAttribute(_ formatter: CFDateFormatter, attributeName: CFString, value: AnyObject?) {
         if let value = value {
             CFDateFormatterSetProperty(formatter, attributeName, value)
         }

--- a/Sources/Foundation/DateIntervalFormatter.swift
+++ b/Sources/Foundation/DateIntervalFormatter.swift
@@ -83,8 +83,8 @@ internal extension _CFDateIntervalFormatterBoundaryStyle {
 // DateIntervalFormatter returns nil and NO for all methods in Formatter.
 
 open class DateIntervalFormatter: Formatter {
-    var _core: AnyObject
-    var core: CFDateIntervalFormatter {
+    private var _core: AnyObject
+    private final var core: CFDateIntervalFormatter {
         get { unsafeBitCast(_core, to: CFDateIntervalFormatter.self) }
         set { _core = newValue }
     }

--- a/Sources/Foundation/ISO8601DateFormatter.swift
+++ b/Sources/Foundation/ISO8601DateFormatter.swift
@@ -51,8 +51,8 @@ extension ISO8601DateFormatter {
 open class ISO8601DateFormatter : Formatter, NSSecureCoding {
     
     typealias CFType = CFDateFormatter
-    private var __cfObject: CFType?
-    private var _cfObject: CFType {
+    private final var __cfObject: CFType?
+    private final var _cfObject: CFType {
         guard let obj = __cfObject else {
             let format = CFISO8601DateFormatOptions(rawValue: formatOptions.rawValue)
             let obj = CFDateFormatterCreateISO8601Formatter(kCFAllocatorSystemDefault, format)!

--- a/Sources/Foundation/NSCalendar.swift
+++ b/Sources/Foundation/NSCalendar.swift
@@ -301,7 +301,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
     
     // Methods to return component name strings localized to the calendar's locale
     
-    private func _symbols(_ key: CFString) -> [String] {
+    private final func _symbols(_ key: CFString) -> [String] {
         let dateFormatter = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale?._cfObject, kCFDateFormatterNoStyle, kCFDateFormatterNoStyle)
         CFDateFormatterSetProperty(dateFormatter, kCFDateFormatterCalendarKey, _cfObject)
         let result = (CFDateFormatterCopyProperty(dateFormatter, key) as! NSArray)._swiftObject
@@ -310,7 +310,7 @@ open class NSCalendar : NSObject, NSCopying, NSSecureCoding {
         }
     }
     
-    private func _symbol(_ key: CFString) -> String {
+    private final func _symbol(_ key: CFString) -> String {
         let dateFormatter = CFDateFormatterCreate(kCFAllocatorSystemDefault, locale?._bridgeToObjectiveC()._cfObject, kCFDateFormatterNoStyle, kCFDateFormatterNoStyle)
         CFDateFormatterSetProperty(dateFormatter, kCFDateFormatterCalendarKey, self._cfObject)
         return (CFDateFormatterCopyProperty(dateFormatter, key) as! NSString)._swiftObject

--- a/Sources/Foundation/NSCharacterSet.swift
+++ b/Sources/Foundation/NSCharacterSet.swift
@@ -72,7 +72,7 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
         return unsafeBitCast(self, to: CFType.self)
     }
     
-    internal var _cfMutableObject: CFMutableCharacterSet {
+    internal final var _cfMutableObject: CFMutableCharacterSet {
         return unsafeBitCast(self, to: CFMutableCharacterSet.self)
     }
     

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -77,7 +77,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     private var _deallocHandler: _NSDataDeallocator? = _NSDataDeallocator() // for Swift
     private var _bytes: UnsafeMutablePointer<UInt8>? = nil
 
-    internal var _cfObject: CFType {
+    internal final var _cfObject: CFType {
         if type(of: self) === NSData.self || type(of: self) === NSMutableData.self {
             return unsafeBitCast(self, to: CFType.self)
         } else {
@@ -957,7 +957,7 @@ extension CFData : _NSBridgeable, _SwiftBridgeable {
 
 // MARK: -
 open class NSMutableData : NSData {
-    internal var _cfMutableObject: CFMutableData { return unsafeBitCast(self, to: CFMutableData.self) }
+    internal final var _cfMutableObject: CFMutableData { return unsafeBitCast(self, to: CFMutableData.self) }
 
     public override init() {
         super.init(bytes: nil, length: 0)

--- a/Sources/Foundation/NSDate.swift
+++ b/Sources/Foundation/NSDate.swift
@@ -52,7 +52,7 @@ open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
         _CFDeinit(self)
     }
     
-    internal var _cfObject: CFType {
+    internal final var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
     }
     

--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -50,7 +50,7 @@ public let NSFilePathErrorKey: String = "NSFilePathErrorKey"
 open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFError
     
-    internal var _cfObject: CFType {
+    internal final var _cfObject: CFType {
         return CFErrorCreate(kCFAllocatorSystemDefault, domain._cfObject, code, nil)
     }
     

--- a/Sources/Foundation/NSKeyedUnarchiver.swift
+++ b/Sources/Foundation/NSKeyedUnarchiver.swift
@@ -56,7 +56,7 @@ open class NSKeyedUnarchiver : NSCoder {
 #endif
     }
     
-    private var _stream : Stream
+    private final var _stream : Stream
     private var _flags = UnarchiverFlags(rawValue: 0)
     private var _containers : Array<DecodingContext>? = nil
     private var _objects : Array<Any> = []

--- a/Sources/Foundation/NSLocale.swift
+++ b/Sources/Foundation/NSLocale.swift
@@ -21,7 +21,7 @@ open class NSLocale: NSObject, NSCopying, NSSecureCoding {
     private var _lock: _NSCFLock = _NSCFLockInit()
     private var _nullLocale: Bool = false
 
-    internal var _cfObject: CFType {
+    internal final var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
     }
     

--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -609,7 +609,7 @@ open class NSNumber : NSValue {
     private var _base = _CFInfo(typeID: CFNumberGetTypeID())
     private var _pad: UInt64 = 0
 
-    internal var _cfObject: CFType {
+    internal final var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
     }
     
@@ -1088,7 +1088,7 @@ open class NSNumber : NSValue {
         }
     }
     
-    internal func _getValue(_ valuePtr: UnsafeMutableRawPointer, forType type: CFNumberType) -> Bool {
+    internal final func _getValue(_ valuePtr: UnsafeMutableRawPointer, forType type: CFNumberType) -> Bool {
         switch type {
         case kCFNumberSInt8Type:
             valuePtr.assumingMemoryBound(to: Int8.self).pointee = int8Value

--- a/Sources/Foundation/NSRegularExpression.swift
+++ b/Sources/Foundation/NSRegularExpression.swift
@@ -29,7 +29,7 @@ extension NSRegularExpression {
 
 open class NSRegularExpression: NSObject, NSCopying, NSSecureCoding {
     internal var _internalStorage: AnyObject
-    internal var _internal: _CFRegularExpression {
+    internal final var _internal: _CFRegularExpression {
         unsafeBitCast(_internalStorage, to: _CFRegularExpression.self)
     }
     

--- a/Sources/Foundation/NSTimeZone.swift
+++ b/Sources/Foundation/NSTimeZone.swift
@@ -18,7 +18,7 @@ open class NSTimeZone : NSObject, NSCopying, NSSecureCoding, NSCoding {
     private var _periods: UnsafeMutableRawPointer? = nil
     private var _periodCnt = Int32(0)
     
-    internal var _cfObject: CFType {
+    internal final var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
     }
     

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -93,7 +93,7 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     internal var _range8 = NSRange(location: 0, length: 0)
     internal var _range9 = NSRange(location: 0, length: 0)
     
-    internal var _cfObject : CFType {
+    internal final var _cfObject : CFType {
         if type(of: self) === NSURL.self {
             return unsafeBitCast(self, to: CFType.self)
         } else {

--- a/Sources/Foundation/NSURLComponents.swift
+++ b/Sources/Foundation/NSURLComponents.swift
@@ -12,7 +12,7 @@
 
 open class NSURLComponents: NSObject, NSCopying {
     private let _componentsStorage: AnyObject!
-    private var _components: CFURLComponents! { unsafeBitCast(_componentsStorage, to: CFURLComponents?.self) }
+    private final var _components: CFURLComponents! { unsafeBitCast(_componentsStorage, to: CFURLComponents?.self) }
 
     open override func copy() -> Any {
         return copy(with: nil)
@@ -298,7 +298,7 @@ open class NSURLComponents: NSObject, NSCopying {
         return NSRange(_CFURLComponentsGetRangeOfFragment(_components))
     }
 
-    private func mapQueryItemsFromArray(array: CFArray) -> [URLQueryItem] {
+    private final func mapQueryItemsFromArray(array: CFArray) -> [URLQueryItem] {
         let count = CFArrayGetCount(array)
         return (0..<count).map { idx in
             let oneEntry = unsafeBitCast(CFArrayGetValueAtIndex(array, idx), to: NSDictionary.self)

--- a/Sources/Foundation/NotificationQueue.swift
+++ b/Sources/Foundation/NotificationQueue.swift
@@ -36,12 +36,12 @@ open class NotificationQueue: NSObject {
     internal let notificationCenter: NotificationCenter
     internal var asapList = NSNotificationList()
     internal var idleList = NSNotificationList()
-    internal lazy var idleRunloopObserver: CFRunLoopObserver = {
+    internal final lazy var idleRunloopObserver: CFRunLoopObserver = {
         return CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, CFOptionFlags(kCFRunLoopBeforeTimers), true, 0) {[weak self] observer, activity in
             self!.notifyQueues(.whenIdle)
         }
     }()
-    internal lazy var asapRunloopObserver: CFRunLoopObserver = {
+    internal final lazy var asapRunloopObserver: CFRunLoopObserver = {
         return CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, CFOptionFlags(kCFRunLoopBeforeWaiting | kCFRunLoopExit), true, 0) {[weak self] observer, activity in
             self!.notifyQueues(.asap)
         }
@@ -130,12 +130,12 @@ open class NotificationQueue: NSObject {
 
     // MARK: Private
 
-    private func addRunloopObserver(_ observer: CFRunLoopObserver) {
+    private final func addRunloopObserver(_ observer: CFRunLoopObserver) {
         CFRunLoopAddObserver(RunLoop.current._cfRunLoop, observer, kCFRunLoopDefaultMode)
         CFRunLoopAddObserver(RunLoop.current._cfRunLoop, observer, kCFRunLoopCommonModes)
     }
 
-    private func removeRunloopObserver(_ observer: CFRunLoopObserver) {
+    private final func removeRunloopObserver(_ observer: CFRunLoopObserver) {
         CFRunLoopRemoveObserver(RunLoop.current._cfRunLoop, observer, kCFRunLoopDefaultMode)
         CFRunLoopRemoveObserver(RunLoop.current._cfRunLoop, observer, kCFRunLoopCommonModes)
     }

--- a/Sources/Foundation/NumberFormatter.swift
+++ b/Sources/Foundation/NumberFormatter.swift
@@ -44,8 +44,8 @@ extension NumberFormatter {
 open class NumberFormatter : Formatter {
 
     typealias CFType = CFNumberFormatter
-    private var _currentCfFormatter: CFType?
-    private var _cfFormatter: CFType {
+    private final var _currentCfFormatter: CFType?
+    private final var _cfFormatter: CFType {
         if let obj = _currentCfFormatter {
             return obj
         } else {
@@ -192,7 +192,7 @@ open class NumberFormatter : Formatter {
         _currentCfFormatter = nil
     }
 
-    private func _setFormatterAttributes(_ formatter: CFNumberFormatter) {
+    private final func _setFormatterAttributes(_ formatter: CFNumberFormatter) {
         if numberStyle == .currency {
             // Prefer currencySymbol, then currencyCode then locale.currencySymbol
             if let symbol = _currencySymbol {
@@ -253,13 +253,13 @@ open class NumberFormatter : Formatter {
         }
     }
 
-    private func _setFormatterAttribute(_ formatter: CFNumberFormatter, attributeName: CFString, value: AnyObject?) {
+    private final func _setFormatterAttribute(_ formatter: CFNumberFormatter, attributeName: CFString, value: AnyObject?) {
         if let value = value {
             CFNumberFormatterSetProperty(formatter, attributeName, value)
         }
     }
 
-    private func _getFormatterAttribute(_ formatter: CFNumberFormatter, attributeName: CFString) -> String? {
+    private final func _getFormatterAttribute(_ formatter: CFNumberFormatter, attributeName: CFString) -> String? {
         return CFNumberFormatterCopyProperty(formatter, attributeName) as? String
     }
 

--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -476,7 +476,7 @@ open class SocketPort : Port {
         self.init(protocolFamily: PF_INET, socketType: SOCK_STREAM, protocol: IPPROTO_TCP, address: data)
     }
     
-    private func createNonuniquedCore(from socket: CFSocket, protocolFamily family: Int32, socketType type: Int32, protocol: Int32) {
+    private final func createNonuniquedCore(from socket: CFSocket, protocolFamily family: Int32, socketType type: Int32, protocol: Int32) {
         self.core = Core(isUniqued: false)
         let address = CFSocketCopyAddress(socket)._swiftObject
         core.signature = Signature(address: LocalAddress(address), protocolFamily: family, socketType: type, protocol: `protocol`)
@@ -732,7 +732,7 @@ open class SocketPort : Port {
     
     // Sending and receiving:
     
-    fileprivate func socketDidAccept(_ socket: CFSocket?, _ type: CFSocketCallBackType, _ address: CFData?, _ data: UnsafeRawPointer?) {
+    fileprivate final func socketDidAccept(_ socket: CFSocket?, _ type: CFSocketCallBackType, _ address: CFData?, _ data: UnsafeRawPointer?) {
         guard let handle = data?.assumingMemoryBound(to: SocketNativeHandle.self),
             let address = address else {
                 return
@@ -753,7 +753,7 @@ open class SocketPort : Port {
         }
     }
     
-    private func addToLoopsAssumingLockHeld(_ socket: CFSocket) {
+    private final func addToLoopsAssumingLockHeld(_ socket: CFSocket) {
         guard let source = CFSocketCreateRunLoopSource(nil, socket, 600) else {
             return
         }
@@ -772,7 +772,7 @@ open class SocketPort : Port {
         case port = 2
     }
     
-    fileprivate func socketDidReceiveData(_ socket: CFSocket?, _ type: CFSocketCallBackType, _ address: CFData?, _ dataPointer: UnsafeRawPointer?) {
+    fileprivate final func socketDidReceiveData(_ socket: CFSocket?, _ type: CFSocketCallBackType, _ address: CFData?, _ dataPointer: UnsafeRawPointer?) {
         guard let socket = socket,
               let dataPointer = dataPointer else { return }
         let socketKey = ObjectIdentifier(socket)
@@ -839,7 +839,7 @@ open class SocketPort : Port {
         lock.unlock() // Release lock from above ⬆
     }
     
-    fileprivate func socketDidReceiveDatagram(_ socket: CFSocket?, _ type: CFSocketCallBackType, _ address: CFData?, _ data: UnsafeRawPointer?) {
+    fileprivate final func socketDidReceiveDatagram(_ socket: CFSocket?, _ type: CFSocketCallBackType, _ address: CFData?, _ data: UnsafeRawPointer?) {
         guard let address = address?._swiftObject,
               let data = data else {
             return
@@ -859,7 +859,7 @@ open class SocketPort : Port {
         static let offsetOfSignatureAddressLength = 15
     }
     
-    private func handleMessage(_ message: Data, from address: Data, socket: CFSocket?) {
+    private final func handleMessage(_ message: Data, from address: Data, socket: CFSocket?) {
         guard message.count > 24, let delegate = delegate() else { return }
         let portMessage = message.withUnsafeBytes { (messageBuffer) -> PortMessage? in
             guard SocketPort.magicNumber == messageBuffer.load(fromByteOffset: Structure.offsetOfMagicNumber, as: UInt32.self).bigEndian,
@@ -1027,7 +1027,7 @@ open class SocketPort : Port {
     private static let sendingSocketsLock = NSLock()
     private static var sendingSockets: [SocketKind: CFSocket] = [:]
     
-    private func sendingSocket(for port: SocketPort, before time: TimeInterval) -> CFSocket? {
+    private final func sendingSocket(for port: SocketPort, before time: TimeInterval) -> CFSocket? {
         let signature = port.core.signature!
         let socketKind = signature.socketKind
 

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -350,13 +350,13 @@ open class Process: NSObject {
     }
 
     private var _runLoopSourceContextStorage = NonexportedCFRunLoopSourceContextStorage()
-    private var runLoopSourceContext: CFRunLoopSourceContext? {
+    private final var runLoopSourceContext: CFRunLoopSourceContext? {
         get { _runLoopSourceContextStorage.value }
         set { _runLoopSourceContextStorage.value = newValue }
     }
     
     private var _runLoopSourceStorage = NonexportedCFRunLoopSourceStorage()
-    private var runLoopSource: CFRunLoopSource? {
+    private final var runLoopSource: CFRunLoopSource? {
         get { _runLoopSourceStorage.value }
         set { _runLoopSourceStorage.value = newValue }
     }

--- a/Sources/Foundation/PropertyListSerialization.swift
+++ b/Sources/Foundation/PropertyListSerialization.swift
@@ -76,7 +76,7 @@ open class PropertyListSerialization : NSObject {
     }
     
 #if !os(WASI)
-    internal class func propertyList(with stream: CFReadStream, options opt: ReadOptions, format: UnsafeMutablePointer <PropertyListFormat>?) throws -> Any {
+    internal final class func propertyList(with stream: CFReadStream, options opt: ReadOptions, format: UnsafeMutablePointer <PropertyListFormat>?) throws -> Any {
         var fmt = kCFPropertyListBinaryFormat_v1_0
         var error: Unmanaged<CFError>? = nil
         let decoded = withUnsafeMutablePointer(to: &fmt) { (outFmt: UnsafeMutablePointer<CFPropertyListFormat>) -> AnyObject? in

--- a/Sources/Foundation/RunLoop.swift
+++ b/Sources/Foundation/RunLoop.swift
@@ -58,7 +58,7 @@ internal func _NSRunLoopNew(_ cf: CFRunLoop) -> Unmanaged<AnyObject> {
 
 open class RunLoop: NSObject {
     internal var _cfRunLoopStorage : AnyObject!
-    internal var _cfRunLoop: CFRunLoop! {
+    internal final var _cfRunLoop: CFRunLoop! {
         get { unsafeBitCast(_cfRunLoopStorage, to: CFRunLoop?.self) }
         set { _cfRunLoopStorage = newValue }
     }
@@ -98,7 +98,7 @@ open class RunLoop: NSObject {
         return _cfRunLoop
     }
     #else
-    internal var currentCFRunLoop: CFRunLoop { _cfRunLoop }
+    internal final var currentCFRunLoop: CFRunLoop { _cfRunLoop }
 
     @available(*, unavailable, message: "Core Foundation is not available on your platform.")
     open func getCFRunLoop() -> Never {

--- a/Sources/Foundation/Stream.swift
+++ b/Sources/Foundation/Stream.swift
@@ -109,7 +109,7 @@ open class InputStream: Stream {
     }
     
     internal let _streamStorage: AnyObject!
-    internal var _stream: CFReadStream { unsafeBitCast(_streamStorage, to: CFReadStream.self) }
+    internal final var _stream: CFReadStream { unsafeBitCast(_streamStorage, to: CFReadStream.self) }
 
     // reads up to length bytes into the supplied buffer, which must be at least of size len. Returns the actual number of bytes read.
     open func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength len: Int) -> Int {
@@ -129,10 +129,6 @@ open class InputStream: Stream {
     // returns YES if the stream has bytes available or if it impossible to tell without actually doing the read.
     open var hasBytesAvailable: Bool {
         return CFReadStreamHasBytesAvailable(_stream)
-    }
-    
-    fileprivate init(readStream: CFReadStream) {
-        _streamStorage = readStream
     }
     
     public init(data: Data) {
@@ -186,7 +182,7 @@ open class InputStream: Stream {
 open class OutputStream : Stream {
     
     internal let _streamStorage: AnyObject!
-    internal var _stream: CFWriteStream { unsafeBitCast(_streamStorage, to: CFWriteStream.self) }
+    internal final var _stream: CFWriteStream { unsafeBitCast(_streamStorage, to: CFWriteStream.self) }
     
     // writes the bytes from the specified buffer to the stream up to len bytes. Returns the number of bytes actually written.
     open func write(_ buffer: UnsafePointer<UInt8>, maxLength len: Int) -> Int {
@@ -196,10 +192,6 @@ open class OutputStream : Stream {
     // returns YES if the stream can be written to or if it is impossible to tell without actually doing the write.
     open var hasSpaceAvailable: Bool {
         return CFWriteStreamCanAcceptBytes(_stream)
-    }
-    
-    fileprivate init(writeStream: CFWriteStream) {
-        _streamStorage = writeStream
     }
 
     // NOTE: on Darwin this is     'open class func toMemory() -> Self'

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -207,7 +207,7 @@ open class Thread : NSObject {
 
     private let _attrStorage = NonexportedAttrStorage()
 
-    internal var _attr: _CFThreadAttributes {
+    internal final var _attr: _CFThreadAttributes {
         get { _attrStorage.value }
         set { _attrStorage.value = newValue }
     }

--- a/Sources/Foundation/Timer.swift
+++ b/Sources/Foundation/Timer.swift
@@ -16,7 +16,7 @@ internal func __NSFireTimer(_ timer: CFRunLoopTimer?, info: UnsafeMutableRawPoin
 }
 
 open class Timer : NSObject {
-    internal var _cfObject: CFRunLoopTimer {
+    internal final var _cfObject: CFRunLoopTimer {
         get {
             return _timer!
         }
@@ -26,7 +26,7 @@ open class Timer : NSObject {
     }
     
     internal var _timerStorage: AnyObject?
-    internal var _timer: CFRunLoopTimer? { unsafeBitCast(_timerStorage, to: CFRunLoopTimer?.self) } // has to be optional because this is a chicken/egg problem with initialization in swift
+    internal final var _timer: CFRunLoopTimer? { unsafeBitCast(_timerStorage, to: CFRunLoopTimer?.self) } // has to be optional because this is a chicken/egg problem with initialization in swift
     internal var _fire: (Timer) -> Void = { (_: Timer) in }
     
     /// Alternative API for timer creation with a block.


### PR DESCRIPTION
These are not overridden and are private fields which do not need to be
emitted to the vtable.  This allows these members to not impact the
module serialization when `@_implementationOnly import`s are used for
CoreFoundation by removing them entirely from the serialization path.