### PR TITLE
[5.5] Temporary fix for static linking on Linux

### DIFF
--- a/Sources/FoundationNetworking/URLSession/BodySource.swift
+++ b/Sources/FoundationNetworking/URLSession/BodySource.swift
@@ -23,7 +23,13 @@ import Foundation
 #endif
 
 @_implementationOnly import CoreFoundation
+
+#if os(Linux)
+import CFURLSessionInterface
+#else
 @_implementationOnly import CFURLSessionInterface
+#endif
+
 import Dispatch
 
 

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -10,6 +10,9 @@
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import SwiftFoundation
 import CFXMLInterface
+#elseif os(Linux)
+import Foundation
+import CFXMLInterface
 #else
 import Foundation
 @_implementationOnly import CFXMLInterface


### PR DESCRIPTION
When using @_implementationOnly, the dependencies do not get emited into the module files and static linking does not work. There is a proper fix in 5.6, so this is only a temporary solution for 5.5.