### PR TITLE
[5.5] Prevent empty dictionary with non-String keys from encoding as a JSON object.

### DIFF
--- a/Sources/Foundation/JSONEncoder.swift
+++ b/Sources/Foundation/JSONEncoder.swift
@@ -506,8 +506,8 @@ extension _SpecialTreatmentEncoder {
             return .string(url.absoluteString)
         case let decimal as Decimal:
             return .number(decimal.description)
-        case let object as [String: Encodable]:
-            return try self.wrapObject(object, for: additionalKey)
+        case let object as _JSONStringDictionaryEncodableMarker:
+            return try self.wrapObject(object as! [String: Encodable], for: additionalKey)
         default:
             let encoder = self.getEncoder(for: additionalKey)
             try encodable.encode(to: encoder)


### PR DESCRIPTION
Darwin encodes these as an empty array (`[]`), but SCF was encoding an empty JSON object instead (`{}`). Fixes https://bugs.swift.org/browse/SR-15781.