### PR TITLE
[NFC] Fix up some warnings

### DIFF
--- a/Sources/Foundation/NSDecimalNumber.swift
+++ b/Sources/Foundation/NSDecimalNumber.swift
@@ -222,10 +222,10 @@ open class NSDecimalNumber : NSNumber {
         return NSDecimalNumber(integerLiteral: 1)
     }
     open class var minimum: NSDecimalNumber {
-        return NSDecimalNumber(decimal:Decimal.leastFiniteMagnitude)
+        return NSDecimalNumber(decimal: -Decimal.greatestFiniteMagnitude)
     }
     open class var maximum: NSDecimalNumber {
-        return NSDecimalNumber(decimal:Decimal.greatestFiniteMagnitude)
+        return NSDecimalNumber(decimal: Decimal.greatestFiniteMagnitude)
 
     }
     open class var notANumber: NSDecimalNumber {

--- a/Sources/Foundation/NSSet.swift
+++ b/Sources/Foundation/NSSet.swift
@@ -70,13 +70,7 @@ open class NSSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCodi
 
     public convenience init(set: Set<AnyHashable>, copyItems flag: Bool) {
         if flag {
-            self.init(array: set.map {
-                if let item = $0 as? NSObject {
-                    return item.copy()
-                } else {
-                    return $0
-                }
-            })
+            self.init(array: set.map{ ($0 as NSObject).copy() })
         } else {
             self.init(array: Array(set))
         }

--- a/Sources/Foundation/RunLoop.swift
+++ b/Sources/Foundation/RunLoop.swift
@@ -258,7 +258,7 @@ extension RunLoop {
     }
     
     @available(*, deprecated, message: "For XCTest use only.")
-    open func _remove(_ source: _Source, for mode: RunLoop.Mode) {
+    public func _remove(_ source: _Source, for mode: RunLoop.Mode) {
         CFRunLoopRemoveSource(_cfRunLoop, source.cfSource, mode._cfStringUniquingKnown)
     }
 }

--- a/Sources/Foundation/URL.swift
+++ b/Sources/Foundation/URL.swift
@@ -655,13 +655,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// - note: This function will resolve against the base `URL`.
     /// - returns: The path, or an empty string if the URL has an empty path.
     public var path: String {
-        if let parameterString = _url.parameterString {
-            if let path = _url.path {
-                return path + ";" + parameterString
-            } else {
-                return ";" + parameterString
-            }
-        } else if let path = _url.path {
+        if let path = _url.path {
             return path
         } else {
             return ""
@@ -676,13 +670,7 @@ public struct URL : ReferenceConvertible, Equatable {
     /// - note: This function will resolve against the base `URL`.
     /// - returns: The relative path, or an empty string if the URL has an empty path.
     public var relativePath: String {
-        if let parameterString = _url.parameterString {
-            if let path = _url.relativePath {
-                return path + ";" + parameterString
-            } else {
-                return ";" + parameterString
-            }
-        } else if let path = _url.relativePath {
+        if let path = _url.relativePath {
             return path
         } else {
             return ""


### PR DESCRIPTION
- parameterString will always return a nil value for Swift 5.3 or later
- Non-'@objc' class method in extensions cannot be overridden
- AnyHashable to NSObject will always success
- Use -Decimal.greatestFiniteMagnitude instead of Decimal.leastFiniteMagnitude
