### PR TITLE
[5.6] [cmake] Fix ICU static linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(HAS_LIBDISPATCH_API)
   find_package(dispatch CONFIG REQUIRED)
 endif()
 
-find_package(ICU COMPONENTS uc i18n REQUIRED)
+find_package(ICU COMPONENTS uc i18n REQUIRED OPTIONAL_COMPONENTS data)
 
 include(SwiftSupport)
 include(GNUInstallDirs)

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -397,6 +397,10 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(CoreFoundation PRIVATE
     ICU::uc
     ICU::i18n)
+  if(ICU_DATA_FOUND)
+    target_link_libraries(CoreFoundation PRIVATE
+      ICU::data)
+  endif()
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -176,9 +176,19 @@ if(NOT BUILD_SHARED_LIBS)
   get_filename_component(icu_i18n_dir "${icui18n_path}" DIRECTORY)
   string(REPLACE "lib" "" icu_i18n_basename "${icu_i18n_basename}")
 
+  get_target_property(icuuc_path ICU::uc IMPORTED_LOCATION)
+  get_filename_component(icu_uc_basename "${icuuc_path}" NAME_WE)
+  string(REPLACE "lib" "" icu_uc_basename "${icu_uc_basename}")
+
+  get_target_property(icudata_path ICU::data IMPORTED_LOCATION)
+  get_filename_component(icu_data_basename "${icudata_path}" NAME_WE)
+  string(REPLACE "lib" "" icu_data_basename "${icu_data_basename}")
+
   target_compile_options(Foundation
     PRIVATE
       "SHELL:-Xfrontend -public-autolink-library -Xfrontend ${icu_i18n_basename}
+             -Xfrontend -public-autolink-library -Xfrontend ${icu_uc_basename}
+             -Xfrontend -public-autolink-library -Xfrontend ${icu_data_basename}
              -Xfrontend -public-autolink-library -Xfrontend BlocksRuntime")
   # ICU libraries are linked by absolute library path in this project,
   # but -public-autolink-library forces to resolve library path by


### PR DESCRIPTION
When static linking Foundation, some of ICU's dependencies were not being explicitly linked against, so static linking failed for those platforms due to undefined references. This patch only affects the build rules for static linking.

Resolves: https://bugs.swift.org/browse/SR-15770 and rdar://87991595