### PR TITLE
Foundation: make some functions more visible

### DIFF
--- a/Sources/Foundation/NSCharacterSet.swift
+++ b/Sources/Foundation/NSCharacterSet.swift
@@ -62,11 +62,11 @@ fileprivate extension String {
 
 open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     typealias CFType = CFCharacterSet
-    private var _base = _CFInfo(typeID: CFCharacterSetGetTypeID())
-    private var _hashValue = UInt(0) // CFHashCode
-    private var _buffer: UnsafeMutableRawPointer? = nil
-    private var _length = Int(0) // CFIndex
-    private var _annex: UnsafeMutableRawPointer? = nil
+    internal var _base = _CFInfo(typeID: CFCharacterSetGetTypeID())
+    internal var _hashValue = UInt(0) // CFHashCode
+    internal var _buffer: UnsafeMutableRawPointer? = nil
+    internal var _length = Int(0) // CFIndex
+    internal var _annex: UnsafeMutableRawPointer? = nil
     
     internal var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)

--- a/Sources/Foundation/NSCoder.swift
+++ b/Sources/Foundation/NSCoder.swift
@@ -745,7 +745,7 @@ open class NSCoder : NSObject {
         _hasFailed = true
     }
     
-    internal private(set) var _hasFailed = false
+    internal var _hasFailed = false
     
     open internal(set) var decodingFailurePolicy: NSCoder.DecodingFailurePolicy = .raiseException
     

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -340,7 +340,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         return NSMutableData(bytes: UnsafeMutableRawPointer(mutating: bytes), length: length, copy: true, deallocator: nil)
     }
     
-    private func byteDescription(limit: Int? = nil) -> String {
+    internal func byteDescription(limit: Int? = nil) -> String {
         var s = ""
         var i = 0
         while i < self.length {

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -56,7 +56,7 @@ extension NSData {
     }
 }
 
-private final class _NSDataDeallocator {
+internal final class _NSDataDeallocator {
     var handler: (UnsafeMutableRawPointer, Int) -> Void = {_,_ in }
 }
 
@@ -70,12 +70,12 @@ private let __kCFDontDeallocate: CFOptionFlags = 4
 open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     typealias CFType = CFData
 
-    private var _base = _CFInfo(typeID: CFDataGetTypeID())
-    private var _length: Int = 0 // CFIndex
-    private var _capacity: Int = 0 // CFIndex
-    private var _deallocator: UnsafeMutableRawPointer? = nil // for CF only
-    private var _deallocHandler: _NSDataDeallocator? = _NSDataDeallocator() // for Swift
-    private var _bytes: UnsafeMutablePointer<UInt8>? = nil
+    internal var _base = _CFInfo(typeID: CFDataGetTypeID())
+    internal var _length: Int = 0 // CFIndex
+    internal var _capacity: Int = 0 // CFIndex
+    internal var _deallocator: UnsafeMutableRawPointer? = nil // for CF only
+    internal var _deallocHandler: _NSDataDeallocator? = _NSDataDeallocator() // for Swift
+    internal var _bytes: UnsafeMutablePointer<UInt8>? = nil
 
     internal final var _cfObject: CFType {
         if type(of: self) === NSData.self || type(of: self) === NSMutableData.self {
@@ -112,7 +112,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
 
-    fileprivate init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool = false, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)? = nil) {
+    internal init(bytes: UnsafeMutableRawPointer?, length: Int, copy: Bool = false, deallocator: ((UnsafeMutableRawPointer, Int) -> Void)? = nil) {
         super.init()
         _init(bytes: bytes, length: length, copy: copy, deallocator: deallocator)
     }

--- a/Sources/Foundation/NSDictionary.swift
+++ b/Sources/Foundation/NSDictionary.swift
@@ -14,6 +14,28 @@
 import Dispatch
 #endif
 
+fileprivate func getDescription(of object: Any) -> String? {
+    switch object {
+    case let nsArray as NSArray:
+        return nsArray.description(withLocale: nil, indent: 1)
+    case let nsDecimalNumber as NSDecimalNumber:
+        return nsDecimalNumber.description(withLocale: nil)
+    case let nsDate as NSDate:
+        return nsDate.description(with: nil)
+    case let nsOrderedSet as NSOrderedSet:
+        return nsOrderedSet.description(withLocale: nil)
+    case let nsSet as NSSet:
+        return nsSet.description(withLocale: nil)
+    case let nsDictionary as NSDictionary:
+        return nsDictionary.description(withLocale: nil)
+    case let hashableObject as Dictionary<AnyHashable, Any>:
+        return hashableObject._nsObject.description(withLocale: nil, indent: 1)
+    default:
+        return nil
+    }
+}
+
+
 open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCoding, ExpressibleByDictionaryLiteral {
     private let _cfinfo = _CFInfo(typeID: CFDictionaryGetTypeID())
     internal var _storage: [NSObject: AnyObject]
@@ -299,27 +321,6 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
         return description(withLocale: nil)
     }
     
-    private func getDescription(of object: Any) -> String? {
-        switch object {
-        case let nsArray as NSArray:
-            return nsArray.description(withLocale: nil, indent: 1)
-        case let nsDecimalNumber as NSDecimalNumber:
-            return nsDecimalNumber.description(withLocale: nil)
-        case let nsDate as NSDate:
-            return nsDate.description(with: nil)
-        case let nsOrderedSet as NSOrderedSet:
-            return nsOrderedSet.description(withLocale: nil)
-        case let nsSet as NSSet:
-            return nsSet.description(withLocale: nil)
-        case let nsDictionary as NSDictionary:
-            return nsDictionary.description(withLocale: nil)
-        case let hashableObject as Dictionary<AnyHashable, Any>:
-            return hashableObject._nsObject.description(withLocale: nil, indent: 1)
-        default:
-            return nil
-        }
-    }
-
     open var descriptionInStringsFileFormat: String {
         var lines = [String]()
         for key in self.allKeys {

--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -594,7 +594,7 @@ extension NSNumber : ExpressibleByFloatLiteral, ExpressibleByIntegerLiteral, Exp
 
 }
 
-private struct CFSInt128Struct {
+internal struct CFSInt128Struct {
     var high: Int64
     var low: UInt64
 }
@@ -606,8 +606,8 @@ fileprivate func cast<T, U>(_ t: T) -> U {
 open class NSNumber : NSValue {
     typealias CFType = CFNumber
     // This layout MUST be the same as CFNumber so that they are bridgeable
-    private var _base = _CFInfo(typeID: CFNumberGetTypeID())
-    private var _pad: UInt64 = 0
+    internal var _base = _CFInfo(typeID: CFNumberGetTypeID())
+    internal var _pad: UInt64 = 0
 
     internal final var _cfObject: CFType {
         return unsafeBitCast(self, to: CFType.self)
@@ -903,7 +903,7 @@ open class NSNumber : NSValue {
         return .init(truncatingIfNeeded: value.low)
     }
 
-    private var int128Value: CFSInt128Struct {
+    internal var int128Value: CFSInt128Struct {
         var value = CFSInt128Struct(high: 0, low: 0)
         CFNumberGetValue(_cfObject, kCFNumberSInt128Type, &value)
         return value

--- a/Sources/Foundation/NSObject.swift
+++ b/Sources/Foundation/NSObject.swift
@@ -367,7 +367,7 @@ open class NSObject : NSObjectProtocol, Equatable, Hashable {
     // Please note:
     // the following methods are not overridable in swift-corelibs-foundation.
     
-    private class var nsObjectSuperclass: NSObject.Type? {
+    internal class var nsObjectSuperclass: NSObject.Type? {
         // Pretend that {Swift,}Foundation.NSObject is the top of the class hierarchy.
         // On Darwin, avoids dipping into the class hierarchy that exists above this class,
         // which is ultimately rooted in the ObjC NSObject class.

--- a/Sources/Foundation/Progress.swift
+++ b/Sources/Foundation/Progress.swift
@@ -30,14 +30,14 @@ import Dispatch
  */
 open class Progress : NSObject {
     
-    private weak var _parent : Progress?
-    private var _children : Set<Progress>
-    private var _selfFraction : _ProgressFraction
-    private var _childFraction : _ProgressFraction
-    private var _userInfo : [ProgressUserInfoKey : Any]
+    internal weak var _parent : Progress?
+    internal var _children : Set<Progress>
+    internal var _selfFraction : _ProgressFraction
+    internal var _childFraction : _ProgressFraction
+    internal var _userInfo : [ProgressUserInfoKey : Any]
     
     // This is set once, but after initialization
-    private var _portionOfParent : Int64
+    internal var _portionOfParent : Int64
     
     static private var _tsdKey = "_Foundation_CurrentProgressKey"
     
@@ -167,7 +167,7 @@ open class Progress : NSObject {
         }
     }
     
-    private func _setParent(_ parent: Progress, portion: Int64) {
+    internal func _setParent(_ parent: Progress, portion: Int64) {
         _parent = parent
         _portionOfParent = portion
         
@@ -416,18 +416,18 @@ open class Progress : NSObject {
     // MARK: -
     // MARK: Implementation of unit counts
     
-    private var _overallFraction : _ProgressFraction {
+    internal var _overallFraction : _ProgressFraction {
         return _selfFraction + _childFraction
     }
     
-    private func _addCompletedUnitCount(_ unitCount : Int64) {
+    internal func _addCompletedUnitCount(_ unitCount : Int64) {
         let old = _overallFraction
         _selfFraction.completed += unitCount
         let new = _overallFraction
         _updateFractionCompleted(from: old, to: new)
     }
 
-    private func _updateFractionCompleted(from: _ProgressFraction, to: _ProgressFraction) {
+    internal func _updateFractionCompleted(from: _ProgressFraction, to: _ProgressFraction) {
         if from != to {
             _parent?._updateChild(self, from: from, to: to, portion: _portionOfParent)
         }

--- a/Tests/Foundation/Tests/TestNSData.swift
+++ b/Tests/Foundation/Tests/TestNSData.swift
@@ -20,7 +20,7 @@ import CoreFoundation
 class TestNSData: LoopbackServerTest {
     
     class AllOnesImmutableData : NSData {
-        private var _length : Int
+        private var __length : Int
         var _pointer : UnsafeMutableBufferPointer<UInt8>? {
             willSet {
                 if let p = _pointer { free(p.baseAddress) }
@@ -28,7 +28,7 @@ class TestNSData: LoopbackServerTest {
         }
         
         init(length: Int) {
-            _length = length
+            __length = length
             super.init()
         }
         
@@ -45,7 +45,7 @@ class TestNSData: LoopbackServerTest {
         
         override var length : Int {
             get {
-                return _length
+                return __length
             }
         }
         
@@ -78,7 +78,7 @@ class TestNSData: LoopbackServerTest {
     
     class AllOnesData : NSMutableData {
         
-        private var _length : Int
+        private var __length : Int
         var _pointer : UnsafeMutableBufferPointer<UInt8>? {
             willSet {
                 if let p = _pointer { free(p.baseAddress) }
@@ -86,7 +86,7 @@ class TestNSData: LoopbackServerTest {
         }
         
         override init(length: Int) {
-            _length = length
+            __length = length
             super.init()
         }
         
@@ -103,22 +103,22 @@ class TestNSData: LoopbackServerTest {
         
         override var length : Int {
             get {
-                return _length
+                return __length
             }
             set {
                 if let ptr = _pointer {
                     // Copy the data to our new length buffer
                     let newBuffer = malloc(newValue)!
-                    if newValue <= _length {
+                    if newValue <= __length {
                         memmove(newBuffer, ptr.baseAddress!, newValue)
-                    } else if newValue > _length {
-                        memmove(newBuffer, ptr.baseAddress!, _length)
-                        memset(newBuffer + _length, 1, newValue - _length)
+                    } else if newValue > __length {
+                        memmove(newBuffer, ptr.baseAddress!, __length)
+                        memset(newBuffer + __length, 1, newValue - __length)
                     }
                     let bytePtr = newBuffer.bindMemory(to: UInt8.self, capacity: newValue)
                     _pointer = UnsafeMutableBufferPointer(start: bytePtr, count: newValue)
                 }
-                _length = newValue
+                __length = newValue
             }
         }
         
@@ -138,7 +138,7 @@ class TestNSData: LoopbackServerTest {
         }
         
         override var mutableBytes: UnsafeMutableRawPointer {
-            let newBufferLength = _length
+            let newBufferLength = __length
             let newBuffer = malloc(newBufferLength)
             if let ptr = _pointer {
                 // Copy the existing data to the new box, then return its pointer
@@ -150,7 +150,7 @@ class TestNSData: LoopbackServerTest {
             let bytePtr = newBuffer!.bindMemory(to: UInt8.self, capacity: newBufferLength)
             let result = UnsafeMutableBufferPointer(start: bytePtr, count: newBufferLength)
             _pointer = result
-            _length = newBufferLength
+            __length = newBufferLength
             return UnsafeMutableRawPointer(result.baseAddress!)
         }
         


### PR DESCRIPTION
These ivars and functions are referenced elsewhere in Foundation.  We
were previously relying on the compiler exporting functions more
aggressively which would ensure that these were emitted even when not
meant to be used outside of the current module.  This marks these
interfaces as `internal` to ensure that references from other source
files are emitted with more aggressive internalization by the compiler.