### PR TITLE
[EXPERIMENTAL] Add support for vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,8 @@ if(HAS_LIBDISPATCH_API)
   find_package(dispatch CONFIG REQUIRED)
 endif()
 
-find_package(ICU COMPONENTS uc i18n REQUIRED OPTIONAL_COMPONENTS data)
+find_package(ICU COMPONENTS uc i18n REQUIRED)
+find_package(ICU OPTIONAL_COMPONENTS data)
 
 include(SwiftSupport)
 include(GNUInstallDirs)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "swift-corelibs-foundation",
+  "version-string": "0.1.0",
+  "dependencies": [
+    "curl",
+    "icu",
+    "libxml2",
+    "zlib"
+  ]
+}


### PR DESCRIPTION
Windows developers have a relatively difficult experience for pulling in dependencies. This patch adds support for [`vcpkg`](https://github.com/microsoft/vcpkg)'s manifest mode, which can seamlessly integrate with CMake.