### PR TITLE
PlugIn: allow for a fallback for other platforms

### DIFF
--- a/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Internal.h
@@ -455,7 +455,7 @@ static bool _CFGetPathFromFileDescriptor(int fd, char *path) {
     return true;
 }
 
-#else
+#elif TARGET_OS_WIN32
 
 static bool _CFGetPathFromFileDescriptor(int fd, char *path) {
     HANDLE hFile = _get_osfhandle(fd);
@@ -481,6 +481,13 @@ static bool _CFGetPathFromFileDescriptor(int fd, char *path) {
     CFRelease(location);
     free(wszPath);
     return true;
+}
+
+#else
+
+static bool _CFGetPathFromFileDescriptor(int fd, char *path) {
+#warning This platform does not have a way to go back from an open file descriptor to a path.
+    return false;
 }
 
 #endif


### PR DESCRIPTION
The Windows path was left as the other case initially during the last
update.  This explicitly captures the Windows path and should allow
addition of new targets.  This addresses some review comments from
@stevapple.