### PR TITLE
Fix IndexPath slicing crash

### DIFF
--- a/Sources/Foundation/IndexPath.swift
+++ b/Sources/Foundation/IndexPath.swift
@@ -261,9 +261,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     case 0:
                         return .empty
                     case 1:
-                        return .single(slice[0])
+                        return .single(slice.first!)
                     case 2:
-                        return .pair(slice[0], slice[1])
+                        return .pair(slice.first!, slice.last!)
                     default:
                         return .array(Array<Int>(slice))
                     }


### PR DESCRIPTION
The following currently crashes:
```
let path = IndexPath(indexes: [ 10, 20, 30, 40 ])
print(path[2...])
```
Due to an assumption of zero-based indexes for a slice.

Still needs a test.
