### PR TITLE
Fix IndexPath slicing crash

### DIFF
--- a/Sources/Foundation/IndexPath.swift
+++ b/Sources/Foundation/IndexPath.swift
@@ -261,9 +261,9 @@ public struct IndexPath : ReferenceConvertible, Equatable, Hashable, MutableColl
                     case 0:
                         return .empty
                     case 1:
-                        return .single(slice[0])
+                        return .single(slice.first!)
                     case 2:
-                        return .pair(slice[0], slice[1])
+                        return .pair(slice.first!, slice.last!)
                     default:
                         return .array(Array<Int>(slice))
                     }

--- a/Tests/Foundation/Tests/TestIndexPath.swift
+++ b/Tests/Foundation/Tests/TestIndexPath.swift
@@ -287,6 +287,15 @@ class TestIndexPath: XCTestCase {
         XCTAssertEqual(ip4.count, 2)
         XCTAssertEqual(ip4[0], 2)
         XCTAssertEqual(ip4[1], 3)
+
+        let ip5 = ip3[1...]
+        XCTAssertEqual(ip5.count, 2)
+        XCTAssertEqual(ip5[0], 3)
+        XCTAssertEqual(ip5[1], 4)
+
+        let ip6 = ip3[2...]
+        XCTAssertEqual(ip6.count, 1)
+        XCTAssertEqual(ip6[0], 4)
     }
     
     func testAppending() {


### PR DESCRIPTION
(Re-open of accidentally closed #3152)

Subscripting of `IndexPath` using a range currently crashes when removing from the front if the result is a pair or single:
```
let path = IndexPath(indexes: [ 10, 20, 30, 40 ])
print(path[2...]) // Crash
```