### PR TITLE
Write string external representation in String.write(to: URL)

### DIFF
--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1254,7 +1254,7 @@ extension NSString {
         let length = self.length
         var numBytes = 0
         let theRange = NSRange(location: 0, length: length)
-        if !getBytes(nil, maxLength: Int.max - 1, usedLength: &numBytes, encoding: enc, options: [], range: theRange, remaining: nil) {
+        if !getBytes(nil, maxLength: Int.max - 1, usedLength: &numBytes, encoding: enc, options: [.externalRepresentation], range: theRange, remaining: nil) {
             throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteInapplicableStringEncoding.rawValue, userInfo: [
                 NSURLErrorKey: dest,
             ])
@@ -1263,7 +1263,7 @@ extension NSString {
         // The getBytes:... call should hopefully not fail, given it succeeded above, but check anyway (mutable string changing behind our back?)
         var used = 0
         try mData.withUnsafeMutableBytes { (mutableRawBuffer: UnsafeMutableRawBufferPointer) -> Void in
-            if !getBytes(mutableRawBuffer.baseAddress, maxLength: numBytes, usedLength: &used, encoding: enc, options: [], range: theRange, remaining: nil) {
+            if !getBytes(mutableRawBuffer.baseAddress, maxLength: numBytes, usedLength: &used, encoding: enc, options: [.externalRepresentation], range: theRange, remaining: nil) {
                 throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteUnknown.rawValue, userInfo: [
                     NSURLErrorKey: dest,
                 ])

--- a/Tests/Foundation/Tests/TestNSString.swift
+++ b/Tests/Foundation/Tests/TestNSString.swift
@@ -460,6 +460,35 @@ class TestNSString: LoopbackServerTest {
         }
     }
 
+    func test_writeToURLHasBOM_UTF32() throws {
+        var url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+        url.appendPathComponent("swiftfoundation-\(#function)-tmp")
+
+        // Writing with String.Encoding.utf32 should include the BOM.
+        let string = NSString("hello, 🌍!")
+        do {
+            try string.write(to: url, atomically: false, encoding: String.Encoding.utf32.rawValue)
+            let data = try Data(contentsOf: url)
+            #if _endian(little)
+                XCTAssertTrue(data.starts(with: [0xFF, 0xFE, 0x00, 0x00]))
+            #else
+                XCTAssertTrue(data.starts(with: [0x00, 0x00, 0xFE, 0xFF]))
+            #endif
+        }
+        // Writing with String.Encoding.utf32{Big/Little}Endian does not include the BOM.
+        do {
+            try string.write(to: url, atomically: false, encoding: String.Encoding.utf32BigEndian.rawValue)
+            let data = try Data(contentsOf: url)
+            XCTAssertTrue(data.starts(with: [0x00, 0x00, 0x00, 0x68]))
+        }
+        do {
+            try string.write(to: url, atomically: false, encoding: String.Encoding.utf32LittleEndian.rawValue)
+            let data = try Data(contentsOf: url)
+            XCTAssertTrue(data.starts(with: [0x68, 0x00, 0x00, 0x00]))
+        }
+    }
+
     func test_uppercaseString() {
         XCTAssertEqual(NSString(stringLiteral: "abcd").uppercased, "ABCD")
         XCTAssertEqual(NSString(stringLiteral: "ａｂｃｄ").uppercased, "ＡＢＣＤ") // full-width
@@ -1682,6 +1711,7 @@ class TestNSString: LoopbackServerTest {
             ("test_FromContentsOfURLUsedEncodingUTF32BE", test_FromContentsOfURLUsedEncodingUTF32BE),
             ("test_FromContentsOfURLUsedEncodingUTF32LE", test_FromContentsOfURLUsedEncodingUTF32LE),
             ("test_FromContentOfFile",test_FromContentOfFile),
+            ("test_writeToURLHasBOM_UTF32", test_writeToURLHasBOM_UTF32),
             ("test_swiftStringUTF16", test_swiftStringUTF16),
             ("test_stringByTrimmingCharactersInSet", test_stringByTrimmingCharactersInSet),
             ("test_initializeWithFormat", test_initializeWithFormat),


### PR DESCRIPTION
`NSString._getExternalRepresentation()` was not returning the string's external representation 👀.

For some reason, CF decides to only include the BOM in the external representation for encodings using the machine's local endianness (e.g. `.utf16`, `.utf32`) but not if you specify an explicit endianness (e.g. `.utf32BigEndian`). It does the same thing on Darwin Foundation -- I don't know why, and I don't agree with it, and it isn't documented anywhere AFAICT, but there it is.