### PR TITLE
Foundation: adjust types for bit-width differences

### DIFF
--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -240,7 +240,7 @@ open class FileHandle : NSObject {
             let szFileSize: UInt64 = (UInt64(fiFileInfo.nFileSizeHigh) << 32) | UInt64(fiFileInfo.nFileSizeLow << 0)
             let szMapSize: UInt64 = Swift.min(UInt64(length), szFileSize)
             let pData: UnsafeMutableRawPointer =
-                MapViewOfFile(hMapping, DWORD(FILE_MAP_READ), 0, 0, szMapSize)
+                MapViewOfFile(hMapping, DWORD(FILE_MAP_READ), 0, 0, SIZE_T(szMapSize))
 
             return NSData.NSDataReadResult(bytes: pData, length: Int(szMapSize)) { buffer, length in
               if !UnmapViewOfFile(buffer) {
@@ -883,7 +883,7 @@ extension FileHandle {
                     var fileInfo = BY_HANDLE_FILE_INFORMATION()
                     GetFileInformationByHandle(self._handle, &fileInfo)
                     if fileInfo.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY) {
-                        translatedError = ERROR_DIRECTORY_NOT_SUPPORTED
+                        translatedError = Int32(ERROR_DIRECTORY_NOT_SUPPORTED)
                     }
                 }
                 userInfo["NSFileHandleError"] = Int(translatedError)

--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -584,7 +584,7 @@ extension FileManager {
 
         if faAttributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) == FILE_ATTRIBUTE_READONLY {
           if try !FileManager.default._fileSystemRepresentation(withPath: path, {
-            SetFileAttributesW($0, faAttributes.dwFileAttributes & DWORD(bitPattern: ~FILE_ATTRIBUTE_READONLY))
+            SetFileAttributesW($0, faAttributes.dwFileAttributes & ~DWORD(FILE_ATTRIBUTE_READONLY))
           }) {
             throw _NSErrorWithWindowsError(GetLastError(), reading: false, paths: [path])
           }
@@ -634,7 +634,7 @@ extension FileManager {
                     itemPath = "\(currentDir)\\\(file)"
                     if ffd.dwFileAttributes & DWORD(FILE_ATTRIBUTE_READONLY) == FILE_ATTRIBUTE_READONLY {
                       if try !FileManager.default._fileSystemRepresentation(withPath: itemPath, {
-                        SetFileAttributesW($0, ffd.dwFileAttributes & DWORD(bitPattern: ~FILE_ATTRIBUTE_READONLY))
+                        SetFileAttributesW($0, ffd.dwFileAttributes & ~DWORD(FILE_ATTRIBUTE_READONLY))
                       }) {
                         throw _NSErrorWithWindowsError(GetLastError(), reading: false, paths: [file])
                       }
@@ -776,11 +776,11 @@ extension FileManager {
         statInfo.st_gid = 0
         statInfo.st_atime = info.ftLastAccessTime.time_t
         statInfo.st_ctime = info.ftCreationTime.time_t
-        statInfo.st_dev = info.dwVolumeSerialNumber
+        statInfo.st_dev = _dev_t(info.dwVolumeSerialNumber)
         // The inode, and therefore st_ino, has no meaning in the FAT, HPFS, or
         // NTFS file systems. -- docs.microsoft.com
         statInfo.st_ino = 0
-        statInfo.st_rdev = info.dwVolumeSerialNumber
+        statInfo.st_rdev = _dev_t(info.dwVolumeSerialNumber)
 
         let isReparsePoint = info.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) != 0
         let isDir = info.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) != 0
@@ -799,7 +799,7 @@ extension FileManager {
         guard info.nFileSizeHigh == 0 else {
             throw _NSErrorWithErrno(EOVERFLOW, reading: true, path: path)
         }
-        statInfo.st_size = Int32(info.nFileSizeLow)
+        statInfo.st_size = _off_t(info.nFileSizeLow)
         // Uid is always 0 on Windows systems
         statInfo.st_uid = 0
 

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -431,7 +431,7 @@ open class FileManager : NSObject {
 
                     let hiddenAttrs = isHidden
                         ? attrs | DWORD(FILE_ATTRIBUTE_HIDDEN)
-                        : attrs & DWORD(bitPattern: ~FILE_ATTRIBUTE_HIDDEN)
+                        : attrs & ~DWORD(FILE_ATTRIBUTE_HIDDEN)
                     guard SetFileAttributesW(fsRep, hiddenAttrs) else {
                       throw _NSErrorWithWindowsError(GetLastError(), reading: false, paths: [path])
                     }

--- a/Sources/Foundation/FoundationErrors.swift
+++ b/Sources/Foundation/FoundationErrors.swift
@@ -213,58 +213,58 @@ internal let _NSWindowsErrorDomain = "org.swift.Foundation.WindowsError"
 
 internal func _NSErrorWithWindowsError(_ windowsError: DWORD, reading: Bool, paths: [String]? = nil) -> NSError {
     var cocoaError : CocoaError.Code
-    switch Int32(bitPattern: windowsError) {
-        case ERROR_LOCK_VIOLATION: cocoaError = .fileLocking
-        case ERROR_NOT_LOCKED: cocoaError = .fileLocking
-        case ERROR_LOCK_FAILED: cocoaError = .fileLocking
-        case ERROR_INVALID_EXE_SIGNATURE: cocoaError = .executableNotLoadable
-        case ERROR_EXE_MARKED_INVALID: cocoaError = .executableNotLoadable
-        case ERROR_BAD_EXE_FORMAT: cocoaError = .executableNotLoadable
-        case ERROR_BAD_EXE_FORMAT: cocoaError = .executableNotLoadable
-        case ERROR_LOCKED: cocoaError = .fileLocking
+    switch windowsError {
+        case DWORD(ERROR_LOCK_VIOLATION): cocoaError = .fileLocking
+        case DWORD(ERROR_NOT_LOCKED): cocoaError = .fileLocking
+        case DWORD(ERROR_LOCK_FAILED): cocoaError = .fileLocking
+        case DWORD(ERROR_INVALID_EXE_SIGNATURE): cocoaError = .executableNotLoadable
+        case DWORD(ERROR_EXE_MARKED_INVALID): cocoaError = .executableNotLoadable
+        case DWORD(ERROR_BAD_EXE_FORMAT): cocoaError = .executableNotLoadable
+        case DWORD(ERROR_BAD_EXE_FORMAT): cocoaError = .executableNotLoadable
+        case DWORD(ERROR_LOCKED): cocoaError = .fileLocking
         default:
             if reading {
-                switch Int32(bitPattern: windowsError) {
-                    case ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND:
+                switch windowsError {
+                    case DWORD(ERROR_FILE_NOT_FOUND), DWORD(ERROR_PATH_NOT_FOUND):
                         // On an empty path, Windows will return FILE/PATH_NOT_FOUND
                         // rather than invalid path as posix does
                         cocoaError = paths?.contains("") ?? false
                             ? .fileReadInvalidFileName
                             : .fileReadNoSuchFile
-                    case ERROR_ACCESS_DENIED: cocoaError = .fileReadNoPermission
-                    case ERROR_INVALID_ACCESS: cocoaError = .fileReadNoPermission
-                    case ERROR_INVALID_DRIVE: cocoaError = .fileReadNoSuchFile
-                    case ERROR_SHARING_VIOLATION: cocoaError = .fileReadNoPermission
-                    case ERROR_INVALID_NAME: cocoaError = .fileReadInvalidFileName
-                    case ERROR_LABEL_TOO_LONG: cocoaError = .fileReadInvalidFileName
-                    case ERROR_BAD_PATHNAME: cocoaError = .fileReadInvalidFileName
-                    case ERROR_FILENAME_EXCED_RANGE: cocoaError = .fileReadInvalidFileName
-                    case ERROR_DIRECTORY: cocoaError = .fileReadInvalidFileName
+                    case DWORD(ERROR_ACCESS_DENIED): cocoaError = .fileReadNoPermission
+                    case DWORD(ERROR_INVALID_ACCESS): cocoaError = .fileReadNoPermission
+                    case DWORD(ERROR_INVALID_DRIVE): cocoaError = .fileReadNoSuchFile
+                    case DWORD(ERROR_SHARING_VIOLATION): cocoaError = .fileReadNoPermission
+                    case DWORD(ERROR_INVALID_NAME): cocoaError = .fileReadInvalidFileName
+                    case DWORD(ERROR_LABEL_TOO_LONG): cocoaError = .fileReadInvalidFileName
+                    case DWORD(ERROR_BAD_PATHNAME): cocoaError = .fileReadInvalidFileName
+                    case DWORD(ERROR_FILENAME_EXCED_RANGE): cocoaError = .fileReadInvalidFileName
+                    case DWORD(ERROR_DIRECTORY): cocoaError = .fileReadInvalidFileName
                     default:  cocoaError = .fileReadUnknown
                 }
             } else {
-                switch Int32(bitPattern: windowsError) {
-                    case ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND:
+                switch windowsError {
+                    case DWORD(ERROR_FILE_NOT_FOUND), DWORD(ERROR_PATH_NOT_FOUND):
                         // On an empty path, Windows will return FILE/PATH_NOT_FOUND
                         // rather than invalid path as posix does
                         cocoaError = paths?.contains("") ?? false
                             ? .fileWriteInvalidFileName
                             : .fileNoSuchFile
-                    case ERROR_ACCESS_DENIED: cocoaError = .fileWriteNoPermission
-                    case ERROR_INVALID_ACCESS: cocoaError = .fileWriteNoPermission
-                    case ERROR_INVALID_DRIVE: cocoaError = .fileNoSuchFile
-                    case ERROR_WRITE_PROTECT: cocoaError = .fileWriteVolumeReadOnly
-                    case ERROR_WRITE_FAULT: cocoaError = .fileWriteNoPermission
-                    case ERROR_SHARING_VIOLATION: cocoaError = .fileWriteNoPermission
-                    case ERROR_FILE_EXISTS: cocoaError = .fileWriteFileExists
-                    case ERROR_DISK_FULL: cocoaError = .fileWriteOutOfSpace
-                    case ERROR_INVALID_NAME: cocoaError = .fileWriteInvalidFileName
-                    case ERROR_LABEL_TOO_LONG: cocoaError = .fileWriteInvalidFileName
-                    case ERROR_BAD_PATHNAME: cocoaError = .fileWriteInvalidFileName
-                    case ERROR_ALREADY_EXISTS: cocoaError = .fileWriteFileExists
-                    case ERROR_FILENAME_EXCED_RANGE: cocoaError = .fileWriteInvalidFileName
-                    case ERROR_DIRECTORY: cocoaError = .fileWriteInvalidFileName
-                    case ERROR_DISK_RESOURCES_EXHAUSTED: cocoaError = .fileWriteOutOfSpace
+                    case DWORD(ERROR_ACCESS_DENIED): cocoaError = .fileWriteNoPermission
+                    case DWORD(ERROR_INVALID_ACCESS): cocoaError = .fileWriteNoPermission
+                    case DWORD(ERROR_INVALID_DRIVE): cocoaError = .fileNoSuchFile
+                    case DWORD(ERROR_WRITE_PROTECT): cocoaError = .fileWriteVolumeReadOnly
+                    case DWORD(ERROR_WRITE_FAULT): cocoaError = .fileWriteNoPermission
+                    case DWORD(ERROR_SHARING_VIOLATION): cocoaError = .fileWriteNoPermission
+                    case DWORD(ERROR_FILE_EXISTS): cocoaError = .fileWriteFileExists
+                    case DWORD(ERROR_DISK_FULL): cocoaError = .fileWriteOutOfSpace
+                    case DWORD(ERROR_INVALID_NAME): cocoaError = .fileWriteInvalidFileName
+                    case DWORD(ERROR_LABEL_TOO_LONG): cocoaError = .fileWriteInvalidFileName
+                    case DWORD(ERROR_BAD_PATHNAME): cocoaError = .fileWriteInvalidFileName
+                    case DWORD(ERROR_ALREADY_EXISTS): cocoaError = .fileWriteFileExists
+                    case DWORD(ERROR_FILENAME_EXCED_RANGE): cocoaError = .fileWriteInvalidFileName
+                    case DWORD(ERROR_DIRECTORY): cocoaError = .fileWriteInvalidFileName
+                    case DWORD(ERROR_DISK_RESOURCES_EXHAUSTED): cocoaError = .fileWriteOutOfSpace
                     default:  cocoaError = .fileWriteUnknown
                 }
             }

--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -239,7 +239,11 @@ fileprivate extension sockaddr_in6 {
         self.init(settingLength: ())
         self.sin6_family = sa_family_t(AF_INET6)
         self.sin6_port = in_port_t(port)
+#if os(Windows)
+        self.sin6_flowinfo = ULONG(flowInfo)
+#else
         self.sin6_flowinfo = flowInfo
+#endif
         withUnsafeMutableBytes(of: &self.sin6_addr) { (buffer) in
             withUnsafeBytes(of: in6Addr) { buffer.copyMemory(from: $0) }
         }

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -447,7 +447,7 @@ open class Process: NSObject {
       }
 
       var value: u_long = 1
-      if ioctlsocket(first, FIONBIO, &value) == SOCKET_ERROR {
+      if ioctlsocket(first, CLong(FIONBIO), &value) == SOCKET_ERROR {
         closesocket(first)
         return (first: INVALID_SOCKET, second: INVALID_SOCKET)
       }
@@ -638,7 +638,7 @@ open class Process: NSObject {
                 process._terminationStatus = Int32(dwExitCode & 0x3FFFFFFF)
                 process._terminationReason = .uncaughtSignal
             } else {
-                process._terminationStatus = Int32(bitPattern: dwExitCode)
+                process._terminationStatus = Int32(bitPattern: UInt32(dwExitCode))
                 process._terminationReason = .exit
             }
 


### PR DESCRIPTION
This adjusts the types to be more explicit about types as appropriate.
These changes are required to enable building a 32-bit variant of
Foundation for Windows.  It also happens to clean up some constants
which were being formed oddly.  This enables building Windows x86
version of Foundation.