### PR TITLE
Foundation: more idiomatic Swift in NSKeyedArchiver

### DIFF
--- a/Docs/Archiving.md
+++ b/Docs/Archiving.md
@@ -37,7 +37,7 @@ There is a preliminary implementation of NSKeyedArchiver and NSKeyedUnarchiver w
 * NSTimeZone
 * NSURL
 * NSUUID
-* NSValue (via class cluster hack)
+* NSValue
 
 ## TODO
 

--- a/Sources/Foundation/NSGeometry.swift
+++ b/Sources/Foundation/NSGeometry.swift
@@ -1085,42 +1085,38 @@ public func NSRectFromString(_ aString: String) -> NSRect {
 
 extension NSValue {
     public convenience init(point: NSPoint) {
-        self.init()
-        self._concreteValue = NSSpecialValue(point)
+        self.init { NSSpecialValue(point) as! Self }
     }
     
     public convenience init(size: NSSize) {
-        self.init()
-        self._concreteValue = NSSpecialValue(size)
+        self.init { NSSpecialValue(size) as! Self }
     }
     
     public convenience init(rect: NSRect) {
-        self.init()
-        self._concreteValue = NSSpecialValue(rect)
+        self.init { NSSpecialValue(rect) as! Self }
     }
     
     public convenience init(edgeInsets insets: NSEdgeInsets) {
-        self.init()
-        self._concreteValue = NSSpecialValue(insets)
+        self.init { NSSpecialValue(insets) as! Self }
     }
     
     public var pointValue: NSPoint {
-        let specialValue = self._concreteValue as! NSSpecialValue
+        let specialValue = self as! NSSpecialValue
         return specialValue._value as! NSPoint
     }
     
     public var sizeValue: NSSize {
-        let specialValue = self._concreteValue as! NSSpecialValue
+        let specialValue = self as! NSSpecialValue
         return specialValue._value as! NSSize
     }
     
     public var rectValue: NSRect {
-        let specialValue = self._concreteValue as! NSSpecialValue
+        let specialValue = self as! NSSpecialValue
         return specialValue._value as! NSRect
     }
     
     public var edgeInsetsValue: NSEdgeInsets {
-        let specialValue = self._concreteValue as! NSSpecialValue
+        let specialValue = self as! NSSpecialValue
         return specialValue._value as! NSEdgeInsets
     }
 }

--- a/Sources/Foundation/NSKeyedArchiver.swift
+++ b/Sources/Foundation/NSKeyedArchiver.swift
@@ -405,11 +405,12 @@ open class NSKeyedArchiver : NSCoder {
         Returns true if the object has already been encoded.
      */ 
     private func _haveVisited(_ objv: Any?) -> Bool {
-        if objv == nil {
-            return true // always have a null reference
-        } else {
-            return self._objRefMap[__SwiftValue.store(objv!)] != nil
+        guard let objv = objv else {
+            // always have a null reference
+            return true
         }
+        
+        return self._objRefMap[__SwiftValue.store(objv)] != nil
     }
     
     /**

--- a/Sources/Foundation/NSKeyedUnarchiver.swift
+++ b/Sources/Foundation/NSKeyedUnarchiver.swift
@@ -201,15 +201,15 @@ open class NSKeyedUnarchiver : NSCoder {
     }
     
     private func _objectInCurrentDecodingContext<T>(forKey key: String?) -> T? {
-        var unwrappedKey = key
+        let unwrappedKey: String
         
-        if key != nil {
-            unwrappedKey = escapeArchiverKey(key!)
+        if let key = key {
+            unwrappedKey = escapeArchiverKey(key)
         } else {
             unwrappedKey = _nextGenericKey()
         }
 
-        if let v = _currentDecodingContext.dict[unwrappedKey!] {
+        if let v = _currentDecodingContext.dict[unwrappedKey] {
             return v as? T
         }
         return nil
@@ -272,18 +272,18 @@ open class NSKeyedUnarchiver : NSCoder {
     }
     
     private func _isClassAllowed(_ assertedClass: AnyClass?, allowedClasses: [AnyClass]?) -> Bool {
-        if assertedClass == nil {
+        guard let assertedClass = assertedClass else {
             return false
         }
         
         if _flags.contains(.requiresSecureCoding) {
             if let unwrappedAllowedClasses = allowedClasses {
-                if unwrappedAllowedClasses.contains(where: {NSKeyedUnarchiver._classIsKindOfClass(assertedClass!, $0)}) {
+                if unwrappedAllowedClasses.contains(where: {NSKeyedUnarchiver._classIsKindOfClass(assertedClass, $0)}) {
                     return true
                 }
             }
             
-            fatalError("Value was of unexpected class \(assertedClass!)")
+            fatalError("Value was of unexpected class \(assertedClass)")
         } else {
             return true
         }
@@ -320,16 +320,16 @@ open class NSKeyedUnarchiver : NSCoder {
         let assertedClassHints = unwrappedClassDict["$classhints"] as? [String]
         let assertedClasses = unwrappedClassDict["$classes"] as? [String]
         
-        if assertedClassName != nil {
-            let assertedClass : AnyClass? = _classForClassName(assertedClassName!)
+        if let assertedClassName = assertedClassName {
+            let assertedClass : AnyClass? = _classForClassName(assertedClassName)
             if _isClassAllowed(assertedClass, allowedClasses: allowedClasses) {
                 classToConstruct = assertedClass
                 return true
             }
         }
         
-        if assertedClassHints != nil {
-            for assertedClassHint in assertedClassHints! {
+        if let assertedClassHints = assertedClassHints {
+            for assertedClassHint in assertedClassHints {
                 // FIXME check whether class hints should be subject to mapping or not
                 let assertedClass : AnyClass? = NSClassFromString(assertedClassHint)
                 if _isClassAllowed(assertedClass, allowedClasses: allowedClasses) {
@@ -339,11 +339,11 @@ open class NSKeyedUnarchiver : NSCoder {
             }
         }
         
-        if assertedClassName != nil {
+        if let assertedClassName = assertedClassName {
             if let unwrappedDelegate = self.delegate {
                 classToConstruct = unwrappedDelegate.unarchiver(self,
-                                                                cannotDecodeObjectOfClassName: assertedClassName!,
-                                                                originalClasses: assertedClasses != nil ? assertedClasses! : [])
+                                                                cannotDecodeObjectOfClassName: assertedClassName,
+                                                                originalClasses: assertedClasses ?? [])
                 if classToConstruct != nil {
                     return true
                 }
@@ -417,28 +417,26 @@ open class NSKeyedUnarchiver : NSCoder {
     }
     
     private func _replacementObject(_ decodedObject: Any?) -> Any? {
-        var object : Any? = nil // object to encode after substitution
-        
-        // nil cannot be mapped
-        if decodedObject == nil {
+        // nil cannot be mapped (this appears to differ from Darwin?)
+        guard let decodedObject = decodedObject else {
             return nil
         }
         
         // check replacement cache
-        object = self._replacementMap[__SwiftValue.store(decodedObject!)]
-        if object != nil {
+        if let object = self._replacementMap[__SwiftValue.store(decodedObject)] {
             return object
         }
-        
-        // object replaced by delegate. If the delegate returns nil, nil is encoded
+
+        // object replaced by delegate. If using ARC, the delegate should only return
+        // nil if the object itself is nil.
         if let unwrappedDelegate = self.delegate {
-            object = unwrappedDelegate.unarchiver(self, didDecode: decodedObject!)
-            if object != nil {
-                replaceObject(decodedObject!, withObject: object!)
-                return object
-            }
+             let object = unwrappedDelegate.unarchiver(self, didDecode: decodedObject)
+             if object != nil {
+                 replaceObject(decodedObject, withObject: object!)
+                 return object
+             }
         }
-        
+
         return decodedObject
     }
     
@@ -470,12 +468,12 @@ open class NSKeyedUnarchiver : NSCoder {
             throw InternalError.decodingHasAlreadyFailed
         }
 
-        if !(objectRef is _NSKeyedArchiverUID) {
+        guard let objectRef = objectRef as? _NSKeyedArchiverUID else {
             throw _decodingError(.coderReadCorrupt,
                                  withDescription: "Object \(objectRef) is not a reference. The data may be corrupt.")
         }
-
-        guard let dereferencedObject = _dereferenceObjectReference(objectRef as! _NSKeyedArchiverUID) else {
+        
+        guard let dereferencedObject = _dereferenceObjectReference(objectRef) else {
             throw _decodingError(.coderReadCorrupt,
                                  withDescription: "Invalid object reference \(objectRef). The data may be corrupt.")
         }
@@ -486,7 +484,7 @@ open class NSKeyedUnarchiver : NSCoder {
 
         if _isContainer(dereferencedObject) {
             // check cached of decoded objects
-            object = _cachedObjectForReference(objectRef as! _NSKeyedArchiverUID)
+            object = _cachedObjectForReference(objectRef)
             if object == nil {
                 guard let dict = dereferencedObject as? Dictionary<String, Any> else {
                     throw _decodingError(.coderReadCorrupt,
@@ -523,7 +521,7 @@ open class NSKeyedUnarchiver : NSCoder {
                                          withDescription: "Class \(classToConstruct!) failed to decode. The data may be corrupt.")
                 }
 
-                _cacheObject(object!, forReference: objectRef as! _NSKeyedArchiverUID)
+                _cacheObject(object!, forReference: objectRef)
             }
         } else {
             object = __SwiftValue.store(dereferencedObject)

--- a/Sources/Foundation/NSKeyedUnarchiver.swift
+++ b/Sources/Foundation/NSKeyedUnarchiver.swift
@@ -311,14 +311,14 @@ open class NSKeyedUnarchiver : NSCoder {
             return aClass
         }
         
-        guard let unwrappedClassDict = classDict else {
+        guard let classDict = classDict else {
             return false
         }
         
         // TODO is it required to validate the superclass hierarchy?
-        let assertedClassName = unwrappedClassDict["$classname"] as? String
-        let assertedClassHints = unwrappedClassDict["$classhints"] as? [String]
-        let assertedClasses = unwrappedClassDict["$classes"] as? [String]
+        let assertedClassName = classDict["$classname"] as? String
+        let assertedClassHints = classDict["$classhints"] as? [String]
+        let assertedClasses = classDict["$classes"] as? [String]
         
         if let assertedClassName = assertedClassName {
             let assertedClass : AnyClass? = _classForClassName(assertedClassName)

--- a/Sources/Foundation/NSRange.swift
+++ b/Sources/Foundation/NSRange.swift
@@ -403,12 +403,11 @@ extension NSRange: NSSpecialValueCoding {
     
 extension NSValue {
     public convenience init(range: NSRange) {
-        self.init()
-        self._concreteValue = NSSpecialValue(range)
+        self.init { NSSpecialValue(range) as! Self }
     }
     
     public var rangeValue: NSRange {
-        let specialValue = self._concreteValue as! NSSpecialValue
+        let specialValue = self as! NSSpecialValue
         return specialValue._value as! NSRange
     }
 }

--- a/Sources/Foundation/NSSpecialValue.swift
+++ b/Sources/Foundation/NSSpecialValue.swift
@@ -46,33 +46,17 @@ internal class NSSpecialValue : NSValue {
     }
     
     private static func _flagsFromType(_ type: NSSpecialValueCoding.Type) -> Int {
-        for (F, T) in _specialTypes {
-            if T == type {
-                return F
-            }
-        }
-        return 0
+        return _specialTypes.first(where: { $1 == type })?.0 ?? 0
     }
     
     private static func _objCTypeFromType(_ type: NSSpecialValueCoding.Type) -> String? {
-        for (_, T) in _specialTypes {
-            if T == type {
-                return T.objCType()
-            }
-        }
-        return nil
+        return _specialTypes.first(where: { $1 == type })?.1.objCType()
     }
     
     internal static func _typeFromObjCType(_ type: UnsafePointer<Int8>) -> NSSpecialValueCoding.Type? {
         let objCType = String(cString: type)
         
-        for (_, T) in _specialTypes {
-            if T.objCType() == objCType {
-                return T
-            }
-        }
-        
-        return nil
+        return _specialTypes.first(where: { $1.objCType() == objCType })?.1
     }
     
     internal var _value : NSSpecialValueCoding

--- a/Sources/Foundation/NSSpecialValue.swift
+++ b/Sources/Foundation/NSSpecialValue.swift
@@ -121,7 +121,6 @@ internal class NSSpecialValue : NSValue {
     }
     
     override var classForCoder: AnyClass {
-        // for some day when we support class clusters
         return NSValue.self
     }
     

--- a/Sources/Foundation/NSSpecialValue.swift
+++ b/Sources/Foundation/NSSpecialValue.swift
@@ -82,10 +82,8 @@ internal class NSSpecialValue : NSValue {
             preconditionFailure("Unkeyed coding is unsupported.")
         }
         let specialFlags = aDecoder.decodeInteger(forKey: "NS.special")
-        guard let specialType = NSSpecialValue._typeFromFlags(specialFlags) else {
-            return nil
-        }
-        guard let specialValue = specialType.init(coder: aDecoder) else {
+        guard let specialType = NSSpecialValue._typeFromFlags(specialFlags),
+              let specialValue = specialType.init(coder: aDecoder) else {
             return nil
         }
         self.init(specialValue)

--- a/Tests/Foundation/Tests/TestNSKeyedArchiver.swift
+++ b/Tests/Foundation/Tests/TestNSKeyedArchiver.swift
@@ -170,7 +170,7 @@ class TestNSKeyedArchiver : XCTestCase {
     }
     
     private func test_archive(_ object: AnyObject, allowsSecureCoding: Bool = true) {
-        return test_archive(object, classes: [type(of: object)], allowsSecureCoding: allowsSecureCoding)
+        return test_archive(object, classes: [(object as! NSObject).classForCoder], allowsSecureCoding: allowsSecureCoding)
     }
     
     func test_archive_array() {

--- a/Tests/Foundation/Tests/TestNSKeyedUnarchiver.swift
+++ b/Tests/Foundation/Tests/TestNSKeyedUnarchiver.swift
@@ -52,7 +52,7 @@ class TestNSKeyedUnarchiver : XCTestCase {
         case .skip:
             classes = []
         case .performWithDefaultClass:
-            classes = [ type(of: expectedObject as AnyObject) ]
+            classes = [ (expectedObject as! NSObject).classForCoder ]
         case .performWithClasses(let specifiedClasses):
             classes = specifiedClasses
         }


### PR DESCRIPTION
Originally when I implemented `NSValue`, I intended for it to be a class cluster with the concrete classes being `NSSpecialValue` or `NSConcreteValue`. At the time, Swift didn't support this pattern. Now it does support reassigning `self` (also see 00737ae0e), it makes sense to revisit this.

Also, make some other related code paths more idiomatically Swift, by eliminating force-unwrap and force-cast; at the time, I was less familiar with Swift.

Unfortunately since I [cannot build the TestFoundation target](https://forums.swift.org/t/cant-run-testfoundation-target-in-swift-corelibs-foundation-repository/50360/6) on macOS, it's not possible for me to run the tests (I don't have a Linux VM handy right now).