### PR TITLE
[5.6] Solve a memory leak in CFLocaleGetSystem()

### DIFF
--- a/CoreFoundation/Locale.subproj/CFLocale.c
+++ b/CoreFoundation/Locale.subproj/CFLocale.c
@@ -293,7 +293,12 @@ CFLocaleRef CFLocaleGetSystem(void) {
             uselessLocale = locale;
 	}
     }
+#if !DEPLOYMENT_RUNTIME_SWIFT
+    // This line relies on the fact that outside of Swift, __CFLocaleSystem is immortal.
     locale = __CFLocaleSystem ? (CFLocaleRef)CFRetain(__CFLocaleSystem) : NULL;
+#else
+    locale = __CFLocaleSystem;
+#endif
     __CFLocaleUnlockGlobal();
     if (uselessLocale) CFRelease(uselessLocale);
     return locale;


### PR DESCRIPTION
These objects have a real (live) retain count rather than being immortal on Swift; do not overretain as it is not a no-op. rdar://88461050