### PR TITLE
CoreFoundation: clean up module locator logic

### DIFF
--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -478,7 +478,8 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
                           AdvAPI32
                           Secur32
                           User32
-                          mincore)
+                          mincore
+                          pathcch)
   target_link_libraries(CFURLSessionInterface
                         PRIVATE
                           AdvAPI32


### PR DESCRIPTION
Use the address of the function to get a module handle without bumping
the refcount of the module.  This avoids the need to hardcode the
library name and enables the use of CoreFoundation in a statically
linked fashion as well.  We can further reduce the logic by using the
PathCch routine to remove the trailing file specification.  This reduces
the complexity in the module location code and reuses the system
libraries for a small additional cost of an additional iteration of the
string path.