### PR TITLE
Fix `JSONDecoder` superDecoder darwin/linux discrepancy

### DIFF
--- a/Sources/Foundation/JSONDecoder.swift
+++ b/Sources/Foundation/JSONDecoder.swift
@@ -750,37 +750,34 @@ extension JSONDecoderImpl {
         }
 
         func superDecoder() throws -> Decoder {
-            do {
-                return try decoderForKey(_JSONKey.super)
-            } catch DecodingError.keyNotFound {
-                var newPath = self.codingPath
-                newPath.append(_JSONKey.super)
-                return JSONDecoderImpl(
-                    userInfo: self.impl.userInfo,
-                    from: .null,
-                    codingPath: newPath,
-                    options: self.impl.options
-                )
-            }
+            return decoderForKeyNoThrow(_JSONKey.super)
         }
 
         func superDecoder(forKey key: K) throws -> Decoder {
-            do {
-                return try decoderForKey(key)
-            } catch DecodingError.keyNotFound {
-                var newPath = self.codingPath
-                newPath.append(key)
-                return JSONDecoderImpl(
-                    userInfo: self.impl.userInfo,
-                    from: .null,
-                    codingPath: newPath,
-                    options: self.impl.options
-                )
-            }
+            return decoderForKeyNoThrow(key)
         }
 
         private func decoderForKey<LocalKey: CodingKey>(_ key: LocalKey) throws -> JSONDecoderImpl {
             let value = try getValue(forKey: key)
+            var newPath = self.codingPath
+            newPath.append(key)
+
+            return JSONDecoderImpl(
+                userInfo: self.impl.userInfo,
+                from: value,
+                codingPath: newPath,
+                options: self.impl.options
+            )
+        }
+
+        private func decoderForKeyNoThrow<LocalKey: CodingKey>(_ key: LocalKey) -> JSONDecoderImpl {
+            let value: JSONValue
+            do {
+                value = try getValue(forKey: key)
+            } catch {
+                // if there no value for this key then return a null value
+                value = .null
+            }
             var newPath = self.codingPath
             newPath.append(key)
 

--- a/Sources/Foundation/JSONDecoder.swift
+++ b/Sources/Foundation/JSONDecoder.swift
@@ -227,34 +227,46 @@ extension JSONDecoderImpl: Decoder {
     @usableFromInline func container<Key>(keyedBy _: Key.Type) throws ->
         KeyedDecodingContainer<Key> where Key: CodingKey
     {
-        guard case .object(let dictionary) = self.json else {
+        switch self.json {
+        case .object(let dictionary):
+            let container = KeyedContainer<Key>(
+                impl: self,
+                codingPath: codingPath,
+                dictionary: dictionary
+            )
+            return KeyedDecodingContainer(container)
+        case .null:
+            throw DecodingError.valueNotFound([String: JSONValue].self, DecodingError.Context(
+                codingPath: self.codingPath, 
+                debugDescription: "Cannot get keyed decoding container -- found null value instead"
+            ))
+        default:
             throw DecodingError.typeMismatch([String: JSONValue].self, DecodingError.Context(
                 codingPath: self.codingPath,
                 debugDescription: "Expected to decode \([String: JSONValue].self) but found \(self.json.debugDataTypeDescription) instead."
             ))
         }
-
-        let container = KeyedContainer<Key>(
-            impl: self,
-            codingPath: codingPath,
-            dictionary: dictionary
-        )
-        return KeyedDecodingContainer(container)
     }
 
     @usableFromInline func unkeyedContainer() throws -> UnkeyedDecodingContainer {
-        guard case .array(let array) = self.json else {
+        switch self.json {
+        case .array(let array):
+            return UnkeyedContainer(
+                impl: self,
+                codingPath: self.codingPath,
+                array: array
+            )
+        case .null:
+            throw DecodingError.valueNotFound([String: JSONValue].self, DecodingError.Context(
+                codingPath: self.codingPath, 
+                debugDescription: "Cannot get unkeyed decoding container -- found null value instead"
+            ))
+        default:
             throw DecodingError.typeMismatch([JSONValue].self, DecodingError.Context(
                 codingPath: self.codingPath,
                 debugDescription: "Expected to decode \([JSONValue].self) but found \(self.json.debugDataTypeDescription) instead."
             ))
         }
-
-        return UnkeyedContainer(
-            impl: self,
-            codingPath: self.codingPath,
-            array: array
-        )
     }
 
     @usableFromInline func singleValueContainer() throws -> SingleValueDecodingContainer {

--- a/Sources/Foundation/JSONDecoder.swift
+++ b/Sources/Foundation/JSONDecoder.swift
@@ -750,11 +750,33 @@ extension JSONDecoderImpl {
         }
 
         func superDecoder() throws -> Decoder {
-            try decoderForKey(_JSONKey.super)
+            do {
+                return try decoderForKey(_JSONKey.super)
+            } catch DecodingError.keyNotFound {
+                var newPath = self.codingPath
+                newPath.append(_JSONKey.super)
+                return JSONDecoderImpl(
+                    userInfo: self.impl.userInfo,
+                    from: .null,
+                    codingPath: newPath,
+                    options: self.impl.options
+                )
+            }
         }
 
         func superDecoder(forKey key: K) throws -> Decoder {
-            try decoderForKey(key)
+            do {
+                return try decoderForKey(key)
+            } catch DecodingError.keyNotFound {
+                var newPath = self.codingPath
+                newPath.append(key)
+                return JSONDecoderImpl(
+                    userInfo: self.impl.userInfo,
+                    from: .null,
+                    codingPath: newPath,
+                    options: self.impl.options
+                )
+            }
         }
 
         private func decoderForKey<LocalKey: CodingKey>(_ key: LocalKey) throws -> JSONDecoderImpl {

--- a/Tests/Foundation/Tests/TestJSONEncoder.swift
+++ b/Tests/Foundation/Tests/TestJSONEncoder.swift
@@ -1500,6 +1500,7 @@ extension TestJSONEncoder {
             ("test_encodingNonConformingFloatStrings", test_encodingNonConformingFloatStrings),
             ("test_nestedContainerCodingPaths", test_nestedContainerCodingPaths),
             ("test_superEncoderCodingPaths", test_superEncoderCodingPaths),
+            ("test_notFoundSuperDecoder", test_notFoundSuperDecoder),
             ("test_codingOfBool", test_codingOfBool),
             ("test_codingOfNil", test_codingOfNil),
             ("test_codingOfInt8", test_codingOfInt8),

--- a/Tests/Foundation/Tests/TestJSONEncoder.swift
+++ b/Tests/Foundation/Tests/TestJSONEncoder.swift
@@ -456,6 +456,25 @@ class TestJSONEncoder : XCTestCase {
         }
     }
 
+    func test_notFoundSuperDecoder() {
+        struct NotFoundSuperDecoderTestType: Decodable {
+            init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                _ = try container.superDecoder(forKey: .superDecoder)
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case superDecoder = "super"
+            }
+        }
+        let decoder = JSONDecoder()
+        do {
+            let _ = try decoder.decode(NotFoundSuperDecoderTestType.self, from: Data(#"{}"#.utf8))
+        } catch {
+            XCTFail("Caught error during decoding empty super decoder: \(error)")
+        }
+    }
+
     // MARK: - Test encoding and decoding of built-in Codable types
     func test_codingOfBool() {
         test_codingOf(value: Bool(true), toAndFrom: "true")


### PR DESCRIPTION
On Darwin when you call `superDecoder` on the `JSONDecoder` keyed container and there is no associated value for the key passed in, it returns a new decoder that returns empty containers. On Linux it would throw a `DecodingError.keyNotFound` error.

This PR resolves this discrepancy by catching the `DecodingError.keyNotFound` error and returning a decoder that references a `JSONValue.null`.

The PR also adds a new test `test_notFoundSuperDecoder` to verify this fix.

This resolves apple/swift-corelibs-foundation#3169

cc: @fabianfett 