### PR TITLE
[DateInterval] Fix `func contains(_:) -> Bool`.

### DIFF
--- a/Sources/Foundation/DateInterval.swift
+++ b/Sources/Foundation/DateInterval.swift
@@ -141,13 +141,7 @@ public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
     
     /// Returns `true` if `self` contains `date`.
     public func contains(_ date: Date) -> Bool {
-        let timeIntervalForGivenDate = abs(date.timeIntervalSinceReferenceDate)
-        let timeIntervalForSelfStart = abs(start.timeIntervalSinceReferenceDate)
-        let timeIntervalForSelfEnd = abs(end.timeIntervalSinceReferenceDate)
-        if (timeIntervalForGivenDate >= timeIntervalForSelfStart) && (timeIntervalForGivenDate <= timeIntervalForSelfEnd) {
-            return true
-        }
-        return false
+        return (start...end).contains(date)
     }
     
     public func hash(into hasher: inout Hasher) {

--- a/Tests/Foundation/Tests/TestDateInterval.swift
+++ b/Tests/Foundation/Tests/TestDateInterval.swift
@@ -118,14 +118,20 @@ class TestDateInterval: XCTestCase {
     }
 
     func test_contains() {
+        let date0 = dateWithString("1964-10-01 06:00:00 +0900")
         let date1 = dateWithString("2019-04-04 17:00:00 -0700")
         let date2 = dateWithString("2019-04-04 17:30:00 -0700")
         let date3 = dateWithString("2019-04-04 17:45:00 -0700")
         let date4 = dateWithString("2019-04-04 17:50:00 -0700")
-        let dateInterval = DateInterval(start: date1, duration: 60 * 45)
-        XCTAssertTrue(dateInterval.contains(date2))
-        XCTAssertTrue(dateInterval.contains(date3))
-        XCTAssertFalse(dateInterval.contains(date4))
+
+        XCTAssertTrue(DateInterval(start: .distantPast, end: .distantFuture).contains(date0))
+        XCTAssertTrue(DateInterval(start: .distantPast, end: date1).contains(date0))
+        XCTAssertFalse(DateInterval(start: .distantPast, end: date1).contains(date2))
+        XCTAssertTrue(DateInterval(start: date0, end: date4).contains(date2))
+        XCTAssertTrue(DateInterval(start: date1, duration: 60 * 45).contains(date3))
+        XCTAssertFalse(DateInterval(start: date1, duration: 60 * 45).contains(date4))
+        XCTAssertTrue(DateInterval(start: date2, end: .distantFuture).contains(date2))
+        XCTAssertFalse(DateInterval(start: date2, end: .distantFuture).contains(date0))
     }
 
     func test_hashing() {


### PR DESCRIPTION
Resolves https://github.com/apple/swift-corelibs-foundation/issues/4588