### PR TITLE
CoreFoundation: adjust `uuid.h` inclusion

### DIFF
--- a/CoreFoundation/Base.subproj/CFUUID.c
+++ b/CoreFoundation/Base.subproj/CFUUID.c
@@ -133,10 +133,12 @@ static CFUUIDRef __CFUUIDCreateWithBytesPrimitive(CFAllocatorRef allocator, CFUU
 
 #if TARGET_OS_WIN32
 #include <Rpc.h>
-#else
+#endif
+
 #if DEPLOYMENT_RUNTIME_SWIFT
 #include "uuid/uuid.h"
 #else
+#if !TARGET_OS_WIN32
 #include <uuid/uuid.h>
 #endif
 #endif


### PR DESCRIPTION
The Swift Runtime path always uses the UUID functions from the
statically linked UUID library.  However, the header was only included
in the non-Windows case.  The latest LLVM update makes implicit
declarations invalid as per the C99 standard.  Adjust the inclusion path
to also include `uuid.h` on Windows when building with the Swift
Runtime.