### PR TITLE
[Windows] Add an implementation for the missing `bzero` function

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLComponents_URIParser.c
+++ b/CoreFoundation/URL.subproj/CFURLComponents_URIParser.c
@@ -9,6 +9,10 @@
 #include "CFURLComponents_Internal.h"
 #include "CFInternal.h"
 
+#if TARGET_OS_WIN32
+#define bzero(dst, size)    ZeroMemory(dst, size)
+#endif
+
 typedef CF_ENUM(CFIndex, URLPredefinedCharacterSet) {
     kURLUserAllowedCharacterSet     = 0,
     kURLPasswordAllowedCharacterSet = 1,


### PR DESCRIPTION
Rebranch is currently failing with a missing declaration for `bzero` on
Windows. Add a definition as in other uses of `bzero`.