### PR TITLE
[Linux] Add missing glibc import for in_addr declaration

### DIFF
--- a/Sources/FoundationNetworking/HTTPCookie.swift
+++ b/Sources/FoundationNetworking/HTTPCookie.swift
@@ -13,7 +13,9 @@ import SwiftFoundation
 import Foundation
 #endif
 
-#if os(Windows)
+#if canImport(Glibc)
+import Glibc
+#elseif os(Windows)
 import WinSDK
 #endif
 


### PR DESCRIPTION
Rebranch is currently failing with:
```
swift-corelibs-foundation/Sources/FoundationNetworking/HTTPCookie.swift:626:17: error: cannot find 'in_addr' in scope
        var x = in_addr()
                ^~~~~~~
```

Import `Glibc` to grab the declaration.