### PR TITLE
[Modularization] Only include cstd headers when building CoreFoundation

### DIFF
--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -20,7 +20,7 @@
 
 #define DEPLOYMENT_RUNTIME_SWIFT 1
 
-#if !defined(CF_EXCLUDE_CSTD_HEADERS)
+#if defined(CF_BUILDING_CF)
 
 #include <sys/types.h>
 #include <stdarg.h>


### PR DESCRIPTION
Including these headers results in improper modularization as both
SwiftGlibc and CoreFoundation will include these headers. In particular,
`in_addr` from `netinet/in.h` is currently causing issues when building
on Linux in Swift rebranch.