### PR TITLE
Connect `BUILD_TOOLS` option to build system

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -2,4 +2,7 @@ add_subdirectory(UUID)
 add_subdirectory(Foundation)
 add_subdirectory(FoundationNetworking)
 add_subdirectory(FoundationXML)
-add_subdirectory(Tools)
+
+if(BUILD_TOOLS)
+  add_subdirectory(Tools)
+endif()


### PR DESCRIPTION
The `BUILD_TOOLS` flag existed, but was never connected into the build
system, so it didn't do anything. Using it to determine whether or not
to dig down into the `Sources/Tools` directory.