### PR TITLE
Add `Date.now` static property

### DIFF
--- a/Sources/Foundation/Date.swift
+++ b/Sources/Foundation/Date.swift
@@ -28,11 +28,7 @@ public struct Date : ReferenceConvertible, Comparable, Equatable {
     }
     
     /// Returns a `Date` initialized to the current date and time.
-    public static var now: Date {
-        get {
-            init()
-        }
-    }
+    public static var now: Date { Date() }
     
     /// Returns a `Date` initialized to the current date and time.
     public init() {


### PR DESCRIPTION
I've had builds that succeed on macOS fail on Linux because bizarrely, `Date.now` is only supported on macOS, despite it being equivalent to just calling `init()`. Easy fix.