### PR TITLE
Don't redefine asprintf when building for Android

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1510,7 +1510,7 @@ void _CF_dispatch_once(dispatch_once_t *predicate, void (^block)(void)) {
 #pragma mark -
 #pragma mark Windows and Linux Helpers
 
-#if TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_WIN32 || (TARGET_OS_LINUX && !TARGET_OS_ANDROID)
 
 #include <stdio.h>
 

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -448,7 +448,7 @@ CF_INLINE int popcountll(long long x) {
 #define CF_TEST_PRIVATE CF_PRIVATE
 #endif
 
-#if TARGET_OS_LINUX || TARGET_OS_WIN32
+#if TARGET_OS_WIN32 || (TARGET_OS_LINUX && !TARGET_OS_ANDROID)
 
 #include <stdarg.h>
 


### PR DESCRIPTION
Bionic includes a definition and implementation of asprintf. We should
not include our own on Android.

See 'include/stdio.h' and 'libc/stdio/stdio.cpp'

https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/include/stdio.h#288
https://android.googlesource.com/platform/bionic/+/refs/heads/master/libc/stdio/stdio.cpp#736