### PR TITLE
Foundation: rework handling for `ECANCELED`

### DIFF
--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -995,14 +995,6 @@ extension POSIXErrorCode: _ErrorCodeProtocol {
     public typealias _ErrorType = POSIXError
 }
 
-#if os(Windows)
-extension POSIXErrorCode {
-  public static var ECANCELED: POSIXErrorCode {
-      return POSIXError.Code(rawValue: WinSDK.ECANCELED)!
-  }
-}
-#endif
-
 extension POSIXError {
     /// Operation not permitted.
     public static var EPERM: POSIXError.Code { return .EPERM }
@@ -1322,7 +1314,13 @@ extension POSIXError {
     #endif
 
     /// Operation canceled.
-    public static var ECANCELED: POSIXError.Code { return .ECANCELED }
+    public static var ECANCELED: POSIXError.Code {
+#if os(Windows)
+        return POSIXError.Code(rawValue: ERROR_CANCELLED)!
+#else
+        return .ECANCELED
+#endif
+    }
 
     #if !os(Windows)
     /// Identifier removed.


### PR DESCRIPTION
Windows does not have a proper POSIX equivalent to `ECANCELED`.  The
closes equivalent appears to be `WSAECANCELLED` which is a WinSock error
code for a cancelled operation.  The Windows Error `ERROR_CANCELLED`
(0x04c7) is the ideal mapping even though the error code resides in a
different domain.  As long as the error code is compared via name, this
should be safe.