### PR TITLE
Define `asprintf` when `_GNU_SOURCE` is not set on Linux

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1510,7 +1510,7 @@ void _CF_dispatch_once(dispatch_once_t *predicate, void (^block)(void)) {
 #pragma mark -
 #pragma mark Windows and Linux Helpers
 
-#if TARGET_OS_WIN32
+#if TARGET_OS_WIN32 || (TARGET_OS_LINUX && !defined(_GNU_SOURCE))
 
 #include <stdio.h>
 

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -448,7 +448,7 @@ CF_INLINE int popcountll(long long x) {
 #define CF_TEST_PRIVATE CF_PRIVATE
 #endif
 
-#if TARGET_OS_WIN32
+#if TARGET_OS_WIN32 || (TARGET_OS_LINUX && !defined(_GNU_SOURCE))
 
 #include <stdarg.h>
 


### PR DESCRIPTION
This PR will define `asprintf` when `_GNU_SOURCE` is not set while building for Linux. The build system defines `_GNU_SOURCE` when building for Linux/Android here; https://github.com/apple/swift-corelibs-foundation/blob/main/CoreFoundation/CMakeLists.txt#L69-L70, but being pedantically correct will ensure there are no surprises.