### PR TITLE
[5.6] backport some changes regarding `asprintf`

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1510,7 +1510,7 @@ void _CF_dispatch_once(dispatch_once_t *predicate, void (^block)(void)) {
 #pragma mark -
 #pragma mark Windows and Linux Helpers
 
-#if TARGET_OS_WIN32
+#if TARGET_OS_WIN32 || (TARGET_OS_LINUX && !defined(_GNU_SOURCE))
 
 #include <stdio.h>
 

--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1510,7 +1510,7 @@ void _CF_dispatch_once(dispatch_once_t *predicate, void (^block)(void)) {
 #pragma mark -
 #pragma mark Windows and Linux Helpers
 
-#if TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_WIN32
 
 #include <stdio.h>
 

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -448,7 +448,7 @@ CF_INLINE int popcountll(long long x) {
 #define CF_TEST_PRIVATE CF_PRIVATE
 #endif
 
-#if TARGET_OS_WIN32
+#if TARGET_OS_WIN32 || (TARGET_OS_LINUX && !defined(_GNU_SOURCE))
 
 #include <stdarg.h>
 

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -448,7 +448,7 @@ CF_INLINE int popcountll(long long x) {
 #define CF_TEST_PRIVATE CF_PRIVATE
 #endif
 
-#if TARGET_OS_LINUX || TARGET_OS_WIN32
+#if TARGET_OS_WIN32
 
 #include <stdarg.h>
 


### PR DESCRIPTION
Pull a couple of patches from main which improve handling for `asprintf` on Linux platforms.  `asprintf` is vended by the system libc for most platforms (including android) when `_GNU_SOURCE` is defined which we do set.  Backporting this ensures that we do not accidentally break the build due to re-definition of the symbol.