### PR TITLE
Foundation: explicitly cast value on Windows for 32-bits

### DIFF
--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -1316,7 +1316,7 @@ extension POSIXError {
     /// Operation canceled.
     public static var ECANCELED: POSIXError.Code {
 #if os(Windows)
-        return POSIXError.Code(rawValue: ERROR_CANCELLED)!
+        return POSIXError.Code(rawValue: Int32(ERROR_CANCELLED))!
 #else
         return .ECANCELED
 #endif


### PR DESCRIPTION
The `ERROR_CANCELLED` constant is imported as an `Int`, but `POSIXError` expects an `Int32`.  Explicitly cast the value to make the 32-bit builds clean.