### PR TITLE
Fix typo `ecoding` -> `encoding`

### DIFF
--- a/Darwin/Foundation-swiftoverlay/NSStringAPI.swift
+++ b/Darwin/Foundation-swiftoverlay/NSStringAPI.swift
@@ -205,7 +205,7 @@ extension String {
   ///
   /// - Parameters:
   ///   - bytes: A sequence of bytes to interpret using `encoding`.
-  ///   - encoding: The ecoding to use to interpret `bytes`.
+  ///   - encoding: The encoding to use to interpret `bytes`.
   public init?<S: Sequence>(bytes: __shared S, encoding: Encoding)
   where S.Iterator.Element == UInt8 {
     let byteArray = Array(bytes)


### PR DESCRIPTION
This is present on Apple's developer website: https://developer.apple.com/documentation/swift/string/init(bytes:encoding:)

<img width="714" alt="Screen Shot 2022-08-08 at 8 12 08 PM" src="https://user-images.githubusercontent.com/71743241/183535589-7feddd3d-3605-4cbc-9efd-d4c2dd4752ad.png">

