### PR TITLE
Add definition for _Bool in C++ mode

### DIFF
--- a/CoreFoundation/Base.subproj/CFBase.h
+++ b/CoreFoundation/Base.subproj/CFBase.h
@@ -66,8 +66,9 @@
 
 #if defined(__GNUC__) || TARGET_OS_WIN32
 #include <stdint.h>
-#include <stdbool.h>
 #endif
+
+#include <stdbool.h>
 
 #if __BLOCKS__ && (TARGET_OS_OSX || TARGET_OS_IPHONE)
 #include <Block.h>
@@ -80,7 +81,7 @@
 #if !defined(__MACTYPES__)
 #if !defined(_OS_OSTYPES_H)
 #if DEPLOYMENT_RUNTIME_SWIFT
-    typedef _Bool                   Boolean;
+    typedef bool                    Boolean;
 #else
     typedef unsigned char           Boolean;
 #endif

--- a/CoreFoundation/Base.subproj/CFOverflow.h
+++ b/CoreFoundation/Base.subproj/CFOverflow.h
@@ -15,8 +15,8 @@
 #if __has_include(<os/overflow.h>)
 #include <os/overflow.h>
 #else
-    static _Bool __os_warn_unused(_Bool x) __attribute__((__warn_unused_result__));
-    static _Bool __os_warn_unused(_Bool x) { return x; }
+    static bool __os_warn_unused(bool x) __attribute__((__warn_unused_result__));
+    static bool __os_warn_unused(bool x) { return x; }
 
     #if __has_builtin(__builtin_add_overflow) && \
     __has_builtin(__builtin_sub_overflow) && \

--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -84,7 +84,7 @@ typedef CF_ENUM(CFOptionFlags, _CFAllocatorHint) {
 #define NSISARGTYPE id _Nullable
 #else
 #define NSISARGTYPE void * _Nullable
-#define BOOL _Bool
+#define BOOL bool
 #endif
 
 CF_EXPORT BOOL _NSIsNSArray(NSISARGTYPE arg);

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -482,10 +482,10 @@ CF_CROSS_PLATFORM_EXPORT void __CFURLComponentsDeallocate(CFTypeRef cf);
 typedef struct {
     void *_Nonnull memory;
     size_t capacity;
-    _Bool onStack;
+    bool onStack;
 } _ConditionalAllocationBuffer;
 
-static inline _Bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuffer *_Nonnull buffer, size_t amt) {
+static inline bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuffer *_Nonnull buffer, size_t amt) {
 #if TARGET_OS_MAC
     size_t amount = malloc_good_size(amt);
 #else
@@ -509,7 +509,7 @@ static inline _Bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuf
 }
 
 #if TARGET_OS_WASI
-static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
+static inline bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
     _ConditionalAllocationBuffer buffer;
     buffer.capacity = amount;
     buffer.onStack = false;
@@ -520,7 +520,7 @@ static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((n
     return true;
 }
 #else
-static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
+static inline bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
     _ConditionalAllocationBuffer buffer;
 #if TARGET_OS_MAC
     buffer.capacity = malloc_good_size(amount);
@@ -538,7 +538,7 @@ static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((n
 }
 #endif
 
-static inline _Bool _withStackOrHeapBufferWithResultInArguments(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(void *_Nonnull memory, size_t capacity, _Bool onStack)) {
+static inline bool _withStackOrHeapBufferWithResultInArguments(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(void *_Nonnull memory, size_t capacity, bool onStack)) {
     return _withStackOrHeapBuffer(amount, ^(_ConditionalAllocationBuffer *buffer) {
         applier(buffer->memory, buffer->capacity, buffer->onStack);
     });
@@ -645,13 +645,13 @@ _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *bti
 
 static unsigned int const _CF_renameat2_RENAME_EXCHANGE = 1 << 1;
 #ifdef SYS_renameat2
-static _Bool const _CFHasRenameat2 = 1;
+static bool const _CFHasRenameat2 = 1;
 static inline int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
                                 int newdirfd, const char *_Nonnull newpath, unsigned int flags) {
     return syscall(SYS_renameat2, olddirfd, oldpath, newdirfd, newpath, flags);
 }
 #else
-static _Bool const _CFHasRenameat2 = 0;
+static bool const _CFHasRenameat2 = 0;
 static inline int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
                                 int newdirfd, const char *_Nonnull newpath, unsigned int flags) {
     return ENOSYS;

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Grok.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Grok.c
@@ -46,7 +46,7 @@
 
 // Windows isspace implementation limits the input chars to < 256 in the ASCII range.  It will
 // assert in debug builds.  This is annoying.  We merrily grok chars > 256.
-static inline _Bool _CF_isspace(int c) {
+static inline bool _CF_isspace(int c) {
     return (c == ' ' || c == '\t' || c == '\n' || c == '\r'|| c == '\v' || c == '\f');
 }
 #define isspace _CF_isspace

--- a/Darwin/shims/FoundationOverlayShims.h
+++ b/Darwin/shims/FoundationOverlayShims.h
@@ -37,10 +37,10 @@
 typedef struct {
     void *_Nonnull memory;
     size_t capacity;
-    _Bool onStack;
+    bool onStack;
 } _ConditionalAllocationBuffer;
 
-static inline _Bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuffer *_Nonnull buffer, size_t amt) {
+static inline bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuffer *_Nonnull buffer, size_t amt) {
     size_t amount = malloc_good_size(amt);
     if (amount <= buffer->capacity) { return true; }
     void *newMemory;
@@ -59,7 +59,7 @@ static inline _Bool _resizeConditionalAllocationBuffer(_ConditionalAllocationBuf
     return true;
 }
 
-static inline _Bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
+static inline bool _withStackOrHeapBuffer(size_t amount, void (__attribute__((noescape)) ^ _Nonnull applier)(_ConditionalAllocationBuffer *_Nonnull)) {
     _ConditionalAllocationBuffer buffer;
     buffer.capacity = malloc_good_size(amount);
     buffer.onStack = (pthread_main_np() != 0 ? buffer.capacity < 2048 : buffer.capacity < 512);


### PR DESCRIPTION
`_Bool` is not defined when importing Foundation with C++ interop enabled
resulting in the missing type. This patch defines `_Bool` to `bool` when
compiling for C++.

I'm not entire sure how to test this. The test itself is fairly simple, it's just
```
import Foundation
```
with the invocation `swiftc -Xcc -std=c++17 -enable-experimental-cxx-interop`, but I don't know how to tell XCTest to do that so I would like pointers there.

rdar://99713881