### PR TITLE
Remove CFErrorSetCallBackForDomain

### DIFF
--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -529,12 +529,6 @@ CF_EXPORT CFErrorUserInfoKeyCallBackBlock CFErrorGetCallBackBlockForDomain(CFStr
 CF_EXPORT CFErrorUserInfoKeyCallBackBlock CFErrorCopyCallBackBlockForDomain(CFStringRef domainName) API_AVAILABLE(macos(10.13), ios(11.0), watchos(4.0), tvos(11.0));
 #endif
 
-/* This variant of the error domain callback has been deprecated and will be removed.  This callback function is consulted if a key is not present in the userInfo dictionary. Note that setting a callback for the same domain again simply replaces the previous callback. Set NULL as the callback to remove it. The callback function should return a result that is retained.
- */
-typedef CFTypeRef _Nonnull (*CFErrorUserInfoKeyCallBack)(CFErrorRef err, CFStringRef key);
-CF_EXPORT void CFErrorSetCallBackForDomain(CFStringRef domainName, CFErrorUserInfoKeyCallBack _Nullable callBack) API_AVAILABLE(macos(10.5), ios(2.0), watchos(2.0), tvos(9.0));
-CF_EXPORT CFErrorUserInfoKeyCallBack _Nullable CFErrorGetCallBackForDomain(CFStringRef domainName) API_AVAILABLE(macos(10.5), ios(2.0), watchos(2.0), tvos(9.0));
-
 _CF_EXPORT_SCOPE_END
 
 // ---- Windows-specific material ---------------------------------------

--- a/CoreFoundation/Error.subproj/CFError.c
+++ b/CoreFoundation/Error.subproj/CFError.c
@@ -621,27 +621,3 @@ static void __CFErrorSetCallBackForDomainNoLock(CFStringRef domainName, CFErrorU
         CFDictionaryRemoveValue(_CFErrorCallBackTable, domainName);
     }
 }
-
-// !!! This function can go away after 10.13/iOS 11
-void CFErrorSetCallBackForDomain(CFStringRef domainName, CFErrorUserInfoKeyCallBack callBack) {
-    // Since we have replaced the callback functionality with a callback block functionality, we now register (legacy) callback functions embedded in a block which autoreleases the result
-    CFErrorUserInfoKeyCallBackBlock block = (!callBack) ? NULL : ^(CFErrorRef err, CFStringRef key){
-        CFTypeRef result = callBack(err, key);
-#if !DEPLOYMENT_RUNTIME_SWIFT
-        if (result) CFAutorelease(result);
-#endif
-        return result;
-    };
-    CFErrorSetCallBackBlockForDomain(domainName, block);
-}
-
-// !!! This function can go away after 10.13/iOS 11
-CFErrorUserInfoKeyCallBack CFErrorGetCallBackForDomain(CFStringRef domainName) {
-    // Since there were no callers other than CF, removed as of 10.11/iOS9
-    // Otherwise would have had to have separate tables for callback functions and blocks
-    return NULL;
-}
-
-
-
-


### PR DESCRIPTION
Since it has been 5 years since iOS 11, we can safely remove the functions that were set to go away after 10.13/iOS 11