### PR TITLE
Fix logic error in AttributedString.Runs.== for empty collections

### DIFF
--- a/Tests/Foundation/Tests/TestAttributedString.swift
+++ b/Tests/Foundation/Tests/TestAttributedString.swift
@@ -989,6 +989,19 @@ E {
             XCTAssertFalse(desc.isEmpty)
         }
     }
+    
+    func testSubstringEquality() {
+        let str = AttributedString("")
+        let range = str.startIndex ..< str.endIndex
+        XCTAssertEqual(str[range], str[range])
+        
+        let str2 = "A" + AttributedString("A", attributes: .init().testInt(2))
+        let substringA = str2[str2.startIndex ..< str2.index(afterCharacter: str2.startIndex)]
+        let substringB = str2[str2.index(afterCharacter: str2.startIndex) ..< str2.endIndex]
+        XCTAssertNotEqual(substringA, substringB)
+        XCTAssertEqual(substringA, substringA)
+        XCTAssertEqual(substringB, substringB)
+    }
 
     // MARK: - Coding Tests
     
@@ -2196,6 +2209,7 @@ E {
             ("testSubstringBase", testSubstringBase),
             ("testSubstringGetAttribute", testSubstringGetAttribute),
             ("testSubstringDescription", testSubstringDescription),
+            ("testSubstringEquality", testSubstringEquality),
             ("testJSONEncoding", testJSONEncoding),
             ("testDecodingThenConvertingToNSAttributedString", testDecodingThenConvertingToNSAttributedString),
             ("testCustomAttributeCoding", testCustomAttributeCoding),


### PR DESCRIPTION
This corrects an issue in the `AttributedString.Runs` equality check when both collections are empty. Previously this led to an array out of bounds access when attempting to compare a run in the collection that did not exist. This also refactors the code a bit to make it more readable.

Resolves #4634