### PR TITLE
Temporary fix for static linking on Linux

### DIFF
--- a/Sources/FoundationNetworking/URLSession/BodySource.swift
+++ b/Sources/FoundationNetworking/URLSession/BodySource.swift
@@ -23,7 +23,13 @@ import Foundation
 #endif
 
 @_implementationOnly import CoreFoundation
+
+#if os(Linux)
+import CFURLSessionInterface
+#else
 @_implementationOnly import CFURLSessionInterface
+#endif
+
 import Dispatch
 
 

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -10,6 +10,9 @@
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 import SwiftFoundation
 import CFXMLInterface
+#elseif os(Linux)
+import Foundation
+import CFXMLInterface
 #else
 import Foundation
 @_implementationOnly import CFXMLInterface


### PR DESCRIPTION
When using `@_implementationOnly`, the dependencies do not get emitted into the module files and static linking does not work.

Originally submitted by @drexin as https://github.com/apple/swift-corelibs-foundation/pull/3135.

There was another PR that was supposed to fix it, but apparently it currently doesn't work on Linux: https://github.com/apple/swift-corelibs-foundation/pull/3052

Repro test case added in https://github.com/apple/swift/pull/61372