### PR TITLE
`NumberFormatter` fraction digits, Fixes #4221

### DIFF
--- a/Sources/Foundation/NumberFormatter.swift
+++ b/Sources/Foundation/NumberFormatter.swift
@@ -222,9 +222,7 @@ open class NumberFormatter : Formatter {
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinIntegerDigits, value: _minimumIntegerDigits?._bridgeToObjectiveC()._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxIntegerDigits, value: _maximumIntegerDigits?._bridgeToObjectiveC()._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMinFractionDigits, value: _minimumFractionDigits?._bridgeToObjectiveC()._cfObject)
-        if minimumFractionDigits <= 0 {
-            _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxFractionDigits, value: maximumFractionDigits._bridgeToObjectiveC()._cfObject)
-        }
+        _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterMaxFractionDigits, value: maximumFractionDigits._bridgeToObjectiveC()._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterGroupingSize, value: groupingSize._bridgeToObjectiveC()._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterSecondaryGroupingSize, value: _secondaryGroupingSize._bridgeToObjectiveC()._cfObject)
         _setFormatterAttribute(formatter, attributeName: kCFNumberFormatterRoundingMode, value: _roundingMode.rawValue._bridgeToObjectiveC()._cfObject)

--- a/Tests/Foundation/Tests/TestNumberFormatter.swift
+++ b/Tests/Foundation/Tests/TestNumberFormatter.swift
@@ -696,6 +696,24 @@ class TestNumberFormatter: XCTestCase {
         let formattedString = numberFormatter.string(from: 42.4242)
         XCTAssertEqual(formattedString, "42-424")
     }
+
+    func test_bothFractionDigitsSet_longerThanMaximumFractionDigits() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.minimumFractionDigits = 3
+        numberFormatter.maximumFractionDigits = 4
+        numberFormatter.decimalSeparator = "-"
+        let formattedString = numberFormatter.string(from: 42.424242)
+        XCTAssertEqual(formattedString, "42-4242")
+    }
+
+    func test_bothFractionDigitsSet_shorterThanMinimumFractionDigits() {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.minimumFractionDigits = 3
+        numberFormatter.maximumFractionDigits = 4
+        numberFormatter.decimalSeparator = "-"
+        let formattedString = numberFormatter.string(from: 42.42)
+        XCTAssertEqual(formattedString, "42-420")
+    }
     
     func test_groupingSize() {
         let numberFormatter = NumberFormatter()


### PR DESCRIPTION
NumberFormatter should accept both `minimumFractionDigits` and `maximumFractionDigits` at the same time, issue: https://github.com/apple/swift-corelibs-foundation/issues/4221

The limitation removed here is not explained anywhere, makes no sense (to me) and seems arbitrary and breaks formatter on Linux and Windows:

```swift
if minimumFractionDigits <= 0 
```

Added two tests covering the modified logic.

**To reviewer:**
Thank you for reading this PR and taking your time to consider accepting the changes.