### PR TITLE
Fixes issue #4642: Encountering "Constant strings cannot be deallocated" in Linux foundation

### DIFF
--- a/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFDateIntervalFormatter.c
@@ -507,7 +507,7 @@ void _CFDateIntervalFormatterSetBoundaryStyle(CFDateIntervalFormatterRef formatt
 CFStringRef CFDateIntervalFormatterCreateStringFromDateToDate(CFDateIntervalFormatterRef formatter, CFDateRef fromDate, CFDateRef toDate) {
     LOCK();
     
-    CFStringRef resultStr = CFSTR("");
+    CFStringRef resultStr = NULL;
     updateFormatter(formatter);
     
     if (formatter->_formatter) {
@@ -531,7 +531,7 @@ CFStringRef CFDateIntervalFormatterCreateStringFromDateToDate(CFDateIntervalForm
             resultStr = CFStringCreateWithCharacters(kCFAllocatorSystemDefault, result, len);
         }
     } else {
-        resultStr = CFSTR("");
+        resultStr = (CFStringRef)CFRetain(CFSTR(""));
     }
     UNLOCK();
     

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Resources.c
@@ -1242,7 +1242,7 @@ CF_EXPORT CFTypeRef _Nullable _CFBundleCopyFindResources(CFBundleRef _Nullable b
             if (returnValue) CFRelease(returnValue);
             if ((bundleVersion == _CFBundleVersionOldStyleResources && realSubdirectory && CFEqual(realSubdirectory, CFSTR("Resources"))) || (bundleVersion == _CFBundleVersionContentsResources && realSubdirectory && CFEqual(realSubdirectory, CFSTR("Contents/Resources")))) {
                 if (realSubdirectory) CFRelease(realSubdirectory);
-                realSubdirectory = CFSTR("");
+                realSubdirectory = (CFStringRef)CFRetain(CFSTR(""));
             } else if (bundleVersion == _CFBundleVersionOldStyleResources && realSubdirectory && CFStringGetLength(realSubdirectory) > 10 && CFStringHasPrefix(realSubdirectory, CFSTR("Resources/"))) {
                 CFStringRef tmpRealSubdirectory = CFStringCreateWithSubstring(kCFAllocatorSystemDefault, realSubdirectory, CFRangeMake(10, CFStringGetLength(realSubdirectory) - 10));
                 if (realSubdirectory) CFRelease(realSubdirectory);


### PR DESCRIPTION
Fixes issue #4642: Encountering "Constant strings cannot be deallocated" in Linux foundation

The reported error was an CFSTR("") which is later released. While this should not be a problem, the Linux implementation of CFSTR does not ignore dealloc on constant strings. Fixed this by calling CFRetain on the constant string.

Strictly speaking this is only a workaround. Issue #1351 has some hints how this could be fixed but the workaround is used a over the code so I think it is okay to use it here, too.

I found the same problem in CFDateIntervalFormatter.c where it appeared in a error handling code path that should never be called. Fixed anyways.