### PR TITLE
Remove unnecessary use of renameat2.

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -643,21 +643,6 @@ _stat_with_btime(const char *filename, struct stat *buffer, struct timespec *bti
 }
 #endif // __NR_statx
 
-static unsigned int const _CF_renameat2_RENAME_EXCHANGE = 1 << 1;
-#ifdef SYS_renameat2
-static _Bool const _CFHasRenameat2 = 1;
-static inline int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
-                                int newdirfd, const char *_Nonnull newpath, unsigned int flags) {
-    return syscall(SYS_renameat2, olddirfd, oldpath, newdirfd, newpath, flags);
-}
-#else
-static _Bool const _CFHasRenameat2 = 0;
-static inline int _CF_renameat2(int olddirfd, const char *_Nonnull oldpath,
-                                int newdirfd, const char *_Nonnull newpath, unsigned int flags) {
-    return ENOSYS;
-}
-#endif // __SYS_renameat2
-
 
 #endif // TARGET_OS_LINUX
 

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -1275,16 +1275,6 @@ extension FileManager {
                     return newItemURL.withUnsafeFileSystemRepresentation { (newItemFS) -> Int32? in
                         if let originalFS = originalFS,
                            let newItemFS = newItemFS {
-
-                                #if os(Linux)
-                                if _CFHasRenameat2 && kernelSupportsRenameat2 {
-                                    if _CF_renameat2(AT_FDCWD, originalFS, AT_FDCWD, newItemFS, _CF_renameat2_RENAME_EXCHANGE) == 0 {
-                                        return nil
-                                    } else {
-                                        return errno
-                                    }
-                                }
-                                #endif
                                 if renameat(AT_FDCWD, originalFS, AT_FDCWD, newItemFS) == 0 {
                                     return nil
                                 } else {

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -886,12 +886,6 @@ open class FileManager : NSObject {
         let requiredVersion = OperatingSystemVersion(majorVersion: 4, minorVersion: 11, patchVersion: 0)
         return ProcessInfo.processInfo.isOperatingSystemAtLeast(requiredVersion)
     }()
-
-    // renameat2() is only supported by Linux kernels >= 3.15
-    internal lazy var kernelSupportsRenameat2: Bool = {
-        let requiredVersion = OperatingSystemVersion(majorVersion: 3, minorVersion: 15, patchVersion: 0)
-        return ProcessInfo.processInfo.isOperatingSystemAtLeast(requiredVersion)
-    }()
 #endif
 
     internal func _compareFiles(withFileSystemRepresentation file1Rep: UnsafePointer<NativeFSRCharType>, andFileSystemRepresentation file2Rep: UnsafePointer<NativeFSRCharType>, size: Int64, bufSize: Int) -> Bool {


### PR DESCRIPTION
On Linux, on some code paths, we call renameat2 with `RENAME_EXCHANGE` in the implementation of replaceItemAt(_:withItemAt:). This is a behaviour utterly unique to that code path: Darwin Foundation doesn't do this, and the non-renameat2 codepaths don't do it either.

As Darwin doesn't do this, we maximise compatibility and minimise complexity by just deleting the path and all supporting code altogether.

Resolves #4655.