### PR TITLE
Annotate CFPreferencesCopyMultiple returning nullable

### DIFF
--- a/CoreFoundation/Preferences.subproj/CFPreferences.h
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.h
@@ -93,7 +93,7 @@ keysToFetch that are not present in the returned dictionary
 are not present in the domain.  If keysToFetch is NULL, all
 keys are fetched. */
 CF_EXPORT
-CFDictionaryRef CFPreferencesCopyMultiple(_Nullable CFArrayRef keysToFetch, CFStringRef applicationID, CFStringRef userName, CFStringRef hostName);
+_Nullable CFDictionaryRef CFPreferencesCopyMultiple(_Nullable CFArrayRef keysToFetch, CFStringRef applicationID, CFStringRef userName, CFStringRef hostName);
 
 /* The primitive set function; all arguments except value must be
 non-NULL.  If value is NULL, the given key is removed */


### PR DESCRIPTION
Solves two static analyser issues.

Before:
<img width="1084" alt="Screenshot 2022-11-15 at 08 52 15" src="https://user-images.githubusercontent.com/1630974/201851575-c5eb08d8-b396-451a-a619-72af16b40088.png">

After fix:
<img width="1084" alt="Screenshot 2022-11-15 at 08 54 21" src="https://user-images.githubusercontent.com/1630974/201851625-3306b45f-4f70-4017-8395-4c21aa46f1da.png">
