### PR TITLE
Rename fetchXMLValue -> fetchXMLValueCreate to follow Core Foundation Memory Management naming convention

### DIFF
--- a/CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c
+++ b/CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c
@@ -37,7 +37,7 @@ typedef struct {
 
 static void *createXMLDomain(CFAllocatorRef allocator, CFTypeRef context);
 static void freeXMLDomain(CFAllocatorRef allocator, CFTypeRef context, void *tDomain);
-static CFTypeRef fetchXMLValue(CFTypeRef context, void *xmlDomain, CFStringRef key);
+static CFTypeRef fetchXMLValueCreate(CFTypeRef context, void *xmlDomain, CFStringRef key);
 static void writeXMLValue(CFTypeRef context, void *xmlDomain, CFStringRef key, CFTypeRef value);
 static Boolean synchronizeXMLDomain(CFTypeRef context, void *xmlDomain);
 static void getXMLKeysAndValues(CFAllocatorRef alloc, CFTypeRef context, void *xmlDomain, void **buf[], CFIndex *numKeyValuePairs);
@@ -45,7 +45,7 @@ static CFDictionaryRef copyXMLDomainDictionary(CFTypeRef context, void *domain);
 static void setXMLDomainIsWorldReadable(CFTypeRef context, void *domain, Boolean isWorldReadable);
 
 CF_PRIVATE const _CFPreferencesDomainCallBacks __kCFXMLPropertyListDomainCallBacks;
-const _CFPreferencesDomainCallBacks __kCFXMLPropertyListDomainCallBacks = {createXMLDomain, freeXMLDomain, fetchXMLValue, writeXMLValue, synchronizeXMLDomain, getXMLKeysAndValues, copyXMLDomainDictionary, setXMLDomainIsWorldReadable};
+const _CFPreferencesDomainCallBacks __kCFXMLPropertyListDomainCallBacks = {createXMLDomain, freeXMLDomain, fetchXMLValueCreate, writeXMLValue, synchronizeXMLDomain, getXMLKeysAndValues, copyXMLDomainDictionary, setXMLDomainIsWorldReadable};
 
 CF_PRIVATE CFAllocatorRef __CFPreferencesAllocator(void);
 
@@ -198,7 +198,7 @@ static void _loadXMLDomainIfStale(CFURLRef url, _CFXMLPreferencesDomain *domain)
     domain->_lastReadTime = CFAbsoluteTimeGetCurrent();
 }
 
-static CFTypeRef fetchXMLValue(CFTypeRef context, void *xmlDomain, CFStringRef key) {
+static CFTypeRef fetchXMLValueCreate(CFTypeRef context, void *xmlDomain, CFStringRef key) {
     _CFXMLPreferencesDomain *domain = (_CFXMLPreferencesDomain *)xmlDomain;
     CFTypeRef result;
  


### PR DESCRIPTION
Solves static analyser issue.

Before fix:
<img width="1083" alt="Screenshot 2022-11-15 at 09 17 49" src="https://user-images.githubusercontent.com/1630974/201855029-70b46246-d054-41bb-b139-beb4081ad085.png">

After fix:
<img width="1083" alt="Screenshot 2022-11-15 at 09 16 32" src="https://user-images.githubusercontent.com/1630974/201855080-46d40d53-fe4b-4760-b46c-a64cdee8b895.png">