### PR TITLE
Annotating _CFStringCreateByAddingPercentEncodingWithAllowedCharacters as _Nullable

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLComponents.h
+++ b/CoreFoundation/URL.subproj/CFURLComponents.h
@@ -95,7 +95,7 @@ CF_EXPORT CFRange _CFURLComponentsGetRangeOfPath(CFURLComponentsRef components) 
 CF_EXPORT CFRange _CFURLComponentsGetRangeOfQuery(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 CF_EXPORT CFRange _CFURLComponentsGetRangeOfFragment(CFURLComponentsRef components) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
-CF_EXPORT CFStringRef _CFStringCreateByAddingPercentEncodingWithAllowedCharacters(CFAllocatorRef alloc, CFStringRef string, CFCharacterSetRef allowedCharacters) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
+CF_EXPORT CFStringRef _Nullable _CFStringCreateByAddingPercentEncodingWithAllowedCharacters(CFAllocatorRef alloc, CFStringRef string, CFCharacterSetRef allowedCharacters) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 CF_EXPORT CFStringRef _Nullable _CFStringCreateByRemovingPercentEncoding(CFAllocatorRef alloc, CFStringRef string) _CF_URL_COMPONENTS_API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 
 // These return singletons


### PR DESCRIPTION
Solves static analyzer issue.

<img width="1160" alt="Screenshot 2022-11-18 at 09 35 47" src="https://user-images.githubusercontent.com/1630974/202647941-98a2f585-49d6-43ef-965e-68d9f9b0f95f.png">
