### PR TITLE
[5.7] Ensure libdispatch is always initialized before CoreFoundation

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1171,9 +1171,19 @@ CF_EXPORT
 
 CF_PRIVATE os_unfair_recursive_lock CFPlugInGlobalDataLock;
 
+#if __HAS_DISPATCH__
+extern void libdispatch_init();
+#endif
+
 void __CFInitialize(void) {
     if (!__CFInitialized && !__CFInitializing) {
         __CFInitializing = 1;
+
+#if __HAS_DISPATCH__
+    // libdispatch has to be initialized before CoreFoundation, so to avoid
+    // issues with static initializer ordering, we are doing it explicitly.
+    libdispatch_init();
+#endif
 
     // This is a no-op on Darwin, but is needed on Linux and Windows.
     _CFPerformDynamicInitOfOSRecursiveLock(&CFPlugInGlobalDataLock);


### PR DESCRIPTION
Backporting https://github.com/apple/swift-corelibs-foundation/pull/4666

This has been causing async functions to not return when using static linking.

rdar://96642321