### PR TITLE
URLSessionWebSocketTask.receive() not finishing if server closes connection without a close packet

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -703,6 +703,12 @@ open class URLSessionWebSocketTask : URLSessionTask {
         }
     }
 
+    open override var error: Error? {
+        didSet {
+            doPendingWork()
+        }
+    }
+
     private var sendBuffer = [(Message, (Error?) -> Void)]()
     private var receiveBuffer = [Message]()
     private var receiveCompletionHandlers = [(Result<Message, Error>) -> Void]()

--- a/Sources/FoundationNetworking/URLSession/WebSocket/WebSocketURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/WebSocket/WebSocketURLProtocol.swift
@@ -88,6 +88,13 @@ internal class _WebSocketURLProtocol: _HTTPURLProtocol {
         return .completeTask
     }
     
+    override func completeTask() {
+        if let webSocketTask = task as? URLSessionWebSocketTask {
+            webSocketTask.close(code: .normalClosure, reason: nil)
+        }
+        super.completeTask()
+    }
+
     func sendWebSocketData(_ data: Data, flags: _EasyHandle.WebSocketFlags) throws {
         try easyHandle.sendWebSocketsData(data, flags: flags)
     }

--- a/Tests/Foundation/Tests/TestDecimal.swift
+++ b/Tests/Foundation/Tests/TestDecimal.swift
@@ -7,8 +7,13 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-import Foundation
-import XCTest
+#if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
+    #if canImport(SwiftFoundation) && !DEPLOYMENT_RUNTIME_OBJC
+        @testable import SwiftFoundation
+    #else
+        @testable import Foundation
+    #endif
+#endif
 
 class TestDecimal: XCTestCase {
 


### PR DESCRIPTION
Two fixes required here:

- _WebSocketURLProtocol needs to detect a closing URL connection, and set its state to indicate this is a normal close of the connection
- URLSessionWebSocketTask needs to kick `doPendingWork()` if the connection is closed out due to an error, in order to respond to any pending Tasks parked in `receive()`