### PR TITLE
CoreFoundation: explicitly cast to the proper fptr types

### DIFF
--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -1125,7 +1125,7 @@ _CFXMLDTDPtr _CFXMLNewDTD(_CFXMLDocPtr doc, const unsigned char* name, const uns
     return xmlNewDtd(doc, name, publicID, systemID);
 }
 
-void _CFXMLNotationScanner(void* payload, void* data, xmlChar* name) {
+void _CFXMLNotationScanner(void* payload, void* data, const xmlChar* name) {
     xmlNotationPtr notation = (xmlNotationPtr)payload;
     _cfxmlNotation* node = (_cfxmlNotation*)data;
     node->type = XML_NOTATION_NODE;
@@ -1147,7 +1147,7 @@ _CFXMLDTDNodePtr _CFXMLParseDTDNode(const unsigned char* xmlString) {
         xmlUnlinkNode(node);
     } else if (dtd->notations) {
         node = (xmlNodePtr)calloc(1, sizeof(_cfxmlNotation));
-        xmlHashScan((xmlNotationTablePtr)dtd->notations, &_CFXMLNotationScanner, (void*)node);
+        xmlHashScan((xmlNotationTablePtr)dtd->notations, &_CFXMLNotationScanner, node);
     }
 
     return node;

--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -1769,7 +1769,7 @@ CF_EXPORT CFRunLoopRef _CFRunLoopGet0(_CFThreadRef t) {
 #if _POSIX_THREADS
             _CFSetTSD(__CFTSDKeyRunLoopCntr, (void *)(PTHREAD_DESTRUCTOR_ITERATIONS-1), (void (*)(void *))__CFFinalizeRunLoop);
 #else
-            _CFSetTSD(__CFTSDKeyRunLoopCntr, 0, &__CFFinalizeRunLoop);
+            _CFSetTSD(__CFTSDKeyRunLoopCntr, 0, (void (* _Nullable)(void * _Nullable))&__CFFinalizeRunLoop);
 #endif
         }
     }


### PR DESCRIPTION
With the latest rebranch, the mismatched function pointer types raise an error rather than a warning.  Explicitly cast to the expected function pointer type rather than ignoring the warning.