### PR TITLE
Tests: convert some assertions into XCTest forms

### DIFF
--- a/Tests/Foundation/Tests/TestNSString.swift
+++ b/Tests/Foundation/Tests/TestNSString.swift
@@ -1005,7 +1005,9 @@ class TestNSString: LoopbackServerTest {
         let userName = NSUserName()
         let homeDir2 = NSHomeDirectoryForUser(userName)
         let homeDir3 = NSHomeDirectory()
-        XCTAssert(homeDir != nil && homeDir == homeDir2 && homeDir == homeDir3, "Could get user' home directory")
+        XCTAssertNotNil(homeDir)
+        XCTAssertEqual(homeDir, homeDir2)
+        XCTAssertEqual(homeDir, homeDir3)
     }
     
     func test_expandingTildeInPath() {


### PR DESCRIPTION
Use the `XCTAssert*` helpers to validate the state to get proper diagnostics emitted for test failures.  This should help debugging failures.