### PR TITLE
FileManager: repair `homeDirectoryForCurrentUser` on Windows

### DIFF
--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -1140,7 +1140,7 @@ open class FileManager : NSObject {
     }
 
     open var homeDirectoryForCurrentUser: URL {
-        return homeDirectory(forUser: NSUserName())!
+        CFCopyHomeDirectoryURLForUser(nil)!.takeRetainedValue()._swiftObject
     }
     
     open var temporaryDirectory: URL {
@@ -1149,8 +1149,13 @@ open class FileManager : NSObject {
     
     open func homeDirectory(forUser userName: String) -> URL? {
         guard !userName.isEmpty else { return nil }
-        guard let url = CFCopyHomeDirectoryURLForUser(userName._cfObject) else { return nil }
-        return  url.takeRetainedValue()._swiftObject
+        // Prefer to take the `CFCopyHomeDirectoryURLForUser` path for the
+        // current user.
+        return CFCopyHomeDirectoryURLForUser(userName == NSUserName()
+                                                ? nil
+                                                : userName._cfObject)?
+                    .takeRetainedValue()
+                    ._swiftObject
     }
 }
 


### PR DESCRIPTION
The `homeDirectory(forUser:)` is currently not functioning properly for users other than the current user.  Switch to directly using the CoreFoundation API which simplifies the logic and makes the functionality work on Windows.  This uses the forced unwrap for the return value, which was previously the case and resulted in a trap on Windows.