### PR TITLE
Make `ISO8601DateFormatter.Options` static properties immutable

### DIFF
--- a/Sources/Foundation/ISO8601DateFormatter.swift
+++ b/Sources/Foundation/ISO8601DateFormatter.swift
@@ -17,33 +17,33 @@ extension ISO8601DateFormatter {
         
         public init(rawValue: UInt) { self.rawValue = rawValue }
 
-        public static var withYear = ISO8601DateFormatter.Options(rawValue: 1 << 0)
+        public static let withYear = ISO8601DateFormatter.Options(rawValue: 1 << 0)
 
-        public static var withMonth = ISO8601DateFormatter.Options(rawValue: 1 << 1)
+        public static let withMonth = ISO8601DateFormatter.Options(rawValue: 1 << 1)
 
-        public static var withWeekOfYear = ISO8601DateFormatter.Options(rawValue: 1 << 2)
+        public static let withWeekOfYear = ISO8601DateFormatter.Options(rawValue: 1 << 2)
         
-        public static var withDay = ISO8601DateFormatter.Options(rawValue: 1 << 4)
+        public static let withDay = ISO8601DateFormatter.Options(rawValue: 1 << 4)
         
-        public static var withTime = ISO8601DateFormatter.Options(rawValue: 1 << 5)
+        public static let withTime = ISO8601DateFormatter.Options(rawValue: 1 << 5)
         
-        public static var withTimeZone = ISO8601DateFormatter.Options(rawValue: 1 << 6)
+        public static let withTimeZone = ISO8601DateFormatter.Options(rawValue: 1 << 6)
         
-        public static var withSpaceBetweenDateAndTime = ISO8601DateFormatter.Options(rawValue: 1 << 7)
+        public static let withSpaceBetweenDateAndTime = ISO8601DateFormatter.Options(rawValue: 1 << 7)
         
-        public static var withDashSeparatorInDate = ISO8601DateFormatter.Options(rawValue: 1 << 8)
+        public static let withDashSeparatorInDate = ISO8601DateFormatter.Options(rawValue: 1 << 8)
         
-        public static var withColonSeparatorInTime = ISO8601DateFormatter.Options(rawValue: 1 << 9)
+        public static let withColonSeparatorInTime = ISO8601DateFormatter.Options(rawValue: 1 << 9)
         
-        public static var withColonSeparatorInTimeZone = ISO8601DateFormatter.Options(rawValue: 1 << 10)
+        public static let withColonSeparatorInTimeZone = ISO8601DateFormatter.Options(rawValue: 1 << 10)
         
-        public static var withFractionalSeconds = ISO8601DateFormatter.Options(rawValue: 1 << 11)
+        public static let withFractionalSeconds = ISO8601DateFormatter.Options(rawValue: 1 << 11)
         
-        public static var withFullDate = ISO8601DateFormatter.Options(rawValue: withYear.rawValue + withMonth.rawValue + withDay.rawValue + withDashSeparatorInDate.rawValue)
+        public static let withFullDate = ISO8601DateFormatter.Options(rawValue: withYear.rawValue + withMonth.rawValue + withDay.rawValue + withDashSeparatorInDate.rawValue)
         
-        public static var withFullTime = ISO8601DateFormatter.Options(rawValue: withTime.rawValue + withTimeZone.rawValue + withColonSeparatorInTime.rawValue + withColonSeparatorInTimeZone.rawValue)
+        public static let withFullTime = ISO8601DateFormatter.Options(rawValue: withTime.rawValue + withTimeZone.rawValue + withColonSeparatorInTime.rawValue + withColonSeparatorInTimeZone.rawValue)
 
-        public static var withInternetDateTime = ISO8601DateFormatter.Options(rawValue: withFullDate.rawValue + withFullTime.rawValue)
+        public static let withInternetDateTime = ISO8601DateFormatter.Options(rawValue: withFullDate.rawValue + withFullTime.rawValue)
     }
 
 }


### PR DESCRIPTION
Fixes #4703.

[`ISO8601DateFormatter.Options`](https://github.com/apple/swift-corelibs-foundation/blob/7504fdfa4529ac01b77ab83bfee51a5f06e3e6d1/Sources/Foundation/ISO8601DateFormatter.swift#L14) currently uses `var` for its static properties. The properties should instead be declared using `let` to prevent accidental mutation and to let the compiler know that these properties are concurrency-safe.

Regarding the latter point, the following is an example error caused by this issue:
> error: reference to static property 'withInternetDateTime' is not concurrency-safe because it involves shared mutable state