### PR TITLE
Process: disable Nagle on Windows

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -452,6 +452,13 @@ open class Process: NSObject {
         return (first: INVALID_SOCKET, second: INVALID_SOCKET)
       }
 
+      var option: CInt = 1
+      if setsockopt(first, IPPROTO_TCP.rawValue, TCP_NODELAY, &option,
+                    CInt(MemoryLayout.size(ofValue: option))) == SOCKET_ERROR {
+        closesocket(first)
+        return (first: INVALID_SOCKET, second: INVALID_SOCKET)
+      }
+
       let second: SOCKET = accept(listener, nil, nil)
       if second == INVALID_SOCKET {
         closesocket(first)


### PR DESCRIPTION
Windows does not have a native `socketpair` interface and so we emulate that locally.  Furthermore, the use of `socketpair` on the other platforms uses an `AF_UNIX` (Unix Domain Socket) which is not guaranteed to be available on Windows.  As a result, we workaround that by using an `AF_INET` address family socket.  This will by default have Nagle enabled which can potentially cause some delays when processing a message.  We have observed occasional hangs in the process handling which may be possibly be attributed to the buffering.  Disable nagle on the sender side in the hopes of a more reliable connection.