### PR TITLE
Foundation/Unit: add {m,u,p,n}second units to UnitDuration

### DIFF
--- a/Sources/Foundation/Unit.swift
+++ b/Sources/Foundation/Unit.swift
@@ -627,12 +627,20 @@ public final class UnitDuration : Dimension {
      */
     
     private struct Symbol {
+        static let picoseconds = "ps"
+        static let nanoseconds = "ns"
+        static let microseconds = "µs"
+        static let milliseconds = "ms"
         static let seconds  = "s"
         static let minutes  = "m"
         static let hours    = "h"
     }
     
     private struct Coefficient {
+        static let picoseconds = 1e-12
+        static let nanoseconds = 1e-9
+        static let microseconds = 1e-6
+        static let milliseconds = 1e-3
         static let seconds  = 1.0
         static let minutes  = 60.0
         static let hours    = 3600.0
@@ -642,6 +650,30 @@ public final class UnitDuration : Dimension {
         self.init(symbol: symbol, converter: UnitConverterLinear(coefficient: coefficient))
     }
     
+    public class var picoseconds: UnitDuration {
+        get {
+            return UnitDuration(symbol: Symbol.picoseconds, coefficient: Coefficient.picoseconds)
+        }
+    }
+
+    public class var nanoseconds: UnitDuration {
+        get {
+            return UnitDuration(symbol: Symbol.nanoseconds, coefficient: Coefficient.nanoseconds)
+        }
+    }
+
+    public class var microseconds: UnitDuration {
+        get {
+            return UnitDuration(symbol: Symbol.microseconds, coefficient: Coefficient.microseconds)
+        }
+    }
+
+    public class var milliseconds: UnitDuration {
+        get {
+            return UnitDuration(symbol: Symbol.milliseconds, coefficient: Coefficient.milliseconds)
+        }
+    }
+
     public class var seconds: UnitDuration {
         get {
             return UnitDuration(symbol: Symbol.seconds, coefficient: Coefficient.seconds)


### PR DESCRIPTION
not 100% sure this wasn't implemented elsewhere, but i didn't see these units
