### PR TITLE
install: place the libraries in architecture-specific directories on ELF platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,12 @@ set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG OFF)
 find_package(Threads REQUIRED)
 
+set(SWIFT_INSTALL_SUBDIR "$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+  get_swift_host_arch(swift_arch)
+  set(SWIFT_INSTALL_SUBDIR "${SWIFT_INSTALL_SUBDIR}/${swift_arch}")
+endif()
+
 set(SAVED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS NO)
 add_subdirectory(CoreFoundation EXCLUDE_FROM_ALL)
@@ -99,13 +105,13 @@ if(NOT BUILD_SHARED_LIBS)
   endif()
 
   install(TARGETS CoreFoundation CFXMLInterface
-    DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
+    DESTINATION lib/swift_static/${SWIFT_INSTALL_SUBDIR})
 
   if(BUILD_NETWORKING)
     set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS
       CFURLSessionInterface)
     install(TARGETS CFURLSessionInterface
-      DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
+      DESTINATION lib/swift_static/${SWIFT_INSTALL_SUBDIR})
   endif()
 endif()
 

--- a/Sources/BlocksRuntime/CMakeLists.txt
+++ b/Sources/BlocksRuntime/CMakeLists.txt
@@ -11,5 +11,5 @@ set_target_properties(BlocksRuntime PROPERTIES
 add_library(BlocksRuntime::BlocksRuntime ALIAS BlocksRuntime)
 
 install(TARGETS BlocksRuntime
-  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>)
+  ARCHIVE DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SWIFT_INSTALL_SUBDIR}
+  LIBRARY DESTINATION lib/swift$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:_static>/${SWIFT_INSTALL_SUBDIR})

--- a/Sources/Tools/plutil/CMakeLists.txt
+++ b/Sources/Tools/plutil/CMakeLists.txt
@@ -28,7 +28,7 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
 endif()
 
 set_target_properties(plutil PROPERTIES
-  INSTALL_RPATH "$ORIGIN/../lib/swift/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>")
+  INSTALL_RPATH "$ORIGIN/../lib/swift/${SWIFT_INSTALL_SUBDIR}")
 
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS plutil)

--- a/Sources/UUID/CMakeLists.txt
+++ b/Sources/UUID/CMakeLists.txt
@@ -23,12 +23,8 @@ set_target_properties(uuid PROPERTIES
 if(NOT BUILD_SHARED_LIBS)
   set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS uuid)
 
-  # get_swift_host_arch(swift_arch)
-
-  # TODO(drexin): should be installed in architecture specific folder, once
-  # the layout is fixed for non-Darwin platforms
   install(TARGETS uuid
-    ARCHIVE DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
-    LIBRARY DESTINATION lib/swift_static/$<LOWER_CASE:${CMAKE_SYSTEM_NAME}>
+    ARCHIVE DESTINATION lib/swift_static/${SWIFT_INSTALL_SUBDIR}
+    LIBRARY DESTINATION lib/swift_static/${SWIFT_INSTALL_SUBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -67,15 +67,19 @@ function(_install_target module)
     set(swift swift)
   endif()
 
+  get_swift_host_arch(swift_arch)
+  set(install_subdir "${swift_os}")
+  if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
+    set(install_subdir "${install_subdir}/${swift_arch}")
+  endif()
   install(TARGETS ${module}
-    ARCHIVE DESTINATION lib/${swift}/${swift_os}
-    LIBRARY DESTINATION lib/${swift}/${swift_os}
+    ARCHIVE DESTINATION lib/${swift}/${install_subdir}
+    LIBRARY DESTINATION lib/${swift}/${install_subdir}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   if(type STREQUAL EXECUTABLE)
     return()
   endif()
 
-  get_swift_host_arch(swift_arch)
   get_target_property(module_name ${module} Swift_MODULE_NAME)
   if(NOT module_name)
     set(module_name ${module})


### PR DESCRIPTION
This is needed for apple/swift#63782, which changes the Unix toolchain to look for libraries in architecture-specific directories.