### PR TITLE
Foundation: add missing and disambiguation imports

### DIFF
--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -12,6 +12,15 @@
 
 #if DEPLOYMENT_RUNTIME_SWIFT
 
+#if os(Windows)
+@usableFromInline let calloc = ucrt.calloc
+@usableFromInline let malloc = ucrt.malloc
+@usableFromInline let free = ucrt.free
+@usableFromInline let memset = ucrt.memset
+@usableFromInline let memcpy = ucrt.memcpy
+@usableFromInline let memcmp = ucrt.memcmp
+#endif
+
 #if canImport(Glibc)
 @usableFromInline let calloc = Glibc.calloc
 @usableFromInline let malloc = Glibc.malloc

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -25,10 +25,8 @@ fileprivate let _close = Glibc.close(_:)
 #endif
 
 #if canImport(WinSDK)
-// We used to get the copy that was re-exported by CoreFoundation
-// but we want to explicitly depend on its types in this file,
-// so we need to make sure Swift doesn't think it's @_implementationOnly.
-import WinSDK
+import let WinSDK.INVALID_HANDLE_VALUE
+import struct WinSDK.HANDLE
 #endif
 
 extension NSError {

--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -10,6 +10,9 @@
 @_implementationOnly import CoreFoundation
 
 #if os(Windows)
+import let WinSDK.INVALID_FILE_ATTRIBUTES
+import WinSDK
+
 internal func joinPath(prefix: String, suffix: String) -> String {
     var pszPath: PWSTR?
 

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -18,6 +18,7 @@ fileprivate let UF_HIDDEN: Int32 = 1
 @_implementationOnly import CoreFoundation
 #if os(Windows)
 import CRT
+import WinSDK
 #endif
 
 #if os(Windows)

--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -8,6 +8,9 @@
 //
 
 @_implementationOnly import CoreFoundation
+#if os(Windows)
+import WinSDK
+#endif
 
 #if os(Android)
     // Android Glibc differs a little with respect to the Linux Glibc.

--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -8,6 +8,9 @@
 //
 
 @_implementationOnly import CoreFoundation
+#if os(Windows)
+import WinSDK
+#endif
 
 #if os(Windows)
 let validPathSeps: [Character] = ["\\", "/"]

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -9,6 +9,9 @@
 
 
 @_implementationOnly import CoreFoundation
+#if os(Windows)
+import WinSDK
+#endif
 
 internal let kCFURLPOSIXPathStyle = CFURLPathStyle.cfurlposixPathStyle
 internal let kCFURLWindowsPathStyle = CFURLPathStyle.cfurlWindowsPathStyle

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -8,16 +8,15 @@
 //
 
 @_implementationOnly import CoreFoundation
+#if os(Windows)
+import WinSDK
+import let WinSDK.HANDLE_FLAG_INHERIT
+import let WinSDK.STARTF_USESTDHANDLES
+import struct WinSDK.HANDLE
+#endif
 
 #if canImport(Darwin)
 import Darwin
-#endif
-
-#if canImport(WinSDK)
-// We used to get the copy that was re-exported by CoreFoundation
-// but we want to explicitly depend on its types in this file,
-// so we need to make sure Swift doesn't think it's @_implementationOnly.
-import WinSDK
 #endif
 
 extension Process {

--- a/Sources/Foundation/ProcessInfo.swift
+++ b/Sources/Foundation/ProcessInfo.swift
@@ -8,6 +8,9 @@
 //
 
 @_implementationOnly import CoreFoundation
+#if os(Windows)
+import WinSDK
+#endif
 
 public struct OperatingSystemVersion {
     public var majorVersion: Int

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -8,6 +8,9 @@
 //
 
 @_implementationOnly import CoreFoundation
+#if os(Windows)
+import WinSDK
+#endif
 
 #if canImport(Glibc)
 import Glibc


### PR DESCRIPTION
Add the missing imports for WinSDK and disambiguate the existing ones so resolve the issues identified when removing the SDK and using the `-vfsoverlay` flag to inject the overlay during the builds.