### PR TITLE
Replace calls to CFStringCreateWithCString with CFSTR macro

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -278,8 +278,11 @@ CF_PRIVATE CFStringRef _CFProcessNameString(void) {
     static CFStringRef __CFProcessNameString = NULL;
     if (!__CFProcessNameString) {
         const char *processName = *_CFGetProgname();
-        if (!processName) processName = "";
-        CFStringRef newStr = CFStringCreateWithCString(kCFAllocatorSystemDefault, processName, kCFPlatformInterfaceStringEncoding);
+        CFStringRef newStr;
+        if (processName)
+            newStr  = CFStringCreateWithCString(kCFAllocatorSystemDefault, processName, kCFPlatformInterfaceStringEncoding);
+        else
+            newStr = CFSTR("");
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"
         if (!OSAtomicCompareAndSwapPtrBarrier(NULL, (void *) newStr, (void * volatile *)& __CFProcessNameString)) {
@@ -392,7 +395,7 @@ CF_PRIVATE CFStringRef _CFStringCreateHostName(void) {
     char myName[CFMaxHostNameSize];
 
     // return @"" instead of nil a la CFUserName() and Ali Ozer
-    if (0 != gethostname(myName, CFMaxHostNameSize)) myName[0] = '\0';
+    if (0 != gethostname(myName, CFMaxHostNameSize)) return CFSTR("");
     return CFStringCreateWithCString(kCFAllocatorSystemDefault, myName, kCFPlatformInterfaceStringEncoding);
 }
 

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -274,7 +274,7 @@ bool (*__CFObjCIsCollectable)(void *) = NULL;
 // The constant string class reference is set at link time to _NSCFConstantString
 void *__CFConstantStringClassReferencePtr = &_CF_CONSTANT_STRING_SWIFT_CLASS;
 #else
-#if !__CONSTANT_CFSTRINGS__
+#ifndef __CONSTANT_CFSTRINGS__
 // Compiler uses this symbol name; must match compiler built-in decl, so we use 'int'
 #if TARGET_RT_64_BIT
 int __CFConstantStringClassReference[24] = {0};

--- a/CoreFoundation/Locale.subproj/CFDateFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFDateFormatter.c
@@ -979,7 +979,7 @@ static CFMutableStringRef __createISO8601FormatString(CFISO8601DateFormatOptions
 }
 
 CFDateFormatterRef CFDateFormatterCreateISO8601Formatter(CFAllocatorRef allocator, CFISO8601DateFormatOptions formatOptions) {
-    CFStringRef localeStr = CFStringCreateWithCString(kCFAllocatorSystemDefault, "en_US_POSIX", kCFStringEncodingUTF8);
+    CFStringRef localeStr = CFSTR("en_US_POSIX");
     CFLocaleRef locale = CFLocaleCreate(kCFAllocatorSystemDefault, localeStr);
     CFDateFormatterRef ISO8601Formatter = __CreateCFDateFormatter(allocator, locale, kCFDateFormatterNoStyle, kCFDateFormatterNoStyle, kCFBooleanTrue);  // dateStyle and timeStyle are not relevant for ISO8601
 
@@ -991,7 +991,6 @@ CFDateFormatterRef CFDateFormatterCreateISO8601Formatter(CFAllocatorRef allocato
         }
     }
 
-    CFRelease(localeStr);
     CFRelease(locale);
 
     return ISO8601Formatter;

--- a/CoreFoundation/Preferences.subproj/CFPreferences.c
+++ b/CoreFoundation/Preferences.subproj/CFPreferences.c
@@ -558,7 +558,7 @@ CF_PRIVATE CFArrayRef _CFPreferencesCreateDomainList(CFStringRef  userName, CFSt
         return NULL;
     }
     if (hostName == kCFPreferencesAnyHost) {
-        suffix = CFStringCreateWithCString(prefAlloc, ".plist", kCFStringEncodingASCII);
+        suffix = CFSTR(".plist");
     } else if (hostName == kCFPreferencesCurrentHost) {
         CFStringRef hostID = _CFPreferencesGetByHostIdentifierString();
         suffix = CFStringCreateWithFormat(prefAlloc, NULL, CFSTR(".%@.plist"), hostID);

--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -4058,9 +4058,9 @@ static CFStringRef WindowsPathToURLPath(CFStringRef path, CFAllocatorRef alloc, 
     CFArrayRef urlComponents;
     CFStringRef str;
 
-    if (CFStringGetLength(path) == 0) return CFStringCreateWithCString(alloc, "", kCFStringEncodingASCII);
+    if (CFStringGetLength(path) == 0) return CFSTR("");
     urlComponents = WindowsPathToURLComponents(path, alloc, isDir, isAbsolute);
-    if (!urlComponents) return CFStringCreateWithCString(alloc, "", kCFStringEncodingASCII);
+    if (!urlComponents) return CFSTR("");
 
     // WindowsPathToURLComponents already added percent escapes for us; no need to add them again here.
     str = CFStringCreateByCombiningStrings(alloc, urlComponents, CFSTR("/"));


### PR DESCRIPTION
This would save performance by removing unnecessary calls to CFStringCreateWithCString.

Note: Windows cannot CFSTR to private symbols, so CFXMLInterface is excluded from changes.