### PR TITLE
Memory optimizations

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -496,20 +496,22 @@ CFTypeRef _CFRuntimeCreateInstance(CFAllocatorRef allocator, CFTypeID typeID, CF
     size = (size + 0xF) & ~0xF;	// CF objects are multiples of 16 in size
     // CFType version 0 objects are unscanned by default since they don't have write-barriers and hard retain their innards
     // CFType version 1 objects are scanned and use hand coded write-barriers to store collectable storage within
-    Boolean needsClear = false;
     CFRuntimeBase *memory = NULL;
     if (cls->version & _kCFRuntimeRequiresAlignment) {
         memory = _cf_aligned_calloc(align, size, cls->className);
+        if (NULL == memory) {
+            return NULL;
+        }
     } else if (__CFAllocatorRespectsHintZeroWhenAllocating(allocator)) {
         memory = (CFRuntimeBase *)CFAllocatorAllocate(allocator, size, _CFAllocatorHintZeroWhenAllocating);
+        if (NULL == memory) {
+            return NULL;
+        }
     } else {
         memory = (CFRuntimeBase *)CFAllocatorAllocate(allocator, size, 0);
-        needsClear = true;
-    }
-
-    if (NULL == memory) {
-	return NULL;
-    } else if (needsClear) {
+        if (NULL == memory) {
+            return NULL;
+        }
         memset(memory, 0, size);
     }
 

--- a/CoreFoundation/Base.subproj/CFUUID.c
+++ b/CoreFoundation/Base.subproj/CFUUID.c
@@ -166,8 +166,6 @@ CFUUIDRef CFUUIDCreate(CFAllocatorRef alloc) {
         if (useV1UUIDs == 1) uuid_generate_time(uuid); else uuid_generate_random(uuid);
         memcpy((void *)&bytes, uuid, sizeof(uuid));
 #else
-        //This bzero works around <rdar://problem/23381916>. It isn't actually needed, since the function will simply return NULL on this deployment target, anyway.
-        bzero(&bytes, sizeof(bytes));
         retval = 1;
 #endif
     });

--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -1058,7 +1058,7 @@ static void _CFLogvEx2Predicate(CFLogFunc logit, CFStringRef (*copyDescFunc)(voi
 #endif
     CFStringRef str = format ? _CFStringCreateWithFormatAndArgumentsAux2(kCFAllocatorSystemDefault, copyDescFunc, contextDescFunc, formatOptions, (CFStringRef)format, args) : 0;
     CFIndex blen = str ? CFStringGetMaximumSizeForEncoding(CFStringGetLength(str), kCFStringEncodingUTF8) + 1 : 0;
-    char *buf = str ? (char *)malloc(blen) : 0;
+    char *buf = str ? (char *)malloc(blen) : NULL;
     if (str && buf) {
 	Boolean converted = CFStringGetCString(str, buf, blen, kCFStringEncodingUTF8);
 	size_t len = strlen(buf);
@@ -1144,7 +1144,7 @@ void CFLog1(CFLogLevel lev, CFStringRef message) {
     const char *tag = "Swift"; // process name not available from NDK
     
     if (maxLength > sizeof(stack_buffer) / sizeof(stack_buffer[0])) {
-        buffer = calloc(sizeof(char), maxLength);
+        buffer = calloc(maxLength, sizeof(char));
         if (!buffer) {
             maxLength = sizeof(stack_buffer) / sizeof(stack_buffer[0]);
             buffer = &stack_buffer[0];

--- a/CoreFoundation/Collections.subproj/CFData.c
+++ b/CoreFoundation/Collections.subproj/CFData.c
@@ -282,13 +282,11 @@ static void *__CFDataAllocate(CFDataRef data, CFIndex size, Boolean clear) {
     if (__CFDataUseAllocator(data)) {
 	CFAllocatorRef allocator = __CFGetAllocator(data);
 	bytes = CFAllocatorAllocate(allocator, size, 0);
-	if (clear) memset((uint8_t *)bytes, 0, size);
+	if (clear) memset(bytes, 0, size);
+    } else if (clear) {
+        bytes = calloc(1, size);
     } else {
-        if (clear) {
-            bytes = calloc(1, size);
-        } else {
-            bytes = malloc(size);
-        }
+        bytes = malloc(size);
     }
     return bytes;
 }

--- a/CoreFoundation/Collections.subproj/CFStorage.c
+++ b/CoreFoundation/Collections.subproj/CFStorage.c
@@ -37,14 +37,6 @@
 #include <dispatch/dispatch.h>
 #endif
 
-#if TARGET_OS_WIN32
-// Remember to use _CF_RESTRICT instead of restrict, which is correctly defined for TARGET_OS_WIN32 elsewhere.
-
-// Replace bzero
-#define bzero(dst, size)    ZeroMemory(dst, size)
-
-#endif
-
 #if !defined(PAGE_SIZE)
 #define PAGE_SIZE 4096
 #endif
@@ -1275,13 +1267,13 @@ void CFStorageDeleteValues(CFStorageRef storage, CFRange range) {
 	/* Got a legitimately new root back.  If it is unfrozen, we can just acquire its guts.  If it is frozen, we have more work to do.  Note that we do not have to worry about releasing any existing children of the root, because __CFStorageDeleteUnfrozen already did that.  Also note that if we got a legitimately new root back, we must be a branch node, because if we were a leaf node, we would have been unfrozen and gotten ourself back. */
 	storage->rootNode.numBytes = newRoot->numBytes;
 	storage->rootNode.isLeaf = newRoot->isLeaf;
-	bzero(&storage->rootNode.info, sizeof storage->rootNode.info); //be a little paranoid here
+	memset(&storage->rootNode.info, 0, sizeof storage->rootNode.info); //be a little paranoid here
 	if (newRoot->isLeaf) {
 	    if (! newRoot->isFrozen) {
 		/* If the leaf is not frozen, we can just steal its memory (if any)!  If it is frozen, we must copy it. */
 		*((void **)&storage->rootNode.info.leaf.memory) = newRoot->info.leaf.memory;
-		/* Clear out the old node, because we stole its memory and we don't want it to deallocate it when teh node is destroyed below. */
-		bzero(&newRoot->info, sizeof newRoot->info);
+		/* Clear out the old node, because we stole its memory and we don't want it to deallocate it when the node is destroyed below. */
+		memset(&newRoot->info, 0, sizeof newRoot->info);
 	    }
 	    else {
 		/* The leaf is frozen, so we have to copy its memory.   */

--- a/CoreFoundation/Locale.subproj/CFCalendar.c
+++ b/CoreFoundation/Locale.subproj/CFCalendar.c
@@ -479,10 +479,8 @@ CF_PRIVATE Boolean _CFCalendarIsDateInWeekend(CFCalendarRef calendar, CFDateRef 
 
 CF_PRIVATE Boolean _CFCalendarGetNextWeekend(CFCalendarRef calendar, _CFCalendarWeekendRange *range) {
     // TODO: Double check this logic vs that in _NSCFCalendar
-    CFIndex weekdaysIndex[7];
-    memset(weekdaysIndex, '\0', sizeof(CFIndex)*7);
-    CFIndex firstWeekday = CFCalendarGetFirstWeekday(calendar);
-    weekdaysIndex[0] = firstWeekday;
+    CFIndex weekdaysIndex[7] = {0};
+    weekdaysIndex[0] = CFCalendarGetFirstWeekday(calendar);
     for (CFIndex i = 1; i < 7; i++) {
         weekdaysIndex[i] = (weekdaysIndex[i-1] % 7) + 1;
     }

--- a/CoreFoundation/Locale.subproj/CFListFormatter.c
+++ b/CoreFoundation/Locale.subproj/CFListFormatter.c
@@ -87,7 +87,7 @@ CFStringRef _CFListFormatterCreateStringByJoiningStrings(CFAllocatorRef allocato
     bool *needsFree = calloc(count, sizeof(bool));
 
     CFStringRef string;
-    for (int i = 0; i < count; ++i) {
+    for (CFIndex i = 0; i < count; ++i) {
         string = CFArrayGetValueAtIndex(strings, i);
         CFIndex const len = CFStringGetLength(string);
         UChar const *ucharString = CFStringGetCharactersPtr(string);
@@ -115,7 +115,7 @@ CFStringRef _CFListFormatterCreateStringByJoiningStrings(CFAllocatorRef allocato
         if (fmt) {
             __cficu_ulistfmt_close(fmt);
         }
-        for (int i = 0; i < count; ++i) {
+        for (CFIndex i = 0; i < count; ++i) {
             UChar *ucharString = ucharStrings[i];
             if (ucharString && needsFree[i]) {
                 free(ucharString);

--- a/CoreFoundation/Parsing.subproj/CFXMLInterface.c
+++ b/CoreFoundation/Parsing.subproj/CFXMLInterface.c
@@ -1083,7 +1083,7 @@ CFStringRef _CFXMLNodeCopyPrefix(_CFXMLNodePtr node) {
 
 void _CFXMLValidityErrorHandler(void* ctxt, const char* msg, ...);
 void _CFXMLValidityErrorHandler(void* ctxt, const char* msg, ...) {
-    char* formattedMessage = calloc(1, 1024);
+    char* formattedMessage = calloc(1024, 1);
 
     va_list args;
     va_start(args, msg);
@@ -1247,7 +1247,7 @@ _CFXMLDTDNodePtr _Nullable _CFXMLDTDGetAttributeDesc(_CFXMLDTDPtr dtd, const uns
 
 _CFXMLDTDNodePtr _Nullable _CFXMLDTDGetNotationDesc(_CFXMLDTDPtr dtd, const unsigned char* name) {
     xmlNotationPtr notation = xmlGetDtdNotationDesc(dtd, name);
-    _cfxmlNotation *notationPtr = calloc(sizeof(_cfxmlNotation), 1);
+    _cfxmlNotation *notationPtr = calloc(1, sizeof(_cfxmlNotation));
     notationPtr->type = XML_NOTATION_NODE;
     notationPtr->notation = notation;
     notationPtr->parent = dtd;

--- a/CoreFoundation/PlugIn.subproj/CFBundle_InfoPlist.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_InfoPlist.c
@@ -50,8 +50,8 @@ CF_EXPORT CFStringRef _CFGetProductName(void) {
             _cfBundlePlatform = CFSTR("");
 #else
             char buffer[256];
-            memset(buffer, 0, sizeof(buffer));
             size_t buflen = sizeof(buffer);
+            memset(buffer, 0, buflen);
             int ret = sysctlbyname("hw.machine", buffer, &buflen, NULL, 0);
             if (0 == ret || (-1 == ret && ENOMEM == errno)) {
 #if TARGET_OS_IOS

--- a/CoreFoundation/RunLoop.subproj/CFSocket.c
+++ b/CoreFoundation/RunLoop.subproj/CFSocket.c
@@ -1338,8 +1338,7 @@ static void *__CFSocketManager(void * arg)
         }
 
         if (exceptfds == NULL) {
-            exceptfds = (fd_set*) malloc(maxnrfds * NFDBITS);
-            bzero(exceptfds, maxnrfds * NFDBITS);
+            exceptfds = (fd_set*) calloc(maxnrfds, NFDBITS);
         }
 #endif
 

--- a/CoreFoundation/Stream.subproj/CFConcreteStreams.c
+++ b/CoreFoundation/Stream.subproj/CFConcreteStreams.c
@@ -236,10 +236,7 @@ CF_PRIVATE Boolean fdCanRead(int fd) {
         FD_ZERO(&readSet);
         readSetPtr = &readSet;
     } else {
-        int size = howmany(fd+1, NFDBITS) * sizeof(uint32_t);
-        uint32_t *fds_bits = (uint32_t *)malloc(size);
-        memset(fds_bits, 0, size);
-        readSetPtr = (fd_set *)fds_bits;
+        readSetPtr = (fd_set *)calloc(howmany(fd+1, NFDBITS), sizeof(uint32_t));
     }
     FD_SET(fd, readSetPtr);
     result = (select(fd + 1, readSetPtr, NULL, NULL, &timeout) == 1) ? TRUE : FALSE;
@@ -299,10 +296,7 @@ CF_PRIVATE Boolean fdCanWrite(int fd) {
         FD_ZERO(&writeSet);
         writeSetPtr = &writeSet;
     } else {
-        int size = howmany(fd+1, NFDBITS) * sizeof(uint32_t);
-        uint32_t *fds_bits = (uint32_t *)malloc(size);
-        memset(fds_bits, 0, size);
-        writeSetPtr = (fd_set *)fds_bits;
+        writeSetPtr = (fd_set *)calloc(howmany(fd+1, NFDBITS), sizeof(uint32_t));
     }
     FD_SET(fd, writeSetPtr);
     result = (select(fd + 1, NULL, writeSetPtr, NULL, &timeout) == 1) ? TRUE : FALSE;

--- a/CoreFoundation/URL.subproj/CFURLComponents_URIParser.c
+++ b/CoreFoundation/URL.subproj/CFURLComponents_URIParser.c
@@ -714,7 +714,7 @@ CF_PRIVATE Boolean _CFURIParserParseURIReference(CFStringRef urlString, struct _
     UniChar currentUniChar;
     
     // clear the parseInfo
-    bzero(parseInfo, sizeof(*parseInfo));
+    memset(parseInfo, 0, sizeof(*parseInfo));
     
     // Make sure the URL string isn't too long. We're limiting it to 2GB for backwards compatibility with 32-bit excutables using NS/CFURL
     if ( (urlStringLength > 0) && (urlStringLength <= INT_MAX) )


### PR DESCRIPTION
We can replace bzero with memset, and malloc + memset with calloc.

In addition, cases where the size and number arguments of calloc were swapped were corrected.