### PR TITLE
Rename CFBasicHashFindBucket.m to CFBasicHashFindBucket.c

### DIFF
--- a/CoreFoundation/Collections.subproj/CFBasicHash.c
+++ b/CoreFoundation/Collections.subproj/CFBasicHash.c
@@ -804,73 +804,73 @@ static uintptr_t __CFBasicHashFold(uintptr_t dividend, uint8_t idx) {
 #define FIND_BUCKET_HASH_STYLE		1
 #define FIND_BUCKET_FOR_REHASH		0
 #define FIND_BUCKET_FOR_INDIRECT_KEY	0
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Linear_NoCollision
 #define FIND_BUCKET_HASH_STYLE		1
 #define FIND_BUCKET_FOR_REHASH		1
 #define FIND_BUCKET_FOR_INDIRECT_KEY	0
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Linear_Indirect
 #define FIND_BUCKET_HASH_STYLE		1
 #define FIND_BUCKET_FOR_REHASH		0
 #define FIND_BUCKET_FOR_INDIRECT_KEY	1
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Linear_Indirect_NoCollision
 #define FIND_BUCKET_HASH_STYLE		1
 #define FIND_BUCKET_FOR_REHASH		1
 #define FIND_BUCKET_FOR_INDIRECT_KEY	1
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Double
 #define FIND_BUCKET_HASH_STYLE		2
 #define FIND_BUCKET_FOR_REHASH		0
 #define FIND_BUCKET_FOR_INDIRECT_KEY	0
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Double_NoCollision
 #define FIND_BUCKET_HASH_STYLE		2
 #define FIND_BUCKET_FOR_REHASH		1
 #define FIND_BUCKET_FOR_INDIRECT_KEY	0
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Double_Indirect
 #define FIND_BUCKET_HASH_STYLE		2
 #define FIND_BUCKET_FOR_REHASH		0
 #define FIND_BUCKET_FOR_INDIRECT_KEY	1
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Double_Indirect_NoCollision
 #define FIND_BUCKET_HASH_STYLE		2
 #define FIND_BUCKET_FOR_REHASH		1
 #define FIND_BUCKET_FOR_INDIRECT_KEY	1
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Exponential
 #define FIND_BUCKET_HASH_STYLE		3
 #define FIND_BUCKET_FOR_REHASH		0
 #define FIND_BUCKET_FOR_INDIRECT_KEY	0
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Exponential_NoCollision
 #define FIND_BUCKET_HASH_STYLE		3
 #define FIND_BUCKET_FOR_REHASH		1
 #define FIND_BUCKET_FOR_INDIRECT_KEY	0
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Exponential_Indirect
 #define FIND_BUCKET_HASH_STYLE		3
 #define FIND_BUCKET_FOR_REHASH		0
 #define FIND_BUCKET_FOR_INDIRECT_KEY	1
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 #define FIND_BUCKET_NAME		___CFBasicHashFindBucket_Exponential_Indirect_NoCollision
 #define FIND_BUCKET_HASH_STYLE		3
 #define FIND_BUCKET_FOR_REHASH		1
 #define FIND_BUCKET_FOR_INDIRECT_KEY	1
-#include "CFBasicHashFindBucket.m"
+#include "CFBasicHashFindBucket.c"
 
 
 CF_INLINE CFBasicHashBucket __CFBasicHashFindBucket(CFConstBasicHashRef ht, uintptr_t stack_key) {

--- a/CoreFoundation/Collections.subproj/CFBasicHashFindBucket.c
+++ b/CoreFoundation/Collections.subproj/CFBasicHashFindBucket.c
@@ -1,4 +1,4 @@
-/*	CFBasicHashFindBucket.m
+/*	CFBasicHashFindBucket.c
 	Copyright (c) 2009-2019, Apple Inc. and the Swift project authors
  
 	Portions Copyright (c) 2014-2019, Apple Inc. and the Swift project authors


### PR DESCRIPTION
CFBasicHashFindBucket.m has pure C code, and no need for anything Objective-C related, not to mention this file should be able to be compiled on non-Objective-C compilers.