### PR TITLE
Fix incorrect test_multiProcesses path equality expectation

### DIFF
--- a/Tests/Foundation/Tests/TestProcess.swift
+++ b/Tests/Foundation/Tests/TestProcess.swift
@@ -800,7 +800,7 @@ class TestProcess : XCTestCase {
         do {
             let data = try XCTUnwrap(pipe3.fileHandleForReading.readToEnd())
             let pwd = String.init(decoding: data, as: UTF8.self).trimmingCharacters(in: CharacterSet(["\n", "\r"]))
-            XCTAssertEqual(pwd, FileManager.default.currentDirectoryPath.standardizePath())
+            XCTAssertEqual(pwd, FileManager.default.currentDirectoryPath)
         } catch {
             XCTFail("\(error)")
         }


### PR DESCRIPTION
`test_multiProcesses` was failing in the Windows build when running under a substitute drive (mapping `S:` to `C:\foo\bar`) because it was expecting equality between `FileManager.default.currentDirectoryPath` and `FileManager.default.currentDirectoryPath.standardizePath()`, the latter of which resolves substitute drives.

See `xdgTestHelper`'s `--getcwd`:
https://github.com/apple/swift-corelibs-foundation/blob/5c1d6f67642ad7ce0d94b657bdb8a268fd18e570/Tests/Tools/XDGTestHelper/main.swift#L229

A different test, `test_pipe_stdout` was already doing this comparison properly:
https://github.com/apple/swift-corelibs-foundation/blob/5c1d6f67642ad7ce0d94b657bdb8a268fd18e570/Tests/Foundation/Tests/TestProcess.swift#L126