### PR TITLE
Include accuracy for point and size transformation checks

### DIFF
--- a/Tests/Foundation/Tests/TestAffineTransform.swift
+++ b/Tests/Foundation/Tests/TestAffineTransform.swift
@@ -72,13 +72,27 @@ extension TestAffineTransform {
         
         let nsTransform = transform as NSAffineTransform
         XCTAssertEqual(
-            nsTransform.transform(point), newPoint,
-            "Expected NSAffineTransform to match AffineTransform's point-accepting transform(_:)",
+            nsTransform.transform(point).x, newPoint.x,
+            accuracy: accuracyThreshold,
+            "Expected NSAffineTransform x to match AffineTransform's point-accepting transform(_:)",
             file: file, line: line
         )
         XCTAssertEqual(
-            nsTransform.transform(size), newSize,
-            "Expected NSAffineTransform to match AffineTransform's size-accepting transform(_:)",
+            nsTransform.transform(point).y, newPoint.y,
+            accuracy: accuracyThreshold,
+            "Expected NSAffineTransform y to match AffineTransform's point-accepting transform(_:)",
+            file: file, line: line
+        )
+        XCTAssertEqual(
+            nsTransform.transform(size).width, newSize.width,
+            accuracy: accuracyThreshold,
+            "Expected NSAffineTransform width to match AffineTransform's size-accepting transform(_:)",
+            file: file, line: line
+        )
+        XCTAssertEqual(
+            nsTransform.transform(size).height, newSize.height,
+            accuracy: accuracyThreshold,
+            "Expected NSAffineTransform height to match AffineTransform's size-accepting transform(_:)",
             file: file, line: line
         )
         


### PR DESCRIPTION
The `TestAffineTransform.testInversion` case was failing for me on macOS 13.3 with:

```
TestAffineTransform.swift:692: error: -[SkipFoundationTests.TestAffineTransform testInversion] : XCTAssertEqual failed: ("(10.0, 10.000000000000002)") is not equal to ("(9.999999999999998, 10.000000000000002)") - Expected NSAffineTransform to match AffineTransform's point-accepting transform(_:)

TestAffineTransform.swift:692: error: -[SkipFoundationTests.TestAffineTransform testInversion] : XCTAssertEqual failed: ("(10.000000000000004, 10.000000000000002)") is not equal to ("(10.000000000000002, 10.000000000000002)") - Expected NSAffineTransform to match AffineTransform's size-accepting transform(_:)
```

This PR resolves it by including the accuracy in the `XCTAssertEqual` for the `CGPoint` and `CGSize` instances.