### PR TITLE
Update the UnitMass.pounds coefficient to be more precise

### DIFF
--- a/Sources/Foundation/Unit.swift
+++ b/Sources/Foundation/Unit.swift
@@ -1843,7 +1843,7 @@ public final class UnitMass : Dimension {
         static let nanograms    = 1e-12
         static let picograms    = 1e-15
         static let ounces       = 0.0283495
-        static let pounds       = 0.453592
+        static let pounds       = 0.45359237
         static let stones       = 0.157473
         static let metricTons   = 1000.0
         static let shortTons    = 907.185


### PR DESCRIPTION
The current coefficient for UnitMass.pounds should be more precise.

**For example:**  

<img width="994" alt="Screenshot 2023-04-04 at 8 14 38 PM" src="https://user-images.githubusercontent.com/11606120/229956352-c5f57781-f3cc-4f31-920d-e5e29023c72f.png">

