### PR TITLE
waitUntilExit: ignore RunLoop.run()'s return value

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1179,7 +1179,7 @@ void __CFInitialize(void) {
     if (!__CFInitialized && !__CFInitializing) {
         __CFInitializing = 1;
 
-#if __HAS_DISPATCH__
+#if __HAS_DISPATCH__ && !TARGET_OS_MAC
     // libdispatch has to be initialized before CoreFoundation, so to avoid
     // issues with static initializer ordering, we are doing it explicitly.
     libdispatch_init();

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -1134,14 +1134,17 @@ open class Process: NSObject {
     open func waitUntilExit() {
         let runInterval = 0.05
         let currentRunLoop = RunLoop.current
-        let checkRunLoop : () -> Bool = (currentRunLoop == self.runLoop)
-                ? { currentRunLoop.run(mode: .default, before: Date(timeIntervalSinceNow: runInterval)) }
-                : { currentRunLoop.run(until: Date(timeIntervalSinceNow: runInterval)); return true }
 
-        // update .runLoop to allow early wakeup.
+        let runRunLoop : () -> Void = (currentRunLoop == self.runLoop)
+                ? { currentRunLoop.run(mode: .default, before: Date(timeIntervalSinceNow: runInterval)) }
+                : { currentRunLoop.run(until: Date(timeIntervalSinceNow: runInterval)) }
+        // update .runLoop to allow early wakeup triggered by terminateRunLoop.
         self.runLoop = currentRunLoop
-        while self.isRunning && checkRunLoop() {}
-        
+
+        while self.isRunning {
+            runRunLoop()
+        } 
+
         self.runLoop = nil
         self.runLoopSource = nil
     }


### PR DESCRIPTION
We've been seeing frequent (but not reproducible in isolation) failures in our builds where waitUntilExit returns but terminationStatus fails its precondition on hasFinished because isRunning is still true. This is a speculative fix, since I haven't been able to reproduce the failure in a self-contained test.

This should be safe since Process.waitUntilExit isn't spec'd to relate to RunLoop. In particular there is no guarantee that "stopping" a RunLoop should cause waitUntilExit to return before the monitored process has exited.

---

Unrelated to the above, the [second commit](https://github.com/apple/swift-corelibs-foundation/pull/4740/commits/5404e239d28e1ab32d7b58b5338980620cb5ea06) in this PR is required to unbreak XCTest's tests, which are run as part of this repo's CI (and so is required to be able to get a green run for this PR).
Absent that commit, XCTest's tests exit -5 on my M1 Pro and -4 on CI (with no output). On my machine, Console reveals:
```
BUG IN CLIENT OF LIBPTHREAD: workgroup functions already installed
Abort Cause 8313026928
```
and running under lldb blames `CFRuntime.c:1185`'s call to `libdispatch_init()`.
Breaking on `libdispatch_init` in lldb confirms `libdispatch_init()` is called twice, first by `swift-corelibs-libdispatch/src/init.c` in an `__attribute__((constructor))` and the second in the site being disabled in this commit.
