### PR TITLE
Change equalityOracle to compare based on values rather than indices

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestDate.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDate.swift
@@ -133,7 +133,7 @@ class TestDate : XCTestCase {
             dateWithString("2010-05-17 14:50:47 -0700"),
             dateWithString("2010-05-17 14:49:48 -0700"),
         ]
-        checkHashable(values, equalityOracle: { $0 == $1 })
+        checkHashable(values, equalityOracle: { values[$0] == values[$1] })
     }
 
     func test_AnyHashableContainingDate() {


### PR DESCRIPTION
It appears that the `checkHashable` is mistakenly using an `equalityOracle` that merely compares the two index arguments themselves, rather than the underlying values at those index arguments. And so the comparison will always pass, regardless of whether the underlying values were different.

This appears to be a problem throughout the test cases, but this PR only fixes the check in TestDate.