### PR TITLE
Foundation: implement `Bundle.init(for:)` on Windows

### DIFF
--- a/Sources/Foundation/Bundle.swift
+++ b/Sources/Foundation/Bundle.swift
@@ -107,12 +107,6 @@ open class Bundle: NSObject {
         self.init(path: url.path)
     }
     
-    #if os(Windows)
-    @available(Windows, deprecated, message: "Not yet implemented.")
-    public init(for aClass: AnyClass) {
-        NSUnimplemented()
-    }
-    #else
     public init(for aClass: AnyClass) {
         let pointerInImageOfClass = _getTypeContextDescriptor(of: aClass)
         guard let imagePath = _CFBundleCopyLoadedImagePathForAddress(pointerInImageOfClass)?._swiftObject else {
@@ -138,7 +132,6 @@ open class Bundle: NSObject {
         let bundle = _CFBundleCreateWithExecutableURLIfMightBeBundle(kCFAllocatorSystemDefault, url._cfObject)?.takeRetainedValue()
         _bundleStorage = bundle ?? CFBundleGetMainBundle()
     }
-    #endif
 
     public init?(identifier: String) {
         super.init()

--- a/Tests/Foundation/Tests/TestBundle.swift
+++ b/Tests/Foundation/Tests/TestBundle.swift
@@ -560,8 +560,11 @@ class TestBundle : XCTestCase {
         let maybeURL = Bundle.main.executableURL
         XCTAssertNotNil(maybeURL)
         guard let url = maybeURL else { return }
-        
-        XCTAssertEqual(url.path, ProcessInfo.processInfo._processPath)
+
+        let path = url.withUnsafeFileSystemRepresentation {
+            String(cString: $0!)
+        }
+        XCTAssertEqual(path, ProcessInfo.processInfo._processPath)
     }
 #endif
     
@@ -585,7 +588,7 @@ class TestBundle : XCTestCase {
             ("test_bundleForClass", testExpectedToFailOnWindows(test_bundleForClass, "Functionality not yet implemented on Windows. SR-XXXX")),
         ]
         
-        #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT && !os(Windows)
+        #if NS_FOUNDATION_ALLOWS_TESTABLE_IMPORT
         tests.append(contentsOf: [
             ("test_mainBundleExecutableURL", test_mainBundleExecutableURL),
             ("test_bundleReverseBundleLookup", test_bundleReverseBundleLookup),


### PR DESCRIPTION
This was disabled due to the use of `dlsym` which has been removed in favour of CoreFoundation APIs.  Enable this code path and tweak the test to allow passing on Windows.  This function is required to support apple/swift-docc on Windows.