### PR TITLE
Foundation: add some type conversion extensions for Windows

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -146,7 +146,8 @@ add_library(Foundation
   URLQueryItem.swift
   URLResourceKey.swift
   UserDefaults.swift
-  UUID.swift)
+  UUID.swift
+  WinSDK+Extensions.swift)
 target_compile_definitions(Foundation PRIVATE
   DEPLOYMENT_RUNTIME_SWIFT)
 target_compile_options(Foundation PUBLIC

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -880,7 +880,7 @@ extension FileHandle {
                 if error == ERROR_ACCESS_DENIED {
                     var fileInfo = BY_HANDLE_FILE_INFORMATION()
                     GetFileInformationByHandle(self._handle, &fileInfo)
-                    if fileInfo.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY) {
+                    if fileInfo.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY {
                         translatedError = Int32(ERROR_DIRECTORY_NOT_SUPPORTED)
                     }
                 }

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -431,8 +431,8 @@ open class FileManager : NSObject {
                     }
 
                     let hiddenAttrs = isHidden
-                        ? attrs | DWORD(FILE_ATTRIBUTE_HIDDEN)
-                        : attrs & ~DWORD(FILE_ATTRIBUTE_HIDDEN)
+                        ? attrs | FILE_ATTRIBUTE_HIDDEN
+                        : attrs & ~FILE_ATTRIBUTE_HIDDEN
                     guard SetFileAttributesW(fsRep, hiddenAttrs) else {
                       throw _NSErrorWithWindowsError(GetLastError(), reading: false, paths: [path])
                     }
@@ -604,7 +604,7 @@ open class FileManager : NSObject {
 
 #if os(Windows)
         let attrs = attributes.dwFileAttributes
-        result[._hidden] = attrs & DWORD(FILE_ATTRIBUTE_HIDDEN) != 0
+        result[._hidden] = attrs & FILE_ATTRIBUTE_HIDDEN != 0
 #endif
         result[.ownerAccountID] = NSNumber(value: UInt64(s.st_uid))
         result[.groupOwnerAccountID] = NSNumber(value: UInt64(s.st_gid))
@@ -1295,9 +1295,9 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
 
 #if os(Windows)
     internal init(attributes: WIN32_FILE_ATTRIBUTE_DATA, atPath path: String) {
-        if attributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DEVICE) == DWORD(FILE_ATTRIBUTE_DEVICE) {
+        if attributes.dwFileAttributes & FILE_ATTRIBUTE_DEVICE == FILE_ATTRIBUTE_DEVICE {
             self = .typeCharacterSpecial
-        } else if attributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_REPARSE_POINT) == DWORD(FILE_ATTRIBUTE_REPARSE_POINT) {
+        } else if attributes.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT == FILE_ATTRIBUTE_REPARSE_POINT {
             // A reparse point may or may not actually be a symbolic link, we need to read the reparse tag
             let handle: HANDLE = (try? FileManager.default._fileSystemRepresentation(withPath: path) {
               CreateFileW($0, /*dwDesiredAccess=*/DWORD(0),
@@ -1318,7 +1318,7 @@ public struct FileAttributeType : RawRepresentable, Equatable, Hashable {
                 return
             }
             self = tagInfo.ReparseTag == IO_REPARSE_TAG_SYMLINK ? .typeSymbolicLink : .typeRegular
-        } else if attributes.dwFileAttributes & DWORD(FILE_ATTRIBUTE_DIRECTORY) == DWORD(FILE_ATTRIBUTE_DIRECTORY) {
+        } else if attributes.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY == FILE_ATTRIBUTE_DIRECTORY {
             // Note: Since Windows marks directory symlinks as both
             // directories and reparse points, having this after the
             // reparse point check implicitly encodes Windows

--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -767,7 +767,7 @@ internal func _NSCreateTemporaryFile(_ filePath: String) throws -> (Int32, Strin
                               DWORD(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE),
                               nil,
                               DWORD(OPEN_EXISTING),
-                              DWORD(FILE_ATTRIBUTE_NORMAL),
+                              FILE_ATTRIBUTE_NORMAL,
                               nil),
           h != INVALID_HANDLE_VALUE else {
       throw _NSErrorWithWindowsError(GetLastError(), reading: false)

--- a/Sources/Foundation/WinSDK+Extensions.swift
+++ b/Sources/Foundation/WinSDK+Extensions.swift
@@ -1,0 +1,35 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+#if os(Windows)
+import WinSDK
+
+internal var FILE_ATTRIBUTE_DEVICE: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_DEVICE)
+}
+
+internal var FILE_ATTRIBUTE_DIRECTORY: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_DIRECTORY)
+}
+
+internal var FILE_ATTRIBUTE_NORMAL: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_NORMAL)
+}
+
+internal var FILE_ATTRIBUTE_HIDDEN: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_HIDDEN)
+}
+
+internal var FILE_ATTRIBUTE_READONLY: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_READONLY)
+}
+
+internal var FILE_ATTRIBUTE_REPARSE_POINT: DWORD {
+    DWORD(WinSDK.FILE_ATTRIBUTE_REPARSE_POINT)
+}
+#endif


### PR DESCRIPTION
The file attribute flags are used extensively in the file manipulation code.  Explicitly converting to the value to `DWORD` adds no value and clutters the code.  Provide an internal overload to translate the type appropriately.