### PR TITLE
Foundation: add small extensions for URL

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -13,6 +13,16 @@
 import let WinSDK.INVALID_FILE_ATTRIBUTES
 import WinSDK
 
+extension URL {
+    internal var NTPath: String {
+        return "\\\\?\\\(CFURLCopyFileSystemPath(CFURLCopyAbsoluteURL(_cfObject), kCFURLWindowsPathStyle)!._swiftObject)"
+    }
+
+    internal func withUnsafeNTPath<Result>(_ body: (UnsafePointer<WCHAR>) throws -> Result) rethrows -> Result {
+        return try NTPath.withCString(encodedAs: UTF16.self, body)
+    }
+}
+
 internal func joinPath(prefix: String, suffix: String) -> String {
     var pszPath: PWSTR?
 


### PR DESCRIPTION
We need to convert the paths to NT style paths to get extended paths to work.  Provide the ability to query the NT style path and a helper to perform a callback with the C-style representation of the NT style path representation.