### PR TITLE
Tests: correct spelling of `/dev/null` on Windows

### DIFF
--- a/Tests/Foundation/Tests/TestFileManager.swift
+++ b/Tests/Foundation/Tests/TestFileManager.swift
@@ -322,7 +322,11 @@ class TestFileManager : XCTestCase {
         catch { XCTFail("\(error)") }
 
         // test against known undeletable file
+#if os(Windows)
+        XCTAssertFalse(fm.isDeletableFile(atPath: "NUL"))
+#else
         XCTAssertFalse(fm.isDeletableFile(atPath: "/dev/null"))
+#endif
     }
 
     func test_fileAttributes() throws {


### PR DESCRIPTION
Windows uses a per-directory `NUL` rather than a global `/dev/null`. Adjust the test to use the appropriate spelling rather than potentially seeing a random drive-relative path which may exist as a deletable file.