### PR TITLE
Add `NSDate.now`

### DIFF
--- a/Sources/Foundation/NSDate.swift
+++ b/Sources/Foundation/NSDate.swift
@@ -33,6 +33,8 @@ extension timeval {
 open class NSDate : NSObject, NSCopying, NSSecureCoding, NSCoding {
     typealias CFType = CFDate
     
+    open class var now: Date { Date() }
+
     open override var hash: Int {
         return Int(bitPattern: CFHash(_cfObject))
     }


### PR DESCRIPTION
This PR adds missing `NSDate.now`.
https://developer.apple.com/documentation/foundation/nsdate/3180113-now