### PR TITLE
Implement `ByteCountFormatter.copy()`

### DIFF
--- a/Sources/Foundation/ByteCountFormatter.swift
+++ b/Sources/Foundation/ByteCountFormatter.swift
@@ -67,7 +67,23 @@ open class ByteCountFormatter : Formatter {
         self.includesCount = !coder.decodeBool(forKey: "NSNoCount")
         self.isAdaptive = !coder.decodeBool(forKey: "NSNoAdaptive")
     }
-    
+
+    open override func copy(with zone: NSZone? = nil) -> Any {
+        let copied = ByteCountFormatter()
+        copied.allowedUnits = allowedUnits
+        copied.countStyle = countStyle
+        copied.allowsNonnumericFormatting = allowsNonnumericFormatting
+        copied.includesUnit = includesUnit
+        copied.includesCount = includesCount
+        copied.includesActualByteCount = includesActualByteCount
+        copied.isAdaptive = isAdaptive
+        copied.zeroPadsFractionDigits = zeroPadsFractionDigits
+        copied.formattingContext = formattingContext
+        copied.actualBytes = actualBytes
+        copied.numberFormatter = numberFormatter.copy(with: zone) as? NumberFormatter ?? NumberFormatter()
+        return copied
+    }
+
     open override func encode(with coder: NSCoder) {
         super.encode(with: coder)
         precondition(coder.allowsKeyedCoding)
@@ -144,7 +160,7 @@ open class ByteCountFormatter : Formatter {
     
     /* Create an instance of NumberFormatter for use in various methods
      */
-    private let numberFormatter = NumberFormatter()
+    private var numberFormatter = NumberFormatter()
     
     /* Shortcut for converting a byte count into a string without creating an ByteCountFormatter and an NSNumber. If you need to specify options other than countStyle, create an instance of ByteCountFormatter first.
      */

--- a/Tests/Foundation/Tests/TestByteCountFormatter.swift
+++ b/Tests/Foundation/Tests/TestByteCountFormatter.swift
@@ -456,6 +456,50 @@ class TestByteCountFormatter : XCTestCase {
         }
     }
 
+    func test_copy() throws {
+        let original = ByteCountFormatter()
+        original.allowedUnits = .useAll
+        original.countStyle = .decimal
+        original.allowsNonnumericFormatting = false
+        original.includesUnit = false
+        original.includesCount = false
+        original.includesActualByteCount = true
+        original.isAdaptive = false
+        original.zeroPadsFractionDigits = true
+        original.formattingContext = .dynamic
+
+        let copied = try XCTUnwrap(original.copy() as? ByteCountFormatter)
+        XCTAssertEqual(original.allowedUnits, copied.allowedUnits)
+        XCTAssertEqual(original.countStyle, copied.countStyle)
+        XCTAssertEqual(original.allowsNonnumericFormatting, copied.allowsNonnumericFormatting)
+        XCTAssertEqual(original.includesUnit, copied.includesUnit)
+        XCTAssertEqual(original.includesCount, copied.includesCount)
+        XCTAssertEqual(original.includesActualByteCount, copied.includesActualByteCount)
+        XCTAssertEqual(original.isAdaptive, copied.isAdaptive)
+        XCTAssertEqual(original.zeroPadsFractionDigits, copied.zeroPadsFractionDigits)
+        XCTAssertEqual(original.formattingContext, copied.formattingContext)
+
+        copied.allowedUnits = .useBytes
+        copied.countStyle = .binary
+        copied.allowsNonnumericFormatting = true
+        copied.includesUnit = true
+        copied.includesCount = true
+        copied.includesActualByteCount = false
+        copied.isAdaptive = true
+        copied.zeroPadsFractionDigits = false
+        copied.formattingContext = .standalone
+
+        XCTAssertNotEqual(original.allowedUnits, copied.allowedUnits)
+        XCTAssertNotEqual(original.countStyle, copied.countStyle)
+        XCTAssertNotEqual(original.allowsNonnumericFormatting, copied.allowsNonnumericFormatting)
+        XCTAssertNotEqual(original.includesUnit, copied.includesUnit)
+        XCTAssertNotEqual(original.includesCount, copied.includesCount)
+        XCTAssertNotEqual(original.includesActualByteCount, copied.includesActualByteCount)
+        XCTAssertNotEqual(original.isAdaptive, copied.isAdaptive)
+        XCTAssertNotEqual(original.zeroPadsFractionDigits, copied.zeroPadsFractionDigits)
+        XCTAssertNotEqual(original.formattingContext, copied.formattingContext)
+    }
+
     static var allTests: [(String, (TestByteCountFormatter) -> () throws -> Void)] {
         return [
             ("test_DefaultValues", test_DefaultValues),
@@ -479,6 +523,7 @@ class TestByteCountFormatter : XCTestCase {
             ("test_largeByteValues", test_largeByteValues),
             ("test_negativeByteValues", test_negativeByteValues),
             ("test_unarchivingFixtures", test_unarchivingFixtures),
+            ("test_copy", test_copy),
         ]
     }
     


### PR DESCRIPTION
This PR implements `ByteCountFormatter.copy(with:)` to implement `ByteCountFormatter.copy()`. Resolves #3214.