### PR TITLE
Fix `available` attributes

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestCalendar.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestCalendar.swift
@@ -114,7 +114,7 @@ class TestCalendar : XCTestCase {
 
     func test_properties() {
         // Mainly we want to just make sure these go through to the NSCalendar implementation at this point.
-        if #available(iOS 8.0, OSX 10.7, *) {
+        if #available(iOS 8.0, macOS 10.7, *) {
             var c = Calendar(identifier: .gregorian)
             // Use english localization
             c.locale = Locale(identifier: "en_US")
@@ -158,7 +158,7 @@ class TestCalendar : XCTestCase {
             XCTAssertEqual(Date(timeIntervalSince1970: 1468652400.0), d1)
             XCTAssertEqual(86400, ti)
             
-            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
                 let dateInterval = c.dateInterval(of: .day, for: d)
                 XCTAssertEqual(DateInterval(start: d1, duration: ti), dateInterval)
             }
@@ -202,7 +202,7 @@ class TestCalendar : XCTestCase {
             
             XCTAssertTrue(c.dateIntervalOfWeekend(containing: d, start: &d1, interval: &ti))
             
-            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
                 let thisWeekend = DateInterval(start: Date(timeIntervalSince1970: 1468652400.0), duration: 172800.0)
                 
                 XCTAssertEqual(thisWeekend, DateInterval(start: d1, duration: ti))
@@ -212,7 +212,7 @@ class TestCalendar : XCTestCase {
 
             XCTAssertTrue(c.nextWeekend(startingAfter: d, start: &d1, interval: &ti))
             
-            if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+            if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
                 let nextWeekend = DateInterval(start: Date(timeIntervalSince1970: 1469257200.0), duration: 172800.0)
             
                 XCTAssertEqual(nextWeekend, DateInterval(start: d1, duration: ti))

--- a/Darwin/Foundation-swiftoverlay-Tests/TestDateInterval.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestDateInterval.swift
@@ -23,7 +23,7 @@ class TestDateInterval : XCTestCase {
     }
 
     func test_compareDateIntervals() {
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+        if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
             let start = dateWithString("2010-05-17 14:49:47 -0700")
             let duration: TimeInterval = 10000000.0
             let testInterval1 = DateInterval(start: start, duration: duration)
@@ -45,7 +45,7 @@ class TestDateInterval : XCTestCase {
     }
 
     func test_isEqualToDateInterval() {
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+        if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
             let start = dateWithString("2010-05-17 14:49:47 -0700")
             let duration = 10000000.0
             let testInterval1 = DateInterval(start: start, duration: duration)
@@ -89,7 +89,7 @@ class TestDateInterval : XCTestCase {
     }
 
     func test_checkIntersection() {
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+        if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
             let start1 = dateWithString("2010-05-17 14:49:47 -0700")
             let end1 = dateWithString("2010-08-17 14:49:47 -0700")
             
@@ -112,7 +112,7 @@ class TestDateInterval : XCTestCase {
     }
 
     func test_validIntersections() {
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+        if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
             let start1 = dateWithString("2010-05-17 14:49:47 -0700")
             let end1 = dateWithString("2010-08-17 14:49:47 -0700")
             
@@ -139,7 +139,7 @@ class TestDateInterval : XCTestCase {
     }
 
     func test_containsDate() {
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+        if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
             let start = dateWithString("2010-05-17 14:49:47 -0700")
             let duration = 10000000.0
             
@@ -154,7 +154,7 @@ class TestDateInterval : XCTestCase {
     }
 
     func test_AnyHashableContainingDateInterval() {
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+        if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
             let start = dateWithString("2010-05-17 14:49:47 -0700")
             let duration = 10000000.0
             let values: [DateInterval] = [
@@ -172,7 +172,7 @@ class TestDateInterval : XCTestCase {
     }
 
     func test_AnyHashableCreatedFromNSDateInterval() {
-        if #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) {
+        if #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) {
             let start = dateWithString("2010-05-17 14:49:47 -0700")
             let duration = 10000000.0
             let values: [NSDateInterval] = [

--- a/Darwin/Foundation-swiftoverlay-Tests/TestMeasurement.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestMeasurement.swift
@@ -14,7 +14,7 @@ import Foundation
 import XCTest
 
 // We define our own units here so that we can have closer control over checking the behavior of just struct Measurement and not the rest of Foundation
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 class MyDimensionalUnit : Dimension {
     class var unitA : MyDimensionalUnit {
         return MyDimensionalUnit(symbol: "a", converter: UnitConverterLinear(coefficient: 1))
@@ -30,7 +30,7 @@ class MyDimensionalUnit : Dimension {
     }
 }
 
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 class CustomUnit : Unit {
     override init(symbol: String) {
         super.init(symbol: symbol)
@@ -44,7 +44,7 @@ class CustomUnit : Unit {
     public static let features = CustomUnit(symbol: "feature")
 }
 
-@available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
 class TestMeasurement : XCTestCase {
     
     func testBasicConstruction() {

--- a/Darwin/Foundation-swiftoverlay-Tests/TestPersonNameComponents.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestPersonNameComponents.swift
@@ -15,7 +15,7 @@ import CoreFoundation
 import XCTest
 
 class TestPersonNameComponents : XCTestCase {
-    @available(OSX 10.11, iOS 9.0, *)
+    @available(macOS 10.11, iOS 9.0, *)
     func makePersonNameComponents(givenName: String, familyName: String) -> PersonNameComponents {
         var result = PersonNameComponents()
         result.givenName = givenName
@@ -70,7 +70,7 @@ class TestPersonNameComponents : XCTestCase {
         }
     }
 
-    @available(OSX 10.11, iOS 9.0, *)
+    @available(macOS 10.11, iOS 9.0, *)
     func makeNSPersonNameComponents(givenName: String, familyName: String) -> NSPersonNameComponents {
         let result = NSPersonNameComponents()
         result.givenName = givenName

--- a/Sources/Foundation/Operation.swift
+++ b/Sources/Foundation/Operation.swift
@@ -756,7 +756,7 @@ extension OperationQueue {
     public static let defaultMaxConcurrentOperationCount: Int = -1
 }
 
-@available(OSX 10.5, *)
+@available(macOS 10.5, *)
 open class OperationQueue : NSObject, ProgressReporting {
     let __queueLock = NSLock()
     let __atomicLoad = NSLock()
@@ -1423,7 +1423,7 @@ open class OperationQueue : NSObject, ProgressReporting {
 extension OperationQueue {
     // These two functions are inherently a race condition and should be avoided if possible
     
-    @available(OSX, introduced: 10.5, deprecated: 100000, message: "access to operations is inherently a race condition, it should not be used. For barrier style behaviors please use addBarrierBlock: instead")
+    @available(macOS, introduced: 10.5, deprecated: 100000, message: "access to operations is inherently a race condition, it should not be used. For barrier style behaviors please use addBarrierBlock: instead")
     open var operations: [Operation] {
         get {
             return _operations(includingBarriers: false)
@@ -1431,7 +1431,7 @@ extension OperationQueue {
     }
     
     
-    @available(OSX, introduced: 10.6, deprecated: 100000)
+    @available(macOS, introduced: 10.6, deprecated: 100000)
     open var operationCount: Int {
         get {
             return _operationCount

--- a/Tests/Foundation/Tests/TestDateInterval.swift
+++ b/Tests/Foundation/Tests/TestDateInterval.swift
@@ -135,7 +135,7 @@ class TestDateInterval: XCTestCase {
     }
 
     func test_hashing() {
-        guard #available(iOS 10.10, OSX 10.12, tvOS 10.0, watchOS 3.0, *) else { return }
+        guard #available(iOS 10.10, macOS 10.12, tvOS 10.0, watchOS 3.0, *) else { return }
 
         let start1a = dateWithString("2019-04-04 17:09:23 -0700")
         let start1b = dateWithString("2019-04-04 17:09:23 -0700")

--- a/Tests/Foundation/Tests/TestNSTextCheckingResult.swift
+++ b/Tests/Foundation/Tests/TestNSTextCheckingResult.swift
@@ -76,7 +76,7 @@ class TestNSTextCheckingResult: XCTestCase {
 
 
     func test_rangeWithName() {
-        guard #available(OSX 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) else {
+        guard #available(macOS 10.13, iOS 11.0, watchOS 4.0, tvOS 11.0, *) else {
             return
         }
 


### PR DESCRIPTION
This PR replaces `OSX` with `macOS` in `available` attributes.