### PR TITLE
Foundation: Allow setting `.creationTime` file attribute on Windows

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -964,6 +964,8 @@ extension FileManager {
                                modificationTime: Date? = nil) throws {
       let stat = try _lstatFile(atPath: path, withFileSystemRepresentation: fsr)
 
+      var ctime: FILETIME =
+          FILETIME(from: time_t((creationTime ?? stat.creationDate).timeIntervalSince1970))
       var atime: FILETIME =
           FILETIME(from: time_t((accessTime ?? stat.lastAccessDate).timeIntervalSince1970))
       var mtime: FILETIME =
@@ -977,7 +979,7 @@ extension FileManager {
       }
       defer { CloseHandle(hFile) }
 
-      if !SetFileTime(hFile, nil, &atime, &mtime) {
+      if !SetFileTime(hFile, &ctime, &atime, &mtime) {
           throw _NSErrorWithWindowsError(GetLastError(), reading: false, paths: [path])
       }
 


### PR DESCRIPTION
For some reason, the `_updateTimes` method for windows, when calling `SetFileTime`, did not pass an argument for creation time. This resulted in being unable to set the creation time attribute of a file on Windows.