### PR TITLE
Add support for Musl libc

### DIFF
--- a/CoreFoundation/Base.subproj/CFUtilities.c
+++ b/CoreFoundation/Base.subproj/CFUtilities.c
@@ -1675,7 +1675,7 @@ CFDictionaryRef __CFGetEnvironment() {
         extern char **environ;
         char **envp = environ;
 #elif TARGET_OS_LINUX
-#if !defined(environ) && !TARGET_OS_ANDROID
+#if !defined(environ) && !TARGET_OS_ANDROID && defined(__GLIBC_PREREQ)
 #define environ __environ
 #endif
         char **envp = environ;

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -189,7 +189,7 @@ static dispatch_queue_t __ ## PREFIX ## Queue(void) {			\
 #define CF_RETAIN_BALANCED_ELSEWHERE(obj, identified_location) do { } while (0)
 #endif
 
-#if (TARGET_OS_LINUX && !TARGET_OS_ANDROID && !TARGET_OS_CYGWIN) || TARGET_OS_WIN32
+#if (TARGET_OS_LINUX && !TARGET_OS_ANDROID && !TARGET_OS_CYGWIN && defined(__GLIBC_PREREQ)) || TARGET_OS_WIN32
 CF_INLINE size_t
 strlcpy(char * dst, const char * src, size_t maxlen) {
     const size_t srclen = strlen(src);
@@ -300,7 +300,7 @@ typedef unsigned long fd_mask;
 #endif
     
 
-#if !TARGET_OS_CYGWIN && !TARGET_OS_BSD
+#if !TARGET_OS_CYGWIN && !TARGET_OS_BSD && defined(__GLIBC_PREREQ)
 #define issetugid() 0
 #endif
 

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -69,6 +69,7 @@
 #include <features.h>
 #include <termios.h>
 
+#if defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2, 28) == 0
 // required for statx() system call, glibc >=2.28 wraps the kernel function
 #include <sys/syscall.h>
@@ -78,6 +79,7 @@
 #include <linux/fs.h>
 #define AT_STATX_SYNC_AS_STAT   0x0000  /* - Do whatever stat() does */
 #endif //__GLIBC_PREREQ(2. 28)
+#endif // defined(__GLIBC_PREREQ)
 
 #ifndef __NR_statx
 #include <sys/stat.h>
@@ -562,7 +564,7 @@ CF_CROSS_PLATFORM_EXPORT int _CFOpenFile(const char *path, int opts);
 static inline int _direntNameLength(struct dirent *entry) {
 #ifdef _D_EXACT_NAMLEN  // defined on Linux
     return _D_EXACT_NAMLEN(entry);
-#elif TARGET_OS_ANDROID
+#elif TARGET_OS_ANDROID || !defined(__GLIBC_PREREQ)
     return strlen(entry->d_name);
 #else
     return entry->d_namlen;

--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -28,6 +28,13 @@
 @usableFromInline let memset = Glibc.memset
 @usableFromInline let memcpy = Glibc.memcpy
 @usableFromInline let memcmp = Glibc.memcmp
+#elseif canImport(Musl)
+@usableFromInline let calloc = Musl.calloc
+@usableFromInline let malloc = Musl.malloc
+@usableFromInline let free = Musl.free
+@usableFromInline let memset = Musl.memset
+@usableFromInline let memcpy = Musl.memcpy
+@usableFromInline let memcmp = Musl.memcmp
 #elseif canImport(WASILibc)
 @usableFromInline let calloc = WASILibc.calloc
 @usableFromInline let malloc = WASILibc.malloc

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -22,6 +22,11 @@ import Glibc
 fileprivate let _read = Glibc.read(_:_:_:)
 fileprivate let _write = Glibc.write(_:_:_:)
 fileprivate let _close = Glibc.close(_:)
+#elseif canImport(Musl)
+import Musl
+fileprivate let _read = Musl.read(_:_:_:)
+fileprivate let _write = Musl.write(_:_:_:)
+fileprivate let _close = Musl.close(_:)
 #endif
 
 #if canImport(WinSDK)

--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -281,7 +281,7 @@ open class Host: NSObject {
             }
             var hints = addrinfo()
             hints.ai_family = PF_UNSPEC
-#if os(macOS) || os(iOS) || os(Android) || os(OpenBSD)
+#if os(macOS) || os(iOS) || os(Android) || os(OpenBSD) || canImport(Musl)
             hints.ai_socktype = SOCK_STREAM
 #else
             hints.ai_socktype = Int32(SOCK_STREAM.rawValue)

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -488,8 +488,10 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             let createMode = Int(ucrt.S_IREAD) | Int(ucrt.S_IWRITE)
 #elseif canImport(Darwin)
             let createMode = Int(S_IRUSR) | Int(S_IWUSR) | Int(S_IRGRP) | Int(S_IWGRP) | Int(S_IROTH) | Int(S_IWOTH)
-#else
+#elseif canImport(Glibc)
             let createMode = Int(Glibc.S_IRUSR) | Int(Glibc.S_IWUSR) | Int(Glibc.S_IRGRP) | Int(Glibc.S_IWGRP) | Int(Glibc.S_IROTH) | Int(Glibc.S_IWOTH)
+#elseif canImport(Musl)
+            let createMode = Int(Musl.S_IRUSR) | Int(Musl.S_IWUSR) | Int(Musl.S_IRGRP) | Int(Musl.S_IWGRP) | Int(Musl.S_IROTH) | Int(Musl.S_IWOTH)
 #endif
             guard let fh = FileHandle(path: path, flags: flags, createMode: createMode) else {
                 throw _NSErrorWithErrno(errno, reading: false, path: path)

--- a/Sources/Foundation/NSSwiftRuntime.swift
+++ b/Sources/Foundation/NSSwiftRuntime.swift
@@ -14,8 +14,10 @@
 // This mimics the behavior of the swift sdk overlay on Darwin
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 @_exported import Darwin
-#elseif os(Linux) || os(Android) || CYGWIN || os(OpenBSD)
+#elseif canImport (Glibc)
 @_exported import Glibc
+#elseif canImport(Musl)
+@_exported import Musl
 #elseif os(WASI)
 @_exported import WASILibc
 #elseif os(Windows)

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -20,6 +20,8 @@ internal let kCFURLWindowsPathStyle = CFURLPathStyle.cfurlWindowsPathStyle
 import Darwin
 #elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 // NOTE: this represents PLATFORM_PATH_STYLE

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -776,7 +776,7 @@ open class Process: NSObject {
         }
 
         var taskSocketPair : [Int32] = [0, 0]
-#if os(macOS) || os(iOS) || os(Android) || os(OpenBSD)
+#if os(macOS) || os(iOS) || os(Android) || os(OpenBSD) || canImport(Musl)
         socketpair(AF_UNIX, SOCK_STREAM, 0, &taskSocketPair)
 #else
         socketpair(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0, &taskSocketPair)

--- a/Sources/Foundation/Thread.swift
+++ b/Sources/Foundation/Thread.swift
@@ -14,6 +14,8 @@ import WinSDK
 
 #if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 // WORKAROUND_SR9811
@@ -362,7 +364,7 @@ open class Thread : NSObject {
         let maxSupportedStackDepth = 128;
         let addrs = UnsafeMutablePointer<UnsafeMutableRawPointer?>.allocate(capacity: maxSupportedStackDepth)
         defer { addrs.deallocate() }
-#if os(Android) || os(OpenBSD)
+#if os(Android) || os(OpenBSD) || canImport(Musl)
         let count = 0
 #elseif os(Windows)
         let count = RtlCaptureStackBackTrace(0, DWORD(maxSupportedStackDepth),
@@ -383,7 +385,7 @@ open class Thread : NSObject {
     }
 
     open class var callStackSymbols: [String] {
-#if os(Android) || os(OpenBSD)
+#if os(Android) || os(OpenBSD) || canImport(Musl)
         return []
 #elseif os(Windows)
         let hProcess: HANDLE = GetCurrentProcess()

--- a/Sources/Tools/plutil/main.swift
+++ b/Sources/Tools/plutil/main.swift
@@ -12,6 +12,9 @@ import SwiftFoundation
 #elseif canImport(Glibc)
 import Foundation
 import Glibc
+#elseif canImport(Musl)
+import Foundation
+import Musl
 #elseif canImport(CRT)
 import Foundation
 import CRT


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.