### PR TITLE
Fix `UserDefaults.string(forKey:)` behavior

### DIFF
--- a/Sources/Foundation/UserDefaults.swift
+++ b/Sources/Foundation/UserDefaults.swift
@@ -147,7 +147,25 @@ open class UserDefaults: NSObject {
     }
     
     open func string(forKey defaultName: String) -> String? {
-        return object(forKey: defaultName) as? String
+        guard let aVal = object(forKey: defaultName) else {
+            return nil
+        }
+        if let bVal = aVal as? String {
+            return bVal
+        }
+        if let bVal = aVal as? Bool {
+            return NSNumber(value: bVal).stringValue
+        }
+        if let bVal = aVal as? Int {
+            return NSNumber(value: bVal).stringValue
+        }
+        if let bVal = aVal as? Float {
+            return NSNumber(value: bVal).stringValue
+        }
+        if let bVal = aVal as? Double {
+            return NSNumber(value: bVal).stringValue
+        }
+        return nil
     }
     
     open func array(forKey defaultName: String) -> [Any]? {

--- a/Tests/Foundation/Tests/TestUserDefaults.swift
+++ b/Tests/Foundation/Tests/TestUserDefaults.swift
@@ -30,6 +30,10 @@ class TestUserDefaults : XCTestCase {
 			("test_setValue_BoolFromString", test_setValue_BoolFromString ),
 			("test_setValue_IntFromString", test_setValue_IntFromString ),
 			("test_setValue_DoubleFromString", test_setValue_DoubleFromString ),
+			("test_setValue_StringFromBool", test_setValue_StringFromBool ),
+			("test_setValue_StringFromInt", test_setValue_StringFromInt ),
+			("test_setValue_StringFromFloat", test_setValue_StringFromFloat ),
+			("test_setValue_StringFromDouble", test_setValue_StringFromDouble ),
 			("test_volatileDomains", test_volatileDomains),
 			("test_persistentDomain", test_persistentDomain ),
 		]
@@ -245,6 +249,42 @@ class TestUserDefaults : XCTestCase {
 		XCTAssertEqual(defaults.double(forKey: "key1"), 12.34)
 	}
 	
+	func test_setValue_StringFromBool() {
+		let defaults = UserDefaults.standard
+
+		// Register a bool default value. UserDefaults.string(forKey:) is supposed to return the converted String value
+		defaults.set(true, forKey: "key1")
+
+		XCTAssertEqual(defaults.string(forKey: "key1"), "1")
+	}
+
+	func test_setValue_StringFromInt() {
+		let defaults = UserDefaults.standard
+
+		// Register a int default value. UserDefaults.string(forKey:) is supposed to return the converted String value
+		defaults.set(42, forKey: "key1")
+
+		XCTAssertEqual(defaults.string(forKey: "key1"), "42")
+	}
+
+	func test_setValue_StringFromFloat() {
+		let defaults = UserDefaults.standard
+
+		// Register a float default value. UserDefaults.string(forKey:) is supposed to return the converted String value
+		defaults.set(12.34 as Float, forKey: "key1")
+
+		XCTAssertEqual(defaults.string(forKey: "key1"), "12.34")
+	}
+
+	func test_setValue_StringFromDouble() {
+		let defaults = UserDefaults.standard
+
+		// Register a double default value. UserDefaults.string(forKey:) is supposed to return the converted String value
+		defaults.set(12.34, forKey: "key1")
+
+		XCTAssertEqual(defaults.string(forKey: "key1"), "12.34")
+	}
+
 	func test_volatileDomains() {
 		let dateKey = "A Date",
 		stringKey = "A String",


### PR DESCRIPTION
This PR fixes `UserDefaults.string(forKey:)` behavior for number values. Resolves #3362.
https://developer.apple.com/documentation/foundation/userdefaults/1416700-string

```swift
UserDefaults.standard.set(true, forKey: "key1")
UserDefaults.standard.set(42, forKey: "key2")
UserDefaults.standard.set(12.34 as Float, forKey: "key3")
UserDefaults.standard.set(12.34, forKey: "key4")
UserDefaults.standard.set("1234", forKey: "key5")

// on macOS
UserDefaults.standard.string(forKey: "key1") // "1"
UserDefaults.standard.string(forKey: "key2") // "42"
UserDefaults.standard.string(forKey: "key3") // "12.34"
UserDefaults.standard.string(forKey: "key4") // "12.34"
UserDefaults.standard.string(forKey: "key5") // "1234"

// on Linux
UserDefaults.standard.string(forKey: "key1") // nil
UserDefaults.standard.string(forKey: "key2") // nil
UserDefaults.standard.string(forKey: "key3") // nil
UserDefaults.standard.string(forKey: "key4") // nil
UserDefaults.standard.string(forKey: "key5") // "1234"
```