### PR TITLE
Fix `UserDefaults.integer(forKey:)` behavior

### DIFF
--- a/Sources/Foundation/UserDefaults.swift
+++ b/Sources/Foundation/UserDefaults.swift
@@ -173,6 +173,15 @@ open class UserDefaults: NSObject {
         if let bVal = aVal as? Int {
             return bVal
         }
+        if let bVal = aVal as? Bool {
+            return NSNumber(value: bVal).intValue
+        }
+        if let bVal = aVal as? Float {
+            return NSNumber(value: bVal).intValue
+        }
+        if let bVal = aVal as? Double {
+            return NSNumber(value: bVal).intValue
+        }
         if let bVal = aVal as? String {
             return NSString(string: bVal).integerValue
         }

--- a/Tests/Foundation/Tests/TestUserDefaults.swift
+++ b/Tests/Foundation/Tests/TestUserDefaults.swift
@@ -28,6 +28,9 @@ class TestUserDefaults : XCTestCase {
 			("test_setValue_NSData", test_setValue_NSData ),
 			("test_setValue_Data", test_setValue_Data ),
 			("test_setValue_BoolFromString", test_setValue_BoolFromString ),
+			("test_setValue_IntFromBool", test_setValue_IntFromBool ),
+			("test_setValue_IntFromFloat", test_setValue_IntFromFloat ),
+			("test_setValue_IntFromDouble", test_setValue_IntFromDouble ),
 			("test_setValue_IntFromString", test_setValue_IntFromString ),
 			("test_setValue_DoubleFromString", test_setValue_DoubleFromString ),
 			("test_volatileDomains", test_volatileDomains),
@@ -227,6 +230,33 @@ class TestUserDefaults : XCTestCase {
 		XCTAssertEqual(defaults.bool(forKey: "key1"), true)
 	}
 	
+	func test_setValue_IntFromBool() {
+		let defaults = UserDefaults.standard
+
+		// Register an int default value as a boolean. UserDefaults.integer(forKey:) is supposed to return the converted Int value
+		defaults.set(true, forKey: "key1")
+
+		XCTAssertEqual(defaults.integer(forKey: "key1"), 1)
+	}
+
+	func test_setValue_IntFromFloat() {
+		let defaults = UserDefaults.standard
+
+		// Register an int default value as a float. UserDefaults.integer(forKey:) is supposed to return the converted Int value
+		defaults.set(12.34 as Float, forKey: "key1")
+
+		XCTAssertEqual(defaults.integer(forKey: "key1"), 12)
+	}
+
+	func test_setValue_IntFromDouble() {
+		let defaults = UserDefaults.standard
+
+		// Register an int default value as a double. UserDefaults.integer(forKey:) is supposed to return the converted Int value
+		defaults.set(12.34, forKey: "key1")
+
+		XCTAssertEqual(defaults.integer(forKey: "key1"), 12)
+	}
+
 	func test_setValue_IntFromString() {
 		let defaults = UserDefaults.standard
 		


### PR DESCRIPTION
This PR fixes `UserDefaults.integer(forKey:)` behavior for boolean and floating-point values.
https://developer.apple.com/documentation/foundation/userdefaults/1407405-integer

```swift
UserDefaults.standard.set(true, forKey: "key1")
UserDefaults.standard.set(42, forKey: "key2")
UserDefaults.standard.set(12.34 as Float, forKey: "key3")
UserDefaults.standard.set(12.34, forKey: "key4")
UserDefaults.standard.set("1234", forKey: "key5")

// on macOS
UserDefaults.standard.integer(forKey: "key1") // 1
UserDefaults.standard.integer(forKey: "key2") // 42
UserDefaults.standard.integer(forKey: "key3") // 12
UserDefaults.standard.integer(forKey: "key4") // 12
UserDefaults.standard.integer(forKey: "key5") // 1234

// on Linux
UserDefaults.standard.integer(forKey: "key1") // 0
UserDefaults.standard.integer(forKey: "key2") // 42
UserDefaults.standard.integer(forKey: "key3") // 0
UserDefaults.standard.integer(forKey: "key4") // 0
UserDefaults.standard.integer(forKey: "key5") // 1234
```