### PR TITLE
Fix `UserDefaults.float(forKey:)` behavior

### DIFF
--- a/Sources/Foundation/UserDefaults.swift
+++ b/Sources/Foundation/UserDefaults.swift
@@ -186,6 +186,15 @@ open class UserDefaults: NSObject {
         if let bVal = aVal as? Float {
             return bVal
         }
+        if let bVal = aVal as? Bool {
+            return NSNumber(value: bVal).floatValue
+        }
+        if let bVal = aVal as? Int {
+            return NSNumber(value: bVal).floatValue
+        }
+        if let bVal = aVal as? Double {
+            return NSNumber(value: bVal).floatValue
+        }
         if let bVal = aVal as? String {
             return NSString(string: bVal).floatValue
         }

--- a/Tests/Foundation/Tests/TestUserDefaults.swift
+++ b/Tests/Foundation/Tests/TestUserDefaults.swift
@@ -29,6 +29,10 @@ class TestUserDefaults : XCTestCase {
 			("test_setValue_Data", test_setValue_Data ),
 			("test_setValue_BoolFromString", test_setValue_BoolFromString ),
 			("test_setValue_IntFromString", test_setValue_IntFromString ),
+			("test_setValue_FloatFromBool", test_setValue_FloatFromBool ),
+			("test_setValue_FloatFromInt", test_setValue_FloatFromInt ),
+			("test_setValue_FloatFromDouble", test_setValue_FloatFromDouble ),
+			("test_setValue_FloatFromString", test_setValue_FloatFromString ),
 			("test_setValue_DoubleFromString", test_setValue_DoubleFromString ),
 			("test_volatileDomains", test_volatileDomains),
 			("test_persistentDomain", test_persistentDomain ),
@@ -236,6 +240,42 @@ class TestUserDefaults : XCTestCase {
 		XCTAssertEqual(defaults.integer(forKey: "key1"), 1234)
 	}
 	
+	func test_setValue_FloatFromBool() {
+		let defaults = UserDefaults.standard
+
+		// Register a boolean default value. UserDefaults.float(forKey:) is supposed to return the converted Float value
+		defaults.set(true, forKey: "key1")
+
+		XCTAssertEqual(defaults.float(forKey: "key1"), 1)
+	}
+
+	func test_setValue_FloatFromInt() {
+		let defaults = UserDefaults.standard
+
+		// Register an integer default value. UserDefaults.float(forKey:) is supposed to return the converted Float value
+		defaults.set(42, forKey: "key1")
+
+		XCTAssertEqual(defaults.float(forKey: "key1"), 42)
+	}
+
+	func test_setValue_FloatFromDouble() {
+		let defaults = UserDefaults.standard
+
+		// Register a double default value. UserDefaults.float(forKey:) is supposed to return the converted Float value
+		defaults.set(12.34, forKey: "key1")
+
+		XCTAssertEqual(defaults.float(forKey: "key1"), 12.34)
+	}
+
+	func test_setValue_FloatFromString() {
+		let defaults = UserDefaults.standard
+
+		// Register a string default value. UserDefaults.float(forKey:) is supposed to return the parsed Float value
+		defaults.set("1234", forKey: "key1")
+
+		XCTAssertEqual(defaults.float(forKey: "key1"), 1234)
+	}
+
 	func test_setValue_DoubleFromString() {
 		let defaults = UserDefaults.standard
 		


### PR DESCRIPTION
This PR fixes `UserDefaults.float(forKey:)` behavior for missing number values.
https://developer.apple.com/documentation/foundation/userdefaults/1414027-float

```swift
UserDefaults.standard.set(true, forKey: "key1")
UserDefaults.standard.set(42, forKey: "key2")
UserDefaults.standard.set(12.34 as Float, forKey: "key3")
UserDefaults.standard.set(12.34, forKey: "key4")
UserDefaults.standard.set("1234", forKey: "key5")

// on macOS
UserDefaults.standard.float(forKey: "key1") // 1
UserDefaults.standard.float(forKey: "key2") // 42
UserDefaults.standard.float(forKey: "key3") // 12.34
UserDefaults.standard.float(forKey: "key4") // 12.34
UserDefaults.standard.float(forKey: "key5") // 1234

// on Linux
UserDefaults.standard.float(forKey: "key1") // 0
UserDefaults.standard.float(forKey: "key2") // 0
UserDefaults.standard.float(forKey: "key3") // 12.34
UserDefaults.standard.float(forKey: "key4") // 0
UserDefaults.standard.float(forKey: "key5") // 1234
```