### PR TITLE
Fix `UserDefaults.double(forKey:)` behavior

### DIFF
--- a/Sources/Foundation/UserDefaults.swift
+++ b/Sources/Foundation/UserDefaults.swift
@@ -235,6 +235,15 @@ open class UserDefaults: NSObject {
         if let bVal = aVal as? Double {
             return bVal
         }
+        if let bVal = aVal as? Bool {
+            return NSNumber(value: bVal).doubleValue
+        }
+        if let bVal = aVal as? Int {
+            return NSNumber(value: bVal).doubleValue
+        }
+        if let bVal = aVal as? Float {
+            return NSNumber(value: bVal).doubleValue
+        }
         if let bVal = aVal as? String {
             return NSString(string: bVal).doubleValue
         }

--- a/Tests/Foundation/Tests/TestUserDefaults.swift
+++ b/Tests/Foundation/Tests/TestUserDefaults.swift
@@ -36,6 +36,9 @@ class TestUserDefaults : XCTestCase {
 			("test_setValue_FloatFromInt", test_setValue_FloatFromInt ),
 			("test_setValue_FloatFromDouble", test_setValue_FloatFromDouble ),
 			("test_setValue_FloatFromString", test_setValue_FloatFromString ),
+			("test_setValue_DoubleFromBool", test_setValue_DoubleFromBool ),
+			("test_setValue_DoubleFromInt", test_setValue_DoubleFromInt ),
+			("test_setValue_DoubleFromFloat", test_setValue_DoubleFromFloat ),
 			("test_setValue_DoubleFromString", test_setValue_DoubleFromString ),
 			("test_setValue_StringFromBool", test_setValue_StringFromBool ),
 			("test_setValue_StringFromInt", test_setValue_StringFromInt ),
@@ -308,6 +311,33 @@ class TestUserDefaults : XCTestCase {
 		defaults.set("1234", forKey: "key1")
 
 		XCTAssertEqual(defaults.float(forKey: "key1"), 1234)
+	}
+
+	func test_setValue_DoubleFromBool() {
+		let defaults = UserDefaults.standard
+
+		// Register a boolean default value. UserDefaults.double(forKey:) is supposed to return the converted Double value
+		defaults.set(true, forKey: "key1")
+
+		XCTAssertEqual(defaults.double(forKey: "key1"), 1)
+	}
+
+	func test_setValue_DoubleFromInt() {
+		let defaults = UserDefaults.standard
+
+		// Register an integer default value. UserDefaults.double(forKey:) is supposed to return the converted Double value
+		defaults.set(42, forKey: "key1")
+
+		XCTAssertEqual(defaults.double(forKey: "key1"), 42)
+	}
+
+	func test_setValue_DoubleFromFloat() {
+		let defaults = UserDefaults.standard
+
+		// Register a float default value. UserDefaults.double(forKey:) is supposed to return the converted Double value
+		defaults.set(12.34 as Float, forKey: "key1")
+
+		XCTAssertEqual(defaults.double(forKey: "key1"), Double(12.34 as Float))
 	}
 
 	func test_setValue_DoubleFromString() {


### PR DESCRIPTION
This PR fixes `UserDefaults.double(forKey:)` behavior for missing number values.
https://developer.apple.com/documentation/foundation/userdefaults/1416581-double

```swift
UserDefaults.standard.set(true, forKey: "key1")
UserDefaults.standard.set(42, forKey: "key2")
UserDefaults.standard.set(12.34 as Float, forKey: "key3")
UserDefaults.standard.set(12.34, forKey: "key4")
UserDefaults.standard.set("1234", forKey: "key5")

// on macOS
UserDefaults.standard.double(forKey: "key1") // 1
UserDefaults.standard.double(forKey: "key2") // 42
UserDefaults.standard.double(forKey: "key3") // 12.34000015258789
UserDefaults.standard.double(forKey: "key4") // 12.34
UserDefaults.standard.double(forKey: "key5") // 1234

// on Linux
UserDefaults.standard.double(forKey: "key1") // 0
UserDefaults.standard.double(forKey: "key2") // 0
UserDefaults.standard.double(forKey: "key3") // 0
UserDefaults.standard.double(forKey: "key4") // 12.34
UserDefaults.standard.double(forKey: "key5") // 1234
```