### PR TITLE
Variable i may not be able to reach validPathCount if validPathCount is large enough

### DIFF
--- a/CoreFoundation/Base.subproj/CFFileUtilities.c
+++ b/CoreFoundation/Base.subproj/CFFileUtilities.c
@@ -1390,7 +1390,7 @@ CF_PRIVATE CFArrayRef _CFCreateCFArrayByTokenizingString(const char *values, cha
         }
         free(copyDirPath);
         CFArrayRef pathArray = CFArrayCreate(kCFAllocatorSystemDefault, (const void **)pathList  , validPathCount, &kCFTypeArrayCallBacks);
-        for(int i = 0; i < validPathCount; i ++) {
+        for(size_t i = 0; i < validPathCount; i ++) {
             CFRelease(pathList[i]);
         }
         return pathArray;


### PR DESCRIPTION
Should never happen, but in case it does, i should be a size_t, not an int.