### PR TITLE
Fix a concurrency bug in the TestFileHandle.test_readToEndOfFileAndNotify() unit test.

### DIFF
--- a/Tests/Foundation/Tests/TestFileHandle.swift
+++ b/Tests/Foundation/Tests/TestFileHandle.swift
@@ -481,8 +481,7 @@ class TestFileHandle : XCTestCase {
     
     func test_readToEndOfFileAndNotify() {
         let handle = createFileHandle()
-        var readSomeData = false
-        
+        let readSomeData = XCTestExpectation(description: "At least some data must've been read")
         let done = expectation(forNotification: FileHandle.readCompletionNotification, object: handle, notificationCenter: .default) { (notification) -> Bool in
             guard let data = notification.userInfo?[NSFileHandleNotificationDataItem] as? Data else {
                 XCTFail("Couldn't find the data in the user info: \(notification)")
@@ -490,7 +489,7 @@ class TestFileHandle : XCTestCase {
             }
             
             if !data.isEmpty {
-                readSomeData = true
+                readSomeData.fulfill()
                 handle.readInBackgroundAndNotify()
                 return false
             } else {
@@ -500,8 +499,7 @@ class TestFileHandle : XCTestCase {
         
         handle.readInBackgroundAndNotify()
         
-        wait(for: [done], timeout: 10)
-        XCTAssertTrue(readSomeData, "At least some data must've been read")
+        wait(for: [readSomeData, done], timeout: 10)
     }
     
     func test_readToEndOfFileAndNotify_readError() {


### PR DESCRIPTION
Fix a concurrency bug in the `TestFileHandle.test_readToEndOfFileAndNotify()` unit test.

This test fails to build when corelibs-xctest marks the expectation handler as `@Sendable`. The fix is to replace the use of a `Bool` value with a separate expectation.