### PR TITLE
[5.9] Forward unit test concurrency fix from main

### DIFF
--- a/Tests/Foundation/Tests/TestFileHandle.swift
+++ b/Tests/Foundation/Tests/TestFileHandle.swift
@@ -481,8 +481,7 @@ class TestFileHandle : XCTestCase {
     
     func test_readToEndOfFileAndNotify() {
         let handle = createFileHandle()
-        var readSomeData = false
-        
+        let readSomeData = XCTestExpectation(description: "At least some data must've been read")
         let done = expectation(forNotification: FileHandle.readCompletionNotification, object: handle, notificationCenter: .default) { (notification) -> Bool in
             guard let data = notification.userInfo?[NSFileHandleNotificationDataItem] as? Data else {
                 XCTFail("Couldn't find the data in the user info: \(notification)")
@@ -490,7 +489,7 @@ class TestFileHandle : XCTestCase {
             }
             
             if !data.isEmpty {
-                readSomeData = true
+                readSomeData.fulfill()
                 handle.readInBackgroundAndNotify()
                 return false
             } else {
@@ -500,8 +499,7 @@ class TestFileHandle : XCTestCase {
         
         handle.readInBackgroundAndNotify()
         
-        wait(for: [done], timeout: 10)
-        XCTAssertTrue(readSomeData, "At least some data must've been read")
+        wait(for: [readSomeData, done], timeout: 10)
     }
     
     func test_readToEndOfFileAndNotify_readError() {


### PR DESCRIPTION
**Explanation:** swift-corelibs-xctest is adopting some changes in 5.9 to improve concurrency support. This change fixes a unit test in this package that currently fails (due to a real bug in the test) when the XCTest changes are applied.
**Scope:** A fix to a unit test only. No effect on the primary package target.
**Issue:** #4787
**Risk:** No obvious risk.
**Testing:** Simply run the unit test and confirm it builds and passes.
**Reviewer:** @parkera _et al._