### PR TITLE
Foundation: use NT-style paths for `CopyFileW`

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -548,11 +548,13 @@ extension FileManager {
     }
 
     internal func _copyRegularFile(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
-      try FileManager.default._fileSystemRepresentation(withPath: srcPath, andPath: dstPath) {
-        if !CopyFileW($0, $1, false) {
-          throw _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [srcPath, dstPath])
+        try withNTPathRepresentation(of: srcPath) { wszSource in
+            try withNTPathRepresentation(of: dstPath) { wszDestination in
+                if !CopyFileW(wszSource, wszDestination, false) {
+                    throw _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [srcPath, dstPath])
+                }
+            }
         }
-      }
     }
 
     internal func _copySymlink(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {


### PR DESCRIPTION
When invoking `_copyRegularFile` ensure that we use the NT-style path to enable long file names on all targets.  This allows copying directories that contain a deeply nested path.