### PR TITLE
Foundation: improve relative path computation for iteration on Windows

### DIFF
--- a/Sources/Foundation/URL.swift
+++ b/Sources/Foundation/URL.swift
@@ -723,14 +723,6 @@ public struct URL : ReferenceConvertible, Equatable {
         return try block(fsRep)
     }
 
-#if os(Windows)
-    internal func _withUnsafeWideFileSystemRepresentation<ResultType>(_ block: (UnsafePointer<UInt16>?) throws -> ResultType) rethrows -> ResultType {
-      let fsr: UnsafePointer<UInt16> = _url._wideFileSystemRepresentation
-      defer { fsr.deallocate() }
-      return try block(fsr)
-    }
-#endif
-
     // MARK: -
     // MARK: Path manipulation
     


### PR DESCRIPTION
This partially corrects the relative path computation.  We no longer fail to create the file system representation if it exceeds `MAX_PATH` due to the switch to `withUnsafeNTPath`.  We will still fail to properly create the relative path if the paths are unrelated and if the relative path exceeds `MAX_PATH`.  However, this still is an improvement over the status quo.