### PR TITLE
Foundation: alter `NSData.contents(of:options:)` on Windows

### DIFF
--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -24,7 +24,7 @@ extension URL {
         #"\\?\\#(CFURLCopyFileSystemPath(CFURLCopyAbsoluteURL(_cfObject), kCFURLWindowsPathStyle)!._swiftObject)"#
     }
 
-    fileprivate func withUnsafeNTPath<Result>(_ body: (UnsafePointer<WCHAR>) throws -> Result) rethrows -> Result {
+    internal func withUnsafeNTPath<Result>(_ body: (UnsafePointer<WCHAR>) throws -> Result) rethrows -> Result {
         try self.NTPath.withCString(encodedAs: UTF16.self, body)
     }
 }

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -209,10 +209,16 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
 
     internal static func contentsOf(url: URL, options readOptionsMask: ReadingOptions = []) throws -> (result: NSData, textEncodingNameIfAvailable: String?) {
         if url.isFileURL {
+#if os(Windows)
+            return try url.withUnsafeNTPath {
+                return (try NSData.readBytesFromFileWithExtendedAttributes(String(decodingCString: $0, as: UTF16.self), options: readOptionsMask).toNSData(), nil)
+            }
+#else
             return try url.withUnsafeFileSystemRepresentation { (fsRep) -> (result: NSData, textEncodingNameIfAvailable: String?) in
               let data = try NSData.readBytesFromFileWithExtendedAttributes(String(cString: fsRep!), options: readOptionsMask)
               return (data.toNSData(), nil)
             }
+#endif
         } else {
             return try _NSNonfileURLContentLoader.current.contentsOf(url: url)
         }


### PR DESCRIPTION
We would previously use the FSR for the path, however, due to the expectations of FSR, we cannot support long paths with it.  Use the internal `withUnsafeNTPath` extension on `URL` to use a long path representation to support extended paths (>260 characters) on Windows.