### PR TITLE
Fix JSONDecoder.decode(_,from:) behavior

### DIFF
--- a/Tests/Foundation/Tests/TestJSONEncoder.swift
+++ b/Tests/Foundation/Tests/TestJSONEncoder.swift
@@ -474,6 +474,24 @@ class TestJSONEncoder : XCTestCase {
             XCTFail("Caught error during decoding empty super decoder: \(error)")
         }
     }
+    
+    func test_childTypeDecoder() {
+        class BaseTestType: Decodable { }
+        class ChildTestType: BaseTestType { }
+
+        func dynamicTestType() -> BaseTestType.Type {
+            return ChildTestType.self
+        }
+
+        let decoder = JSONDecoder()
+        do {
+            let testType = dynamicTestType()
+            let instance = try decoder.decode(testType, from: Data(#"{}"#.utf8))
+            XCTAssertTrue(instance is ChildTestType)
+        } catch {
+            XCTFail("Caught error during decoding empty super decoder: \(error)")
+        }
+    }
 
     // MARK: - Test encoding and decoding of built-in Codable types
     func test_codingOfBool() {
@@ -1562,6 +1580,7 @@ extension TestJSONEncoder {
             ("test_nestedContainerCodingPaths", test_nestedContainerCodingPaths),
             ("test_superEncoderCodingPaths", test_superEncoderCodingPaths),
             ("test_notFoundSuperDecoder", test_notFoundSuperDecoder),
+            ("test_childTypeDecoder", test_childTypeDecoder),
             ("test_codingOfBool", test_codingOfBool),
             ("test_codingOfNil", test_codingOfNil),
             ("test_codingOfInt8", test_codingOfInt8),


### PR DESCRIPTION
`JSONDecoder.decode(_,from:)` accepts  a generic parameter, but it does not use any concrete type in practice.
This PR fixes that use parameter `type` instead of `T.self`.

This PR solves #4806 

Example Code
```swift
import Foundation

class Base: Codable { }
class Child: Base { }

func dynamicType() -> Base.Type {
    return Child.self
}

let data = "{}".data(using: .utf8)!

let classType = dynamicType()
let instance = try JSONDecoder().decode(classType, from: data)
print("type: \(instance) => \(type(of: instance))")
```

on macOS:
```
type: JSONDecoderExample.Child => Child
```
on Linux:
```
type: JSONDecoderExample.Base => Base
```

