### PR TITLE
build: adjust the build for rebranch

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -152,6 +152,7 @@ target_compile_definitions(Foundation PRIVATE
   DEPLOYMENT_RUNTIME_SWIFT)
 target_compile_options(Foundation PUBLIC
   $<$<BOOL:${ENABLE_TESTING}>:-enable-testing>
+  "SHELL:-Xfrontend -disable-autolink-framework -Xfrontend CoreFoundation"
   "SHELL:-Xcc -F${CMAKE_BINARY_DIR}")
 target_link_libraries(Foundation
   PRIVATE

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -59,6 +59,7 @@ target_compile_options(FoundationNetworking PUBLIC
   # forced load symbol when validating the TBD
   -Xfrontend -validate-tbd-against-ir=none
   $<$<BOOL:${ENABLE_TESTING}>:-enable-testing>
+  "SHELL:-Xfrontend -disable-autolink-framework -Xfrontend CFURLSessionInterface"
   "SHELL:-Xcc -F${CMAKE_BINARY_DIR}")
 target_link_libraries(FoundationNetworking
   PRIVATE

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -10,6 +10,7 @@ target_compile_definitions(FoundationXML PRIVATE
   DEPLOYMENT_RUNTIME_SWIFT)
 target_compile_options(FoundationXML PUBLIC
   $<$<BOOL:${ENABLE_TESTING}>:-enable-testing>
+  "SHELL:-Xfrontend -disable-autolink-framework -Xfrontend CFXMLInterface"
   "SHELL:-Xcc -F${CMAKE_BINARY_DIR}")
 target_link_libraries(FoundationXML
   PRIVATE


### PR DESCRIPTION
The newer clang compiler prefers `module.modulemap` over `module.map`. This will result in us using the framework form of the module definitions for CoreFoundation. While this is fine for the compilation, the linker directive to link against the framework will also be emitted into the object files. This causes a linker failure on Windows as `-framework (CoreFoundation|CFURLInterface|CFXMLInterface)` is not a valid linker option. Use the swift control over the directives to avoid emitting the framework link directive to repair the build.