### PR TITLE
Fix the HTTPCookiePropertyKey.secure behavior.

### DIFF
--- a/Sources/FoundationNetworking/HTTPCookie.swift
+++ b/Sources/FoundationNetworking/HTTPCookie.swift
@@ -306,9 +306,9 @@ open class HTTPCookie : NSObject {
         _domain = canonicalDomain.lowercased()
 
         if let
-            secureString = properties[.secure] as? String, !secureString.isEmpty
+            secureString = properties[.secure] as? String
         {
-            _secure = true
+            _secure = secureString == "TRUE"
         } else {
             _secure = false
         }


### PR DESCRIPTION
Refer to " A string stating whether the cookie should be transmitted only over secure channels. String value must be either "TRUE" or "FALSE". Default is "FALSE". ". Resolves #3301 .