### PR TITLE
[5.9] Cherry-pick Fix divergent overwrite behavior of FileManager.copyItem(at:to:) on Linux and Windows

### DIFF
--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -584,7 +584,7 @@ extension FileManager {
         }
         defer { close(srcfd) }
 
-        let dstfd = open(dstRep, O_WRONLY | O_CREAT | O_TRUNC, 0o666)
+        let dstfd = open(dstRep, O_WRONLY | O_CREAT | O_EXCL | O_TRUNC, 0o666)
         guard dstfd >= 0 else {
             throw _NSErrorWithErrno(errno, reading: false, path: dstPath,
                                     extraUserInfo: extraErrorInfo(srcPath: srcPath, dstPath: dstPath, userVariant: variant))

--- a/Sources/Foundation/FileManager+Win32.swift
+++ b/Sources/Foundation/FileManager+Win32.swift
@@ -476,7 +476,7 @@ extension FileManager {
 
     internal func _copyRegularFile(atPath srcPath: String, toPath dstPath: String, variant: String = "Copy") throws {
       try FileManager.default._fileSystemRepresentation(withPath: srcPath, andPath: dstPath) {
-        if !CopyFileW($0, $1, false) {
+        if !CopyFileW($0, $1, true) {
           throw _NSErrorWithWindowsError(GetLastError(), reading: true, paths: [srcPath, dstPath])
         }
       }


### PR DESCRIPTION
_This is a cherry-pick of #4821 to 5.9._

On Apple platforms, the `FileManager` APIs `copyItem(atPath:toPath:)` and `copyItem(at:to:)` refuse to overwrite the destination file (or link, or directory) if it already exists; this behavior is even [explicitly](https://developer.apple.com/documentation/foundation/nsfilemanager/1407903-copyitematpath#discussion) [documented](https://developer.apple.com/documentation/foundation/nsfilemanager/1412957-copyitematurl#discussion). And indeed, any such attempt results in a `fileWriteFileExists` error.

However, on Linux and Windows, the destination is silently overwritten. This PR changes that behavior to match what's documented. On POSIX platforms, this is accomplished by adding the [`O_EXCL` flag](https://man7.org/linux/man-pages/man2/open.2.html#:~:text=O_EXCL%20Ensure) to the relevant `open(2)` call, which results in an `EEXIST` errno if the path already exists. For Windows, the [`bFailIfExists` parameter of `CopyFileW()`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-copyfile#:~:text=[in]%20bFailIfExists) is changed to `true`.

Fixes #3368