### PR TITLE
Make `Date`, `DateComponents` and `DateInterval` `Sendable`

### DIFF
--- a/Sources/Foundation/Date.swift
+++ b/Sources/Foundation/Date.swift
@@ -14,7 +14,7 @@
  
  A `Date` is independent of a particular calendar or time zone. To represent a `Date` to a user, you must interpret it in the context of a `Calendar`.
  */
-public struct Date : ReferenceConvertible, Comparable, Equatable {
+public struct Date : ReferenceConvertible, Comparable, Equatable, Sendable {
     public typealias ReferenceType = NSDate
     
     fileprivate var _time: TimeInterval

--- a/Sources/Foundation/DateComponents.swift
+++ b/Sources/Foundation/DateComponents.swift
@@ -19,7 +19,7 @@
  
  When a new instance of `DateComponents` is created, the date components are set to `nil`.
  */
-public struct DateComponents : ReferenceConvertible, Hashable, Equatable, _MutableBoxing {
+public struct DateComponents : ReferenceConvertible, Hashable, Equatable, Sendable, _MutableBoxing {
     public typealias ReferenceType = NSDateComponents
     
     internal var _handle: _MutableHandle<NSDateComponents>

--- a/Sources/Foundation/DateInterval.swift
+++ b/Sources/Foundation/DateInterval.swift
@@ -13,7 +13,7 @@
 @_implementationOnly import CoreFoundation
 
 /// DateInterval represents a closed date interval in the form of [startDate, endDate].  It is possible for the start and end dates to be the same with a duration of 0.  DateInterval does not support reverse intervals i.e. intervals where the duration is less than 0 and the end date occurs earlier in time than the start date.
-public struct DateInterval : ReferenceConvertible, Comparable, Hashable {
+public struct DateInterval : ReferenceConvertible, Comparable, Sendable, Hashable {
     public typealias ReferenceType = NSDateInterval
     
     /// The start date.


### PR DESCRIPTION
# Motivation
In https://github.com/apple/swift-corelibs-foundation/pull/4777, I made them `Sendable` in the overlay instead of the real `Foundation` module. This PR fixes that.