### PR TITLE
[5.9.1] Enable macros for Windows in 5.9.1

### DIFF
--- a/Tests/Foundation/Tests/TestURL.swift
+++ b/Tests/Foundation/Tests/TestURL.swift
@@ -559,7 +559,7 @@ class TestURL : XCTestCase {
 
         let url = URL(fileURLWithPath: "foo/bar/baz")
         let result = url.resolvingSymlinksInPath()
-        XCTAssertEqual(result, URL(fileURLWithPath: writableTestDirectoryURL.path + "/foo/bar/baz"))
+        XCTAssertEqual(result, URL(fileURLWithPath: writableTestDirectoryURL.path + "/foo/bar/baz").resolvingSymlinksInPath())
     }
 
     func test_resolvingSymlinksInPathShouldAppendTrailingSlashWhenExistingDirectory() throws {
@@ -573,7 +573,7 @@ class TestURL : XCTestCase {
         }
         let url = URL(fileURLWithPath: path)
         let result = url.resolvingSymlinksInPath()
-        XCTAssertEqual(result, URL(fileURLWithPath: path + "/"))
+        XCTAssertEqual(result, URL(fileURLWithPath: path + "/").resolvingSymlinksInPath())
     }
 
     func test_resolvingSymlinksInPathShouldResolveSymlinks() throws {
@@ -588,7 +588,7 @@ class TestURL : XCTestCase {
         try fileManager.createSymbolicLink(at: symbolicLink, withDestinationURL: destination)
 
         let result = symbolicLink.resolvingSymlinksInPath()
-        XCTAssertEqual(result, URL(fileURLWithPath: writableTestDirectoryURL.path + "/destination"))
+        XCTAssertEqual(result, URL(fileURLWithPath: writableTestDirectoryURL.path + "/destination").resolvingSymlinksInPath())
     }
 
     func test_resolvingSymlinksInPathShouldRemovePrivatePrefix() {


### PR DESCRIPTION
Cherry-picks 6cbe5e0f0c7ca266d322a6d6ba7ad5209a5b31b3.

-----

Don't assume that the temporary directory doesn't include symlinks.