### PR TITLE
Mark `Decimal` as `Sendable`

### DIFF
--- a/Sources/Foundation/Decimal.swift
+++ b/Sources/Foundation/Decimal.swift
@@ -10,7 +10,7 @@
 public var NSDecimalMaxSize: Int32 { 8 }
 public var NSDecimalNoScale: Int32 { Int32(Int16.max) }
 
-public struct Decimal {
+public struct Decimal: Sendable {
     fileprivate var __exponent: Int8
     fileprivate var __lengthAndFlags: UInt8
     fileprivate var __reserved: UInt16


### PR DESCRIPTION
Decimal is a simple value type, so it should be sendable. Currently, using Decimal variables produces warnings when using them with Sendable checking.