### PR TITLE
Android: add better nullability checks for nullability annotations added in NDK 26

### DIFF
--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -568,13 +568,13 @@ open class FileManager : NSObject {
         let attributes = try windowsFileAttributes(atPath: path)
         let type = FileAttributeType(attributes: attributes, atPath: path)
 #else
-        if let pwd = getpwuid(s.st_uid), pwd.pointee.pw_name != nil {
-            let name = String(cString: pwd.pointee.pw_name)
+        if let pwd = getpwuid(s.st_uid), let pwd_name = pwd.pointee.pw_name {
+            let name = String(cString: pwd_name)
             result[.ownerAccountName] = name
         }
 
-        if let grd = getgrgid(s.st_gid), grd.pointee.gr_name != nil {
-            let name = String(cString: grd.pointee.gr_name)
+        if let grd = getgrgid(s.st_gid), let grd_name = grd.pointee.gr_name {
+            let name = String(cString: grd_name)
             result[.groupOwnerAccountName] = name
         }
 

--- a/Sources/Foundation/Host.swift
+++ b/Sources/Foundation/Host.swift
@@ -25,7 +25,8 @@ import WinSDK
 
     // getnameinfo uses size_t for its 4th and 6th arguments.
     private func getnameinfo(_ addr: UnsafePointer<sockaddr>?, _ addrlen: socklen_t, _ host: UnsafeMutablePointer<Int8>?, _ hostlen: socklen_t, _ serv: UnsafeMutablePointer<Int8>?, _ servlen: socklen_t, _ flags: Int32) -> Int32 {
-        return Glibc.getnameinfo(addr, addrlen, host, Int(hostlen), serv, Int(servlen), flags)
+        guard let saddr = addr else { return -1 }
+        return Glibc.getnameinfo(saddr, addrlen, host, Int(hostlen), serv, Int(servlen), flags)
     }
 
     // getifaddrs and freeifaddrs are not available in Android 6.0 or earlier, so call these functions dynamically.

--- a/Tests/Foundation/Tests/TestFileHandle.swift
+++ b/Tests/Foundation/Tests/TestFileHandle.swift
@@ -111,7 +111,7 @@ class TestFileHandle : XCTestCase {
 #else
         var fds: [Int32] = [-1, -1]
         fds.withUnsafeMutableBufferPointer { (pointer) -> Void in
-            pipe(pointer.baseAddress)
+            pipe(pointer.baseAddress!)
         }
         
         close(fds[1])

--- a/Tests/Foundation/Tests/TestTimeZone.swift
+++ b/Tests/Foundation/Tests/TestTimeZone.swift
@@ -160,7 +160,7 @@ class TestTimeZone: XCTestCase {
         var lt = tm()
         localtime_r(&t, &lt)
         let zoneName = NSTimeZone.system.abbreviation() ?? "Invalid Abbreviation"
-        let expectedName = String(cString: lt.tm_zone, encoding: .ascii) ?? "Invalid Zone"
+        let expectedName = String(cString: lt.tm_zone!, encoding: .ascii) ?? "Invalid Zone"
         XCTAssertEqual(zoneName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(zoneName)\"")
     }
 #endif


### PR DESCRIPTION
This is needed because [Bionic recently added a bunch of these annotations](https://android.googlesource.com/platform/bionic/+/25725717861813c18189c2699cf663bdb984d1b9%5E%21/#F0). I made sure this pull doesn't break anything by testing most of it with the previous NDK 25c also. I used this patch with others to build the Swift toolchain for my Android CI, finagolfin/swift-android-sdk#122, and [the Termux app for Android](https://github.com/termux/termux-packages/commit/d10fd452662d3c39c0f19a901433bce8711b4688#diff-b8f3b540c354923485cb06eba2d66237536f89e88fd51e170495ddd8f5d32622R44), which now uses NDK 26b.

@drodriguez or @compnerd, please review.