### PR TITLE
[5.10] Cherry-pick Ensure URLSession and curl agree on the host #4836

### DIFF
--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.c
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.c
@@ -657,3 +657,22 @@ CFURLSessionSList *_Nullable CFURLSessionSListAppend(CFURLSessionSList *_Nullabl
 void CFURLSessionSListFreeAll(CFURLSessionSList *_Nullable list) {
     curl_slist_free_all((struct curl_slist *) list);
 }
+
+bool CFURLSessionCurlHostIsEqual(const char *_Nonnull url, const char *_Nonnull expectedHost) {
+#if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 62)
+    bool isEqual = false;
+    CURLU *h = curl_url();
+    if (0 == curl_url_set(h, CURLUPART_URL, url, 0)) {
+        char *curlHost = NULL;
+        if (0 == curl_url_get(h, CURLUPART_HOST, &curlHost, 0)) {
+            isEqual = (strlen(curlHost) == strlen(expectedHost) &&
+                       strncmp(curlHost, expectedHost, strlen(curlHost)) == 0);
+            curl_free(curlHost);
+        }
+        curl_free(h);
+    }
+    return isEqual;
+#else
+    return true;
+#endif
+}

--- a/CoreFoundation/URL.subproj/CFURLSessionInterface.h
+++ b/CoreFoundation/URL.subproj/CFURLSessionInterface.h
@@ -642,6 +642,7 @@ typedef struct CFURLSessionSList CFURLSessionSList;
 CF_EXPORT CFURLSessionSList *_Nullable CFURLSessionSListAppend(CFURLSessionSList *_Nullable list, const char * _Nullable string);
 CF_EXPORT void CFURLSessionSListFreeAll(CFURLSessionSList *_Nullable list);
 
+CF_EXPORT bool CFURLSessionCurlHostIsEqual(const char *_Nonnull url, const char *_Nonnull expectedHost);
 
 
 CF_EXTERN_C_END

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -311,7 +311,21 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         guard let url = request.url else {
             fatalError("No URL in request.")
         }
-        easyHandle.set(url: url)
+        guard url.host != nil else {
+            self.internalState = .transferFailed
+            let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL,
+                                userInfo: [NSLocalizedDescriptionKey: "HTTP URL must have a host"])
+            failWith(error: error, request: request)
+            return
+        }
+        do {
+            try easyHandle.set(url: url)
+        } catch {
+            self.internalState = .transferFailed
+            let nsError = error as? NSError ?? NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)
+            failWith(error: nsError, request: request)
+            return
+        }
         let session = task?.session as! URLSession
         let _config = session._configuration
         easyHandle.set(sessionConfig: _config)


### PR DESCRIPTION
Cherry-pick of #4836 to `release/5.10`

`URL` and `curl` should agree on the host. Otherwise, fail the transfer with `NSURLErrorBadURL`.

