### PR TITLE
[runloop] Fix the failure memory order argument to atomic_compare_exchange_strong_explicit

### DIFF
--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -1306,7 +1306,7 @@ static Boolean __CFRunLoopSourceIsSignaled(CFRunLoopSourceRef rls) {
 }
 
 CF_INLINE void __CFRunLoopSourceSetSignaled(CFRunLoopSourceRef rls) {
-    atomic_compare_exchange_strong_explicit(&rls->_signaledTime, &(uint64_t){0}, mach_absolute_time(), memory_order_acq_rel, memory_order_acq_rel);
+    atomic_compare_exchange_strong_explicit(&rls->_signaledTime, &(uint64_t){0}, mach_absolute_time(), memory_order_acq_rel, memory_order_acquire);
 }
 
 CF_INLINE void __CFRunLoopSourceUnsetSignaled(CFRunLoopSourceRef rls) {


### PR DESCRIPTION
The failure memory order cannot be release or acq_rel. Clang since https://github.com/llvm/llvm-project/commit/fed564432cef76f8b303c19ab1dfc0a14878fbc3 diagnoses an invalid argument.