### PR TITLE
Use CMake to check for strlcat/strlcpy

### DIFF
--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -189,7 +189,7 @@ static dispatch_queue_t __ ## PREFIX ## Queue(void) {			\
 #define CF_RETAIN_BALANCED_ELSEWHERE(obj, identified_location) do { } while (0)
 #endif
 
-#if (TARGET_OS_LINUX && !TARGET_OS_ANDROID && !TARGET_OS_CYGWIN) || TARGET_OS_WIN32
+#ifndef HAVE_STRING_STRLCPY
 CF_INLINE size_t
 strlcpy(char * dst, const char * src, size_t maxlen) {
     const size_t srclen = strlen(src);
@@ -201,7 +201,9 @@ strlcpy(char * dst, const char * src, size_t maxlen) {
     }
     return srclen;
 }
+#endif // HAVE_STRING_STRLCPY
 
+#ifndef HAVE_STRING_STRLCAT
 CF_INLINE size_t
 strlcat(char * dst, const char * src, size_t maxlen) {
     const size_t srclen = strlen(src);
@@ -215,7 +217,7 @@ strlcat(char * dst, const char * src, size_t maxlen) {
     }
     return dstlen + srclen;
 }
-#endif
+#endif // HAVE_STRING_STRLCAT
 
 #if TARGET_OS_WIN32
 // Compatibility with boolean.h

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -66,11 +66,21 @@ if(CF_DEPLOYMENT_SWIFT)
   add_compile_options($<$<COMPILE_LANGUAGE:C>:$<$<STREQUAL:${CMAKE_C_SIMULATE_ID},MSVC>:/clang:>-fcf-runtime-abi=swift>)
 endif()
 
+include(CheckSymbolExists)
+check_symbol_exists("strlcat" "string.h" HAVE_STRING_STRLCAT)
+if(HAVE_STRING_STRLCAT)
+  add_compile_definitions($<$<COMPILE_LANGUAGE:C>:HAVE_STRING_STRLCAT>)
+endif()
+
+check_symbol_exists("strlcpy" "string.h" HAVE_STRING_STRLCPY)
+if(HAVE_STRING_STRLCPY)
+  add_compile_definitions($<$<COMPILE_LANGUAGE:C>:HAVE_STRING_STRLCPY>)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL Android)
   add_compile_definitions($<$<COMPILE_LANGUAGE:C>:_GNU_SOURCE>)
 
   if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-    include(CheckSymbolExists)
     include(CheckIncludeFile)
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
     check_include_file("sched.h" HAVE_SCHED_H)


### PR DESCRIPTION
Rather than try to hard-code whether or not each version of each platform has strlcat and strlcpy, this patch has CMake check to see if it's available after including string.h. If they are, then we should not redefine them. This comes after trying to build Foundation against glibc 2.38, which finally added these two functions, causing CoreFoundation to fail to compile.