### PR TITLE
Resync URL loading system error codes

### DIFF
--- a/Sources/Foundation/NSURLError.swift
+++ b/Sources/Foundation/NSURLError.swift
@@ -72,13 +72,13 @@ public var NSURLErrorNoPermissionsToReadFile: Int { return -1102 }
 public var NSURLErrorDataLengthExceedsMaximum: Int { return -1103 }
 
 // SSL errors
-public var NSURLErrorSecureConnectionFailed: Int { return -1201 }
-public var NSURLErrorServerCertificateHasBadDate: Int { return -1202 }
-public var NSURLErrorServerCertificateUntrusted: Int { return -1203 }
-public var NSURLErrorServerCertificateHasUnknownRoot: Int { return -1204 }
-public var NSURLErrorServerCertificateNotYetValid: Int { return -1205 }
-public var NSURLErrorClientCertificateRejected: Int { return -1206 }
-public var NSURLErrorClientCertificateRequired: Int { return -1207 }
+public var NSURLErrorSecureConnectionFailed: Int { return -1200 }
+public var NSURLErrorServerCertificateHasBadDate: Int { return -1201 }
+public var NSURLErrorServerCertificateUntrusted: Int { return -1202 }
+public var NSURLErrorServerCertificateHasUnknownRoot: Int { return -1203 }
+public var NSURLErrorServerCertificateNotYetValid: Int { return -1204 }
+public var NSURLErrorClientCertificateRejected: Int { return -1205 }
+public var NSURLErrorClientCertificateRequired: Int { return -1206 }
 public var NSURLErrorCannotLoadFromNetwork: Int { return -2000 }
 
 // Download and file I/O errors

--- a/Sources/Foundation/NSURLError.swift
+++ b/Sources/Foundation/NSURLError.swift
@@ -72,6 +72,7 @@ public var NSURLErrorNoPermissionsToReadFile: Int { return -1102 }
 public var NSURLErrorDataLengthExceedsMaximum: Int { return -1103 }
 
 // SSL errors
+public var NSURLErrorFileOutsideSafeArea: Int { return -1104 }
 public var NSURLErrorSecureConnectionFailed: Int { return -1200 }
 public var NSURLErrorServerCertificateHasBadDate: Int { return -1201 }
 public var NSURLErrorServerCertificateUntrusted: Int { return -1202 }


### PR DESCRIPTION
As I was developing the `https://github.com/dirtyhenry/swift-blocks` package, I noticed that some error codes from the URL Loading System error codes were out of sync (or missing) from what I could see in Xcode and on the Foundation documentation.

I hope it helps. 🙏
