### PR TITLE
[wasm] Port BlocksRuntime for no dlfcn.h platforms

### DIFF
--- a/Sources/BlocksRuntime/runtime.c
+++ b/Sources/BlocksRuntime/runtime.c
@@ -15,7 +15,7 @@
 #if TARGET_OS_WIN32
 #include <Windows.h>
 #include <Psapi.h>
-#else
+#elif __has_include(<dlfcn.h>)
 #include <dlfcn.h>
 #endif
 #if __has_include(<os/assumes.h>)
@@ -268,7 +268,11 @@ void _Block_use_RR( void (*retain)(const void *),
         break;
     }
 #else
+# if __has_include(<dlfcn.h>)
     _Block_destructInstance = dlsym(RTLD_DEFAULT, "objc_destructInstance");
+# else
+    _Block_destructInstance = _Block_destructInstance_default;
+# endif
 #endif
 }
 


### PR DESCRIPTION
BlocksRuntime uses dlsym to find objc_destructInstance, which is not available on all platforms. This change adds a check for dlfcn.h and only uses dlsym if it is available and otherwise crashes the program.

The crash will not usually happen, as `_Block_use_RR` is only called from objc-auto, which is not available for such platforms.