### PR TITLE
[wasm] Fix signatures of `swift_retain`

### DIFF
--- a/CoreFoundation/Base.subproj/CFPlatform.c
+++ b/CoreFoundation/Base.subproj/CFPlatform.c
@@ -1625,7 +1625,7 @@ CF_PRIVATE int asprintf(char **ret, const char *format, ...) {
 #if DEPLOYMENT_RUNTIME_SWIFT
 #include <fcntl.h>
 
-extern void swift_retain(void *);
+extern void *swift_retain(void *);
 extern void swift_release(void *);
 
 #if TARGET_OS_WIN32

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1407,7 +1407,7 @@ int DllMain( HINSTANCE hInstance, DWORD dwReason, LPVOID pReserved ) {
 #endif
 
 #if DEPLOYMENT_RUNTIME_SWIFT
-extern void swift_retain(void *);
+extern void *swift_retain(void *);
 #endif
 
 // For "tryR==true", a return of NULL means "failed".


### PR DESCRIPTION
Function signature cannot be inconsistent in Wasm platforms. This patch fixes the signature of `swift_retain` to return the retained object.