### PR TITLE
[wasm] Port use of `dirent` for wasi-libc

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -576,6 +576,10 @@ static inline int _direntNameLength(struct dirent *entry) {
 #endif
 }
 
+static inline char *_direntName(struct dirent *entry) {
+    return entry->d_name;
+}
+
 // major() and minor() might be implemented as macros or functions.
 static inline unsigned int _dev_major(dev_t rdev) {
     return major(rdev);

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -411,10 +411,8 @@ extension FileManager {
             errno = 0
             while let entry = readdir(dir) {
                 let length = Int(_direntNameLength(entry))
-                let entryName = withUnsafePointer(to: entry.pointee.d_name) { (ptr) -> String in
-                    let namePtr = UnsafeRawPointer(ptr).assumingMemoryBound(to: CChar.self)
-                    return string(withFileSystemRepresentation: namePtr, length: length)
-                }
+                let namePtr = UnsafeRawPointer(_direntName(entry)).assumingMemoryBound(to: CChar.self)
+                let entryName = string(withFileSystemRepresentation: namePtr, length: length)
                 if entryName != "." && entryName != ".." {
                     let entryType = Int32(entry.pointee.d_type)
                     try closure(entryName, entryType)


### PR DESCRIPTION
wasi-libc defines `d_name` as "flexible array member" which is not supported by ClangImporter yet. This patch replaces the use of `d_name` with a helper function `_direntName` to work around the issue.