### PR TITLE
[wasm] Remove too conservative guards around file operations

### DIFF
--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -36,7 +36,11 @@
 @usableFromInline let memcpy = Musl.memcpy
 @usableFromInline let memcmp = Musl.memcmp
 #elseif canImport(WASILibc)
+#if swift(>=6.0)
+private import wasi_emulated_mman
+#else
 import wasi_emulated_mman
+#endif
 @usableFromInline let calloc = WASILibc.calloc
 @usableFromInline let malloc = WASILibc.malloc
 @usableFromInline let free = WASILibc.free

--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -36,6 +36,7 @@
 @usableFromInline let memcpy = Musl.memcpy
 @usableFromInline let memcmp = Musl.memcmp
 #elseif canImport(WASILibc)
+import wasi_emulated_mman
 @usableFromInline let calloc = WASILibc.calloc
 @usableFromInline let malloc = WASILibc.malloc
 @usableFromInline let free = WASILibc.free
@@ -2048,7 +2049,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
-#if !os(WASI)
     /// Initialize a `Data` with the contents of a `URL`.
     ///
     /// - parameter url: The `URL` to read.
@@ -2061,7 +2061,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             return Data(bytes: d.bytes, count: d.length)
         }
     }
-#endif
     
     /// Initialize a `Data` from a Base-64 encoded String using the given options.
     ///
@@ -2325,7 +2324,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
 #endif
     
-#if !os(WASI)
     /// Write the contents of the `Data` to a location.
     ///
     /// - parameter url: The location to write the data into.
@@ -2346,7 +2344,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
 #endif
         }
     }
-#endif
     
     // MARK: -
     

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -151,7 +151,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         _init(bytes: bytes, length: length, copy: false, deallocator: deallocator)
     }
 
-#if !os(WASI)
     /// Initializes a data object with the contents of the file at a given path.
     public init(contentsOfFile path: String, options readOptionsMask: ReadingOptions = []) throws {
         super.init()
@@ -174,7 +173,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             return nil
         }
     }
-#endif
 
     /// Initializes a data object with the contents of another data object.
     public init(data: Data) {
@@ -184,7 +182,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
 
-#if !os(WASI)
     /// Initializes a data object with the data from the location specified by a given URL.
     public init(contentsOf url: URL, options readOptionsMask: ReadingOptions = []) throws {
         super.init()
@@ -223,7 +220,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             return try _NSNonfileURLContentLoader.current.contentsOf(url: url)
         }
     }
-#endif
 
     /// Initializes a data object with the given Base64 encoded string.
     public init?(base64Encoded base64String: String, options: Base64DecodingOptions = []) {
@@ -439,7 +435,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
     }
 
-#if !os(WASI)
     internal static func readBytesFromFileWithExtendedAttributes(_ path: String, options: ReadingOptions) throws -> NSDataReadResult {
         guard let handle = FileHandle(path: path, flags: O_RDONLY, createMode: 0) else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno), userInfo: nil)
@@ -545,7 +540,6 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
         try write(toFile: url.path, options: writeOptionsMask)
     }
-#endif
 
     // MARK: - Bytes
     /// Copies a number of bytes from the start of the data object into a given buffer.
@@ -1012,7 +1006,6 @@ open class NSMutableData : NSData {
         super.init(data: data)
     }
 
-#if !os(WASI)
     public override init?(contentsOfFile path: String) {
         super.init(contentsOfFile: path)
     }
@@ -1028,7 +1021,6 @@ open class NSMutableData : NSData {
     public override init(contentsOf url: URL, options: NSData.ReadingOptions = []) throws {
         try super.init(contentsOf: url, options: options)
     }
-#endif
 
     public override init?(base64Encoded base64Data: Data, options: NSData.Base64DecodingOptions = []) {
         super.init(base64Encoded: base64Data, options: options)

--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -195,7 +195,6 @@ extension String {
         return temp
     }
     
-#if !os(WASI)
     internal func _tryToRemovePathPrefix(_ prefix: String) -> String? {
         guard self != prefix else {
             return nil
@@ -208,7 +207,6 @@ extension String {
         
         return nil
     }
-#endif
 }
 
 extension NSString {
@@ -338,7 +336,6 @@ extension NSString {
         return result._stringByFixingSlashes()
     }
 
-#if !os(WASI)
     public var expandingTildeInPath: String {
         guard hasPrefix("~") else {
             return _swiftObject
@@ -359,7 +356,6 @@ extension NSString {
         
         return result
     }
-#endif
 
 #if os(Windows)
     public var unixPath: String {
@@ -374,7 +370,6 @@ extension NSString {
     }
 #endif
     
-#if !os(WASI)
     public var standardizingPath: String {
 #if os(Windows)
         let expanded = unixPath.expandingTildeInPath
@@ -422,8 +417,6 @@ extension NSString {
         
         return resolvedPath
     }
-#endif
-    
     public func stringsByAppendingPaths(_ paths: [String]) -> [String] {
         if self == "" {
             return paths
@@ -655,7 +648,6 @@ extension NSString {
 
 }
 
-#if !os(WASI)
 extension FileManager {
     public enum SearchPathDirectory: UInt {
         
@@ -731,6 +723,9 @@ public func NSHomeDirectory() -> String {
 }
 
 public func NSHomeDirectoryForUser(_ user: String?) -> String? {
+#if os(WASI) // WASI does not have user concept
+    return nil
+#else
     let userName = user?._cfObject
     guard let homeDir = CFCopyHomeDirectoryURLForUser(userName)?.takeRetainedValue() else {
         return nil
@@ -738,6 +733,7 @@ public func NSHomeDirectoryForUser(_ user: String?) -> String? {
     
     let url: URL = homeDir._swiftObject
     return url.path
+#endif
 }
 
 public func NSUserName() -> String {
@@ -831,4 +827,3 @@ internal func _NSCleanupTemporaryFile(_ auxFilePath: String, _ filePath: String)
     })
 #endif
 }
-#endif

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -556,9 +556,6 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
     // TODO: should be `checkResourceIsReachableAndReturnError` with autoreleased error parameter.
     // Currently Autoreleased pointers is not supported on Linux.
     open func checkResourceIsReachable() throws -> Bool {
-#if os(WASI)
-        return false
-#else
         guard isFileURL,
             let path = path else {
                 throw NSError(domain: NSCocoaErrorDomain,
@@ -574,7 +571,6 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
         }
         
         return true
-#endif
     }
 
     /* Returns a file path URL that refers to the same resource as a specified URL. File path URLs use a file system style path. An error will occur if the url parameter is not a file URL. A file reference URL's resource must exist and be reachable to be converted to a file path URL. Symbol is present in iOS 4, but performs no operation.
@@ -918,12 +914,8 @@ extension NSURL {
         if selfPath.isAbsolutePath {
             absolutePath = selfPath
         } else {
-#if os(WASI)
-            return nil
-#else
             let workingDir = FileManager.default.currentDirectoryPath
             absolutePath = workingDir._bridgeToObjectiveC().appendingPathComponent(selfPath)
-#endif
         }
 
 #if os(Windows)
@@ -971,20 +963,16 @@ extension NSURL {
 
             default:
                 resolvedPath = resolvedPath._bridgeToObjectiveC().appendingPathComponent(component)
-#if !os(WASI)
                 if let destination = FileManager.default._tryToResolveTrailingSymlinkInPath(resolvedPath) {
                     resolvedPath = destination
                 }
-#endif
             }
         }
 
         // It might be a responsibility of NSURL(fileURLWithPath:). Check it.
         var isExistingDirectory: ObjCBool = false
 
-#if !os(WASI)
         let _ = FileManager.default.fileExists(atPath: resolvedPath, isDirectory: &isExistingDirectory)
-#endif
 
         if excludeSystemDirs {
             resolvedPath = resolvedPath._tryToRemovePathPrefix("/private") ?? resolvedPath
@@ -1063,7 +1051,6 @@ extension NSURL : _StructTypeBridgeable {
 
 // -----
 
-#if !os(WASI)
 internal func _CFSwiftURLCopyResourcePropertyForKey(_ url: CFTypeRef, _ key: CFString, _ valuePointer: UnsafeMutablePointer<Unmanaged<CFTypeRef>?>?, _ errorPointer: UnsafeMutablePointer<Unmanaged<CFError>?>?) -> _DarwinCompatibleBoolean {
     do {
         let key = URLResourceKey(rawValue: key._swiftObject)
@@ -1597,7 +1584,6 @@ fileprivate extension URLResourceValuesStorage {
         }
     }
 }
-#endif
 
 // -----
 


### PR DESCRIPTION
Those guards were added to prevent the build from failing on WASI, but they are too conservative and the latest wasi-libc is now providing enough support for these operations.