### PR TITLE
[wasm] Fix definition conflict of `errno`

### DIFF
--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -10,6 +10,15 @@
 @_implementationOnly import CoreFoundation
 #if os(Windows)
 import WinSDK
+#elseif os(WASI)
+import WASILibc
+// CoreFoundation brings <errno.h> but it conflicts with WASILibc.errno
+// definition, so we need to explicitly select the one from WASILibc.
+// This is defined as "internal" since this workaround also used in other files.
+internal var errno: Int32 {
+    get { WASILibc.errno }
+    set { WASILibc.errno = newValue }
+}
 #endif
 
 #if os(Windows)


### PR DESCRIPTION
WASILibc's `errno` conflicts with Clang-imported `errno` in <errno.h>.