### PR TITLE
[wasm] Add objc_retainAutoreleasedReturnValue definition

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1787,6 +1787,18 @@ struct _NSCFXMLBridgeUntyped __NSCFXMLBridgeUntyped = {
   &kCFErrorLocalizedDescriptionKey,
 };
 
+// This function is also provided in libdispatch but we need to define it here for platforms that don't have libdispatch.
+#if !__HAS_DISPATCH__
+// For CF functions with 'Get' semantics, the compiler currently assumes that the result is autoreleased and must be retained. It does so on all platforms by emitting a call to objc_retainAutoreleasedReturnValue. On Darwin, this is implemented by the ObjC runtime. On Linux, there is no runtime, and therefore we have to stub it out here ourselves. The compiler will eventually call swift_release to balance the retain below. This is a workaround until the compiler no longer emits this callout on Linux.
+void * objc_retainAutoreleasedReturnValue(void *obj) {
+    if (obj) {
+        swift_retain(obj);
+        return obj;
+    }
+    else return NULL;
+}
+#endif
+
 // Call out to the CF-level finalizer, because the object is going to go away.
 CF_CROSS_PLATFORM_EXPORT void _CFDeinit(CFTypeRef cf) {
     __CFInfoType info = atomic_load(&(((CFRuntimeBase *)cf)->_cfinfoa));


### PR DESCRIPTION
The function is usually provided by libdispatch, but for platforms where libdispatch is unavailable at this moment, we need to provide it in CF as we do for BlocksRuntime.