### PR TITLE
[wasm] Port FileManager for WASI platform

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -45,7 +45,7 @@
 #if _POSIX_THREADS
 #include <pthread.h>
 #endif
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)
 #include <dirent.h>
 #endif
 
@@ -565,11 +565,11 @@ CF_CROSS_PLATFORM_EXPORT int _CFOpenFileWithMode(const char *path, int opts, mod
 CF_CROSS_PLATFORM_EXPORT void *_CFReallocf(void *ptr, size_t size);
 CF_CROSS_PLATFORM_EXPORT int _CFOpenFile(const char *path, int opts);
 
-#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__)) || defined(__wasi__)
 static inline int _direntNameLength(struct dirent *entry) {
 #ifdef _D_EXACT_NAMLEN  // defined on Linux
     return _D_EXACT_NAMLEN(entry);
-#elif TARGET_OS_LINUX || TARGET_OS_ANDROID
+#elif TARGET_OS_LINUX || TARGET_OS_ANDROID || TARGET_OS_WASI
     return strlen(entry->d_name);
 #else
     return entry->d_namlen;
@@ -578,11 +578,21 @@ static inline int _direntNameLength(struct dirent *entry) {
 
 // major() and minor() might be implemented as macros or functions.
 static inline unsigned int _dev_major(dev_t rdev) {
+#if !TARGET_OS_WASI
     return major(rdev);
+#else
+    // WASI does not have device numbers
+    return 0;
+#endif
 }
 
 static inline unsigned int _dev_minor(dev_t rdev) {
+#if !TARGET_OS_WASI
     return minor(rdev);
+#else
+    // WASI does not have device numbers
+    return 0;
+#endif
 }
 
 #endif

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -27,6 +27,12 @@ import Musl
 fileprivate let _read = Musl.read(_:_:_:)
 fileprivate let _write = Musl.write(_:_:_:)
 fileprivate let _close = Musl.close(_:)
+#elseif canImport(WASILibc)
+import WASILibc
+@_implementationOnly import wasi_emulated_mman
+fileprivate let _read = WASILibc.read(_:_:_:)
+fileprivate let _write = WASILibc.write(_:_:_:)
+fileprivate let _close = WASILibc.close(_:)
 #endif
 
 #if canImport(WinSDK)

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -498,6 +498,8 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             let createMode = Int(Glibc.S_IRUSR) | Int(Glibc.S_IWUSR) | Int(Glibc.S_IRGRP) | Int(Glibc.S_IWGRP) | Int(Glibc.S_IROTH) | Int(Glibc.S_IWOTH)
 #elseif canImport(Musl)
             let createMode = Int(Musl.S_IRUSR) | Int(Musl.S_IWUSR) | Int(Musl.S_IRGRP) | Int(Musl.S_IWGRP) | Int(Musl.S_IROTH) | Int(Musl.S_IWOTH)
+#elseif canImport(WASILibc)
+            let createMode = Int(WASILibc.S_IRUSR) | Int(WASILibc.S_IWUSR) | Int(WASILibc.S_IRGRP) | Int(WASILibc.S_IWGRP) | Int(WASILibc.S_IROTH) | Int(WASILibc.S_IWOTH)
 #endif
             guard let fh = FileHandle(path: path, flags: flags, createMode: createMode) else {
                 throw _NSErrorWithErrno(errno, reading: false, path: path)


### PR DESCRIPTION
This unlocks most of FileManager APIs on WASI platform. WASI lacks the following concepts:
- Device numbers
- File ownership

Also wasi-libc does not provide the following functionalities at the moment:
- `realpath(3)` (This will be included in the next release https://github.com/WebAssembly/wasi-libc/pull/473)
- `fts(3)`