### PR TITLE
[wasm] Include syslog.h only if available

### DIFF
--- a/CoreFoundation/URL.subproj/CFURL.c
+++ b/CoreFoundation/URL.subproj/CFURL.c
@@ -31,7 +31,7 @@
 #include <sys/types.h>
 #if __has_include(<sys/syslog.h>)
 #include <sys/syslog.h>
-#else
+#elif __has_include(<syslog.h>)
 #include <syslog.h>
 #endif
 #include <CoreFoundation/CFURLPriv.h>


### PR DESCRIPTION
wasi-libc does not provide `syslog.h`, so we should only include it if it is available. syslog APIs are only used for debugging code guarded under `DEBUG_URL_MEMORY_USAGE`, so it is safe to exclude it.