### PR TITLE
[wasm] Port CoreFoundation/String.subproj

### DIFF
--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -340,7 +340,7 @@ CF_INLINE size_t malloc_size(void *memblock) {
 #endif
 #endif
 
-#if TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include <sys/param.h>
 #endif
 #if TARGET_OS_WIN32 || TARGET_OS_LINUX

--- a/CoreFoundation/String.subproj/CFCharacterSetData.S
+++ b/CoreFoundation/String.subproj/CFCharacterSetData.S
@@ -11,19 +11,30 @@
 
 #if defined(__ELF__)
 .section .rodata
+#elif defined(__wasm__)
+.section .data.characterset_bitmap_data,"",@
 #endif
 
     .global _C_LABEL(__CFCharacterSetBitmapData)
 _C_LABEL(__CFCharacterSetBitmapData):
     .incbin CF_CHARACTERSET_BITMAP
+#if defined(__wasm__)
+    .size _C_LABEL(__CFCharacterSetBitmapData), . - _C_LABEL(__CFCharacterSetBitmapData)
+#endif
 
     .global _C_LABEL(__CFCharacterSetBitmapDataEnd)
 _C_LABEL(__CFCharacterSetBitmapDataEnd):
     .byte 0
+#if defined(__wasm__)
+    .size _C_LABEL(__CFCharacterSetBitmapDataEnd), . - _C_LABEL(__CFCharacterSetBitmapDataEnd)
+#endif
 
     .global _C_LABEL(__CFCharacterSetBitmapDataSize)
 _C_LABEL(__CFCharacterSetBitmapDataSize):
     .int _C_LABEL(__CFCharacterSetBitmapDataEnd) - _C_LABEL(__CFCharacterSetBitmapData)
+#if defined(__wasm__)
+    .size _C_LABEL(__CFCharacterSetBitmapDataSize), . - _C_LABEL(__CFCharacterSetBitmapDataSize)
+#endif
 
 NO_EXEC_STACK_DIRECTIVE
 SAFESEH_REGISTRATION_DIRECTIVE

--- a/CoreFoundation/String.subproj/CFString.c
+++ b/CoreFoundation/String.subproj/CFString.c
@@ -38,6 +38,9 @@
 #if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD
 #include <unistd.h>
 #endif
+#if TARGET_OS_WASI
+#include <sys/types.h> // for u_char
+#endif
 
 #if defined(__GNUC__)
 #define LONG_DOUBLE_SUPPORT 1
@@ -6276,7 +6279,7 @@ enum {
     CFFormatIncompleteSpecifierType = 43    /* special case for a trailing incomplete specifier */
 };
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
 /* Only come in here if spec->type is CFFormatLongType or CFFormatDoubleType. Pass in 0 for width or precision if not specified. Returns false if couldn't do the format (with the assumption the caller falls back to unlocalized).
 */
 static Boolean __CFStringFormatLocalizedNumber(CFMutableStringRef output, CFLocaleRef locale, const CFPrintValue *values, const CFFormatSpec *spec, SInt32 width, SInt32 precision, Boolean hasPrecision) {
@@ -7493,7 +7496,7 @@ static Boolean __CFStringAppendFormatCore(CFMutableStringRef outputString, CFStr
 	switch (specs[curSpec].type) {
 	case CFFormatLongType:
 	case CFFormatDoubleType:
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
             if (localizedFormatting && (specs[curSpec].flags & kCFStringFormatLocalizable)) {    // We have a locale, so we do localized formatting
                 oldLength = __CFStringFormatOutputLengthIfNeeded();
                 if (__CFStringFormatLocalizedNumber(outputString, (CFLocaleRef)formatOptions, values, &specs[curSpec], width, precision, hasPrecision)) {

--- a/CoreFoundation/String.subproj/CFStringUtilities.c
+++ b/CoreFoundation/String.subproj/CFStringUtilities.c
@@ -18,7 +18,7 @@
 #include "CFString_Internal.h"
 #include <limits.h>
 #include <stdlib.h>
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
 #include <unicode/ucol.h>
 #include <unicode/ucoleitr.h>
 #endif
@@ -111,7 +111,7 @@ CFStringEncoding CFStringConvertIANACharSetNameToEncoding(CFStringRef charsetNam
 
     encoding = __CFStringEncodingGetFromCanonicalName(name);
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     if (kCFStringEncodingInvalidId == encoding) encoding = __CFStringEncodingGetFromICUName(name);
 #endif
     
@@ -262,7 +262,7 @@ CFStringEncoding CFStringGetMostCompatibleMacStringEncoding(CFStringEncoding enc
 
 #define kCFStringCompareAllocationIncrement (128)
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
 
 // -------------------------------------------------------------------------------------------------
 //	CompareSpecials - ignore case & diacritic differences
@@ -425,7 +425,7 @@ static UCollator *__CFStringCopyDefaultCollator(CFLocaleRef compareLocale) {
     return collator;
 }
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
 static void __collatorFinalize(UCollator *collator) {
     CFLocaleRef locale = _CFGetTSD(__CFTSDKeyCollatorLocale);
     _CFSetTSD(__CFTSDKeyCollatorUCollator, NULL, NULL);
@@ -578,7 +578,7 @@ CF_PRIVATE CFComparisonResult _CFCompareStringsWithLocale(CFStringInlineBuffer *
     CFRange range1 = str1Range;
     CFRange range2 = str2Range;
     SInt32 order;
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     Boolean isEqual;
     bool forcedOrdering = ((options & kCFCompareForcedOrdering) ? true : false);
 
@@ -611,7 +611,7 @@ CF_PRIVATE CFComparisonResult _CFCompareStringsWithLocale(CFStringInlineBuffer *
 	range2.location = __extendLocationBackward(range2.location - 1, str2, nonBaseBMP, punctBMP);
     }
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     // First we try to use the last one used on this thread, if the locale is the same,
     // otherwise we try to check out a default one, or then we create one.
     UCollator *threadCollator = _CFGetTSD(__CFTSDKeyCollatorUCollator);
@@ -633,7 +633,7 @@ CF_PRIVATE CFComparisonResult _CFCompareStringsWithLocale(CFStringInlineBuffer *
 	range1.length = (str1Range.location + str1Range.length) - range1.location;
 	range2.length = (str2Range.location + str2Range.length) - range2.location;
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
         if ((NULL != collator) && (__CompareTextDefault(collator, options, characters1, range1.length, characters2, range2.length, &isEqual, &order) == 0 /* noErr */)) {
             compResult = ((isEqual && !forcedOrdering) ? kCFCompareEqualTo : ((order < 0) ? kCFCompareLessThan : kCFCompareGreaterThan));
         } else
@@ -709,7 +709,7 @@ CF_PRIVATE CFComparisonResult _CFCompareStringsWithLocale(CFStringInlineBuffer *
                 }
             }
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
             if ((NULL != collator) && (__CompareTextDefault(collator, options, characters1, range1.length, characters2, range2.length, &isEqual, &order) ==  0 /* noErr */)) {
                 if (isEqual) {
                     if (forcedOrdering && (kCFCompareEqualTo == compResult) && (0 != order)) compResult = ((order < 0) ? kCFCompareLessThan : kCFCompareGreaterThan);
@@ -753,7 +753,7 @@ CF_PRIVATE CFComparisonResult _CFCompareStringsWithLocale(CFStringInlineBuffer *
         if (buffer2Len > 0) CFAllocatorDeallocate(kCFAllocatorSystemDefault, buffer2);
     }
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     if (collator == threadCollator) {
 	// do nothing, already cached
     } else {

--- a/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
+++ b/CoreFoundation/String.subproj/CFUniCharPropertyDatabase.S
@@ -11,19 +11,30 @@
 
 #if defined(__ELF__)
 .section .rodata
+#elif defined(__wasm__)
+.section .data.unichar_property_database,"",@
 #endif
 
     .global _C_LABEL(__CFUniCharPropertyDatabase)
 _C_LABEL(__CFUniCharPropertyDatabase):
     .incbin CF_CHARACTERSET_UNICHAR_DB
+#if defined(__wasm__)
+    .size _C_LABEL(__CFUniCharPropertyDatabase), . - _C_LABEL(__CFUniCharPropertyDatabase)
+#endif
 
     .global _C_LABEL(__CFUniCharPropertyDatabaseEnd)
 _C_LABEL(__CFUniCharPropertyDatabaseEnd):
     .byte 0
+#if defined(__wasm__)
+    .size _C_LABEL(__CFUniCharPropertyDatabaseEnd), . - _C_LABEL(__CFUniCharPropertyDatabaseEnd)
+#endif
 
     .global _C_LABEL(__CFUniCharPropertyDatabaseSize)
 _C_LABEL(__CFUniCharPropertyDatabaseSize):
     .int _C_LABEL(__CFUniCharPropertyDatabaseEnd) - _C_LABEL(__CFUniCharPropertyDatabase)
+#if defined(__wasm__)
+    .size _C_LABEL(__CFUniCharPropertyDatabaseSize), . - _C_LABEL(__CFUniCharPropertyDatabaseSize)
+#endif
 
 NO_EXEC_STACK_DIRECTIVE
 SAFESEH_REGISTRATION_DIRECTIVE

--- a/CoreFoundation/String.subproj/CFUnicodeData.S
+++ b/CoreFoundation/String.subproj/CFUnicodeData.S
@@ -11,6 +11,8 @@
 
 #if defined(__ELF__)
 .section .rodata
+#elif defined(__wasm__)
+.section .data.unicode_data,"",@
 #endif
 
 #if defined(__BIG_ENDIAN__)
@@ -29,14 +31,23 @@ _C_LABEL(__CFUnicodeDataBSize):
     .global _C_LABEL(__CFUnicodeDataL)
 _C_LABEL(__CFUnicodeDataL):
     .incbin CF_CHARACTERSET_UNICODE_DATA_L
+#if defined(__wasm__)
+    .size _C_LABEL(__CFUnicodeDataL), . - _C_LABEL(__CFUnicodeDataL)
+#endif
 
     .global _C_LABEL(__CFUnicodeDataLEnd)
 _C_LABEL(__CFUnicodeDataLEnd):
     .byte 0
+#if defined(__wasm__)
+    .size _C_LABEL(__CFUnicodeDataLEnd), . - _C_LABEL(__CFUnicodeDataLEnd)
+#endif
 
     .global _C_LABEL(__CFUnicodeDataLSize)
 _C_LABEL(__CFUnicodeDataLSize):
     .int _C_LABEL(__CFUnicodeDataLEnd) - _C_LABEL(__CFUnicodeDataL)
+#if defined(__wasm__)
+    .size _C_LABEL(__CFUnicodeDataLSize), . - _C_LABEL(__CFUnicodeDataLSize)
+#endif
 #endif
 
 NO_EXEC_STACK_DIRECTIVE


### PR DESCRIPTION
- LLVM's AsmParser for WebAssembly requires explicit data segment size in `.S`
- Add `TARGET_OS_WASI` branch as Unix-y platform