### PR TITLE
Fix race condition in CFPreferences

### DIFF
--- a/CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c
+++ b/CoreFoundation/Preferences.subproj/CFXMLPreferencesDomain.c
@@ -273,17 +273,16 @@ static Boolean __CFWriteBytesToFileWithAtomicity(CFURLRef url, const void *bytes
     close(fd);
     
     if (atomic) {
+        // If the file was renamed successfully and we wrote it as root we need to reset the owner & group as they were.
+        if (writingFileAsRoot) {
+            chown(auxPath, owner, group);
+        }
         // preserve the mode as passed in originally
         chmod(auxPath, mode);
                 
         if (0 != rename(auxPath, cpath)) {
             unlink(auxPath);
             return false;
-        }
-        
-        // If the file was renamed successfully and we wrote it as root we need to reset the owner & group as they were.
-        if (writingFileAsRoot) {
-            chown(cpath, owner, group);
         }
     }
     return true;


### PR DESCRIPTION
In __CFWriteBytesToFileWithAtomicity(), we first write the contents of the plist to an auxiliary copy file, and then move that copy to where the original used to be. Because that file needs to have the same owner as the original, we would use chown() to change ownership as the last step. This allows a race condition where the new file is in its final location, but doesn't have the correct permissions. To fix this, call chown() on the file before moving.

rdar://121597642