### PR TITLE
[wasm] Grab wasi-libc constants manually

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -64,6 +64,8 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <termios.h>
+#elif TARGET_OS_WASI
+#include <fcntl.h>
 #elif TARGET_OS_LINUX
 #include <errno.h>
 #include <features.h>
@@ -710,6 +712,15 @@ typedef struct _REPARSE_DATA_BUFFER {
         } GenericReparseBuffer;
     } DUMMYUNIONNAME;
 } REPARSE_DATA_BUFFER;
+#endif
+
+#if TARGET_OS_WASI
+static inline uint8_t _getConst_DT_DIR(void) { return DT_DIR; }
+static inline int32_t _getConst_O_CREAT(void) { return O_CREAT; }
+static inline int32_t _getConst_O_DIRECTORY(void) { return O_DIRECTORY; }
+static inline int32_t _getConst_O_EXCL(void) { return O_EXCL; }
+static inline int32_t _getConst_O_TRUNC(void) { return O_TRUNC; }
+static inline int32_t _getConst_O_WRONLY(void) { return O_WRONLY; }
 #endif
 
 #if !TARGET_OS_WIN32

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -13,6 +13,18 @@ internal func &(left: UInt32, right: mode_t) -> mode_t {
 }
 #endif
 
+#if os(WASI)
+import WASILibc
+// wasi-libc defines the following constants in a way that Clang Importer can't
+// understand, so we need to grab them manually through ForSwiftFoundationOnly.h
+internal var DT_DIR: UInt8 { _getConst_DT_DIR() }
+internal var O_CREAT: Int32 { _getConst_O_CREAT() }
+internal var O_DIRECTORY: Int32 { _getConst_O_DIRECTORY() }
+internal var O_EXCL: Int32 { _getConst_O_EXCL() }
+internal var O_TRUNC: Int32 { _getConst_O_TRUNC() }
+internal var O_WRONLY: Int32 { _getConst_O_WRONLY() }
+#endif
+
 @_implementationOnly import CoreFoundation
 
 extension FileManager {


### PR DESCRIPTION
Unfortunately they are defined in the way ClangImporter can't handle them, so we need to grab them manually through function calls. Those calls are usually inlined, so the performance impact should be minimal.

This workaround can be removed after https://github.com/apple/swift/issues/43102 will be "fixed"