### PR TITLE
[wasm] Port CoreFoundation/NumberDate.subproj

### DIFF
--- a/CoreFoundation/NumberDate.subproj/CFDate.c
+++ b/CoreFoundation/NumberDate.subproj/CFDate.c
@@ -359,7 +359,7 @@ CFAbsoluteTime CFGregorianDateGetAbsoluteTime(CFGregorianDate gdate, CFTimeZoneR
     CFAbsoluteTime at;
     at = 86400.0 * __CFAbsoluteFromYMD(gdate.year - 2001, gdate.month, gdate.day);
     at += 3600.0 * gdate.hour + 60.0 * gdate.minute + gdate.second;
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     if (NULL != tz) {
 	__CFGenericValidateType(tz, CFTimeZoneGetTypeID());
     }
@@ -378,7 +378,7 @@ CFGregorianDate CFAbsoluteTimeGetGregorianDate(CFAbsoluteTime at, CFTimeZoneRef 
     int64_t absolute, year;
     int8_t month, day;
     CFAbsoluteTime fixedat;
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     if (NULL != tz) {
 	__CFGenericValidateType(tz, CFTimeZoneGetTypeID());
     }
@@ -406,7 +406,7 @@ CFAbsoluteTime CFAbsoluteTimeAddGregorianUnits(CFAbsoluteTime at, CFTimeZoneRef 
     CFAbsoluteTime candidate_at0, candidate_at1;
     uint8_t monthdays;
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     if (NULL != tz) {
 	__CFGenericValidateType(tz, CFTimeZoneGetTypeID());
     }
@@ -525,7 +525,7 @@ CFGregorianUnits CFAbsoluteTimeGetDifferenceAsGregorianUnits(CFAbsoluteTime at1,
 SInt32 CFAbsoluteTimeGetDayOfWeek(CFAbsoluteTime at, CFTimeZoneRef tz) {
     int64_t absolute;
     CFAbsoluteTime fixedat;
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     if (NULL != tz) {
 	__CFGenericValidateType(tz, CFTimeZoneGetTypeID());
     }
@@ -541,7 +541,7 @@ SInt32 CFAbsoluteTimeGetDayOfYear(CFAbsoluteTime at, CFTimeZoneRef tz) {
     CFAbsoluteTime fixedat;
     int64_t absolute, year;
     int8_t month, day;
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     if (NULL != tz) {
 	__CFGenericValidateType(tz, CFTimeZoneGetTypeID());
     }
@@ -560,7 +560,7 @@ SInt32 CFAbsoluteTimeGetWeekOfYear(CFAbsoluteTime at, CFTimeZoneRef tz) {
     int64_t absolute, year;
     int8_t month, day;
     CFAbsoluteTime fixedat;
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_WASI
     if (NULL != tz) {
 	__CFGenericValidateType(tz, CFTimeZoneGetTypeID());
     }


### PR DESCRIPTION
This commit adds `TARGET_OS_WASI` as ICU supported platform in `#if` conditions under `NumberDate.subproj`.