### PR TITLE
[wasm] Port CoreFoundation/Locale.subproj

### DIFF
--- a/CoreFoundation/Locale.subproj/CFLocale.c
+++ b/CoreFoundation/Locale.subproj/CFLocale.c
@@ -19,15 +19,11 @@
 #include <CoreFoundation/CFNumber.h>
 #include "CFInternal.h"
 #include "CFRuntime_Internal.h"
-#if !TARGET_OS_WASI
 #include <CoreFoundation/CFPreferences.h>
 #include "CFBundle_Internal.h"
-#else
-#include "CFBase.h"
-#endif
 #include "CFLocaleInternal.h"
 #include <stdatomic.h>
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include <unicode/uloc.h>           // ICU locales
 #include <unicode/ulocdata.h>       // ICU locale data
 #include <unicode/ucal.h>


### PR DESCRIPTION
* Remove no longer needed `#if !TARGET_OS_WASI`
* Add WASI to the list of ICU supported platforms