### PR TITLE
[wasm] Guard RunLoop.subproj sources with `__HAS_DISPATCH__`

### DIFF
--- a/CoreFoundation/RunLoop.subproj/CFRunLoop.c
+++ b/CoreFoundation/RunLoop.subproj/CFRunLoop.c
@@ -8,6 +8,8 @@
 	Responsibility: Michael LeHew
 */
 
+#if __HAS_DISPATCH__
+
 #include <CoreFoundation/CFRunLoop.h>
 #include <CoreFoundation/CFSet.h>
 #include <CoreFoundation/CFBag.h>
@@ -4756,3 +4758,4 @@ void CFRunLoopTimerSetTolerance(CFRunLoopTimerRef rlt, CFTimeInterval tolerance)
 #endif
 }
 
+#endif /* __HAS_DISPATCH__ */

--- a/CoreFoundation/RunLoop.subproj/CFSocket.c
+++ b/CoreFoundation/RunLoop.subproj/CFSocket.c
@@ -8,6 +8,8 @@
 	Responsibility: Michael LeHew
 */
 
+#if __HAS_DISPATCH__
+
 #include <CoreFoundation/CFSocket.h>
 #include <sys/types.h>
 #include <math.h>
@@ -2639,3 +2641,4 @@ CF_EXPORT uint16_t CFSocketGetDefaultNameRegistryPortNumber(void) {
     return __CFSocketDefaultNameRegistryPortNumber;
 }
 
+#endif /* __HAS_DISPATCH__ */


### PR DESCRIPTION
Guard out the whole source code for no-dispatch platforms. Excluding them from the build at all is one of the options, but it introduces some complexities in CMake build script just for the specific target, so I prefer this way.