### PR TITLE
[wasm] Define `_WASI_EMULATED_MMAN` to replace imports

### DIFF
--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -66,6 +66,11 @@
 #include <termios.h>
 #elif TARGET_OS_WASI
 #include <fcntl.h>
+// Define _WASI_EMULATED_MMAN here to use the emulated mman functions in
+// Foundation-side without requiring transitive clients to define it.
+#undef _WASI_EMULATED_MMAN
+#define _WASI_EMULATED_MMAN
+#include <sys/mman.h>
 #elif TARGET_OS_LINUX
 #include <errno.h>
 #include <features.h>

--- a/Sources/Foundation/Data.swift
+++ b/Sources/Foundation/Data.swift
@@ -36,11 +36,6 @@
 @usableFromInline let memcpy = Musl.memcpy
 @usableFromInline let memcmp = Musl.memcmp
 #elseif canImport(WASILibc)
-#if swift(>=6.0)
-private import wasi_emulated_mman
-#else
-import wasi_emulated_mman
-#endif
 @usableFromInline let calloc = WASILibc.calloc
 @usableFromInline let malloc = WASILibc.malloc
 @usableFromInline let free = WASILibc.free

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -29,7 +29,6 @@ fileprivate let _write = Musl.write(_:_:_:)
 fileprivate let _close = Musl.close(_:)
 #elseif canImport(WASILibc)
 import WASILibc
-@_implementationOnly import wasi_emulated_mman
 fileprivate let _read = WASILibc.read(_:_:_:)
 fileprivate let _write = WASILibc.write(_:_:_:)
 fileprivate let _close = WASILibc.close(_:)


### PR DESCRIPTION
The `wasi_emulated_mman` module must be imported with `@_implementationOnly` to avoid requiring Foundation users to enable `_WASI_EMULATED_MMAN` by themselves. "private import" does not work here because it still imports private dependencies while building a module that import Foundation.