### PR TITLE
[wasm] Miscellanous Base.subproj fixes

### DIFF
--- a/CoreFoundation/Base.subproj/CFPriv.h
+++ b/CoreFoundation/Base.subproj/CFPriv.h
@@ -46,10 +46,8 @@
 #include <CoreFoundation/CFMessagePort.h>
 #endif
 
-#if !TARGET_OS_WASI
 #include <CoreFoundation/CFRunLoop.h>
 #include <CoreFoundation/CFSocket.h>
-#endif
 #include <CoreFoundation/CFBundlePriv.h>
 
 

--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -239,12 +239,14 @@ _CFClassTables __CFRuntimeClassTables __attribute__((aligned)) = {
 
 
 
+#if !TARGET_OS_WASI
     [_kCFRuntimeIDCFRunLoopMode] = &__CFRunLoopModeClass,
     [_kCFRuntimeIDCFRunLoop] = &__CFRunLoopClass,
     [_kCFRuntimeIDCFRunLoopSource] = &__CFRunLoopSourceClass,
     [_kCFRuntimeIDCFRunLoopObserver] = &__CFRunLoopObserverClass,
     [_kCFRuntimeIDCFRunLoopTimer] = &__CFRunLoopTimerClass,
     [_kCFRuntimeIDCFSocket] = &__CFSocketClass,
+#endif
     [_kCFRuntimeIDCFReadStream] = &__CFReadStreamClass,
     [_kCFRuntimeIDCFWriteStream] = &__CFWriteStreamClass,
     [_kCFRuntimeIDCFAttributedString] = &__CFAttributedStringClass,

--- a/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
+++ b/CoreFoundation/Base.subproj/CoreFoundation_Prefix.h
@@ -260,7 +260,7 @@ CF_INLINE uint64_t mach_absolute_time() {
     ULONGLONG ullTime;
 	QueryUnbiasedInterruptTimePrecise(&ullTime);
     return ullTime;
-#elif TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_MAC
+#elif TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_MAC || TARGET_OS_WASI
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return (uint64_t)ts.tv_nsec + (uint64_t)ts.tv_sec * 1000000000UL;

--- a/CoreFoundation/Base.subproj/ForFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForFoundationOnly.h
@@ -28,10 +28,8 @@
 #include <CoreFoundation/CFBag.h>
 #include <CoreFoundation/CFCalendar.h>
 
-#if !TARGET_OS_WASI
 #include <CoreFoundation/CFStreamPriv.h>
 #include <CoreFoundation/CFRuntime.h>
-#endif
 #include <math.h>
 #include <limits.h>
 
@@ -102,7 +100,6 @@ CF_EXPORT BOOL _NSIsNSCFConstantString(NSISARGTYPE arg);
 CF_EXPORT BOOL _NSIsNSIndexSet(NSISARGTYPE arg);
 CF_EXPORT BOOL _NSIsNSAttributedString(NSISARGTYPE arg);
 
-#if !TARGET_OS_WASI
 #pragma mark - CFBundle
 
 #include <CoreFoundation/CFBundlePriv.h>
@@ -127,7 +124,6 @@ CF_EXPORT Boolean _CFBundleLoadExecutableAndReturnError(CFBundleRef bundle, Bool
 CF_EXPORT CFErrorRef _CFBundleCreateError(CFAllocatorRef _Nullable allocator, CFBundleRef bundle, CFIndex code);
 
 _CF_EXPORT_SCOPE_END
-#endif
 
 #pragma mark - CFUUID
 
@@ -651,7 +647,6 @@ CF_CROSS_PLATFORM_EXPORT void _CFURLInitWithFileSystemPathRelativeToBase(CFURLRe
 CF_CROSS_PLATFORM_EXPORT Boolean _CFURLInitWithURLString(CFURLRef url, CFStringRef string, Boolean checkForLegalCharacters, _Nullable CFURLRef baseURL);
 CF_CROSS_PLATFORM_EXPORT Boolean _CFURLInitAbsoluteURLWithBytes(CFURLRef url, const UInt8 *relativeURLBytes, CFIndex length, CFStringEncoding encoding, _Nullable CFURLRef baseURL);
 
-#if !TARGET_OS_WASI
 CF_EXPORT Boolean _CFRunLoopFinished(CFRunLoopRef rl, CFStringRef mode);
 CF_EXPORT CFTypeRef _CFRunLoopGet2(CFRunLoopRef rl);
 CF_EXPORT Boolean _CFRunLoopIsCurrent(CFRunLoopRef rl);
@@ -662,7 +657,6 @@ CF_EXPORT void _CFWriteStreamInitialize(CFWriteStreamRef writeStream);
 CF_EXPORT void _CFReadStreamDeallocate(CFReadStreamRef readStream);
 CF_EXPORT void _CFWriteStreamDeallocate(CFWriteStreamRef writeStream);
 CF_EXPORT CFReadStreamRef CFReadStreamCreateWithData(_Nullable CFAllocatorRef alloc, CFDataRef data);
-#endif
 
 #if TARGET_OS_MAC
 typedef struct {

--- a/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
+++ b/CoreFoundation/Base.subproj/ForSwiftFoundationOnly.h
@@ -66,6 +66,7 @@
 #include <termios.h>
 #elif TARGET_OS_WASI
 #include <fcntl.h>
+#include <sys/stat.h>
 // Define _WASI_EMULATED_MMAN here to use the emulated mman functions in
 // Foundation-side without requiring transitive clients to define it.
 #undef _WASI_EMULATED_MMAN
@@ -387,9 +388,7 @@ CF_PRIVATE uint64_t __CFMemorySize(void);
 CF_PRIVATE CFIndex __CFActiveProcessorCount(void);
 CF_CROSS_PLATFORM_EXPORT CFStringRef CFCopyFullUserName(void);
 
-#if !TARGET_OS_WASI
 extern CFWriteStreamRef _CFWriteStreamCreateFromFileDescriptor(CFAllocatorRef alloc, int fd);
-#endif
 
 #if !__COREFOUNDATION_FORFOUNDATIONONLY__
 typedef const struct __CFKeyedArchiverUID * CFKeyedArchiverUIDRef;
@@ -401,9 +400,7 @@ extern uint32_t _CFKeyedArchiverUIDGetValue(CFKeyedArchiverUIDRef uid);
 extern CFIndex __CFBinaryPlistWriteToStream(CFPropertyListRef plist, CFTypeRef stream);
 CF_CROSS_PLATFORM_EXPORT CFDataRef _CFPropertyListCreateXMLDataWithExtras(CFAllocatorRef allocator, CFPropertyListRef propertyList);
 
-#if !TARGET_OS_WASI
 extern CFWriteStreamRef _CFWriteStreamCreateFromFileDescriptor(CFAllocatorRef alloc, int fd);
-#endif
 
 CF_EXPORT char *_Nullable *_Nonnull _CFEnviron(void);
 
@@ -451,7 +448,6 @@ CF_EXPORT CFCharacterSetRef _CFCharacterSetCreateCopy(CFAllocatorRef alloc, CFCh
 CF_EXPORT CFMutableCharacterSetRef _CFCharacterSetCreateMutableCopy(CFAllocatorRef alloc, CFCharacterSetRef theSet);
 CF_CROSS_PLATFORM_EXPORT void _CFCharacterSetInitCopyingSet(CFAllocatorRef alloc, CFMutableCharacterSetRef cset, CFCharacterSetRef theSet, bool isMutable, bool validateSubclasses);
 
-#if !TARGET_OS_WASI
 CF_EXPORT _Nullable CFErrorRef CFReadStreamCopyError(CFReadStreamRef _Null_unspecified stream);
 
 CF_EXPORT _Nullable CFErrorRef CFWriteStreamCopyError(CFWriteStreamRef _Null_unspecified stream);
@@ -460,7 +456,6 @@ CF_CROSS_PLATFORM_EXPORT CFStringRef _Nullable _CFBundleCopyExecutablePath(CFBun
 CF_CROSS_PLATFORM_EXPORT Boolean _CFBundleSupportsFHSBundles(void);
 CF_CROSS_PLATFORM_EXPORT Boolean _CFBundleSupportsFreestandingBundles(void);
 CF_CROSS_PLATFORM_EXPORT CFStringRef _Nullable _CFBundleCopyLoadedImagePathForAddress(const void *p);
-#endif
 
 CF_CROSS_PLATFORM_EXPORT CFStringRef __CFTimeZoneCopyDataVersionString(void);
 
@@ -566,7 +561,7 @@ CF_CROSS_PLATFORM_EXPORT CFIndex __CFCharDigitValue(UniChar ch);
 
 #if TARGET_OS_WIN32
 CF_CROSS_PLATFORM_EXPORT int _CFOpenFileWithMode(const unsigned short *path, int opts, mode_t mode);
-#elif !TARGET_OS_WASI
+#else
 CF_CROSS_PLATFORM_EXPORT int _CFOpenFileWithMode(const char *path, int opts, mode_t mode);
 #endif
 CF_CROSS_PLATFORM_EXPORT void *_CFReallocf(void *ptr, size_t size);

--- a/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
+++ b/CoreFoundation/Base.subproj/SwiftRuntime/CoreFoundation.h
@@ -86,13 +86,15 @@
 #include <CoreFoundation/CFUUID.h>
 #include <CoreFoundation/CFUtilities.h>
 
-#if !TARGET_OS_WASI
 #include <CoreFoundation/CFBundle.h>
+#if !TARGET_OS_WASI
 #include <CoreFoundation/CFPlugIn.h>
 #include <CoreFoundation/CFMessagePort.h>
+#endif
 #include <CoreFoundation/CFPreferences.h>
 #include <CoreFoundation/CFRunLoop.h>
 #include <CoreFoundation/CFStream.h>
+#if !TARGET_OS_WASI
 #include <CoreFoundation/CFSocket.h>
 #include <CoreFoundation/CFMachPort.h>
 #endif


### PR DESCRIPTION
* Remove too conservative include guards
* Update class table to exclude unavailable classes
* Port mach_absolute_time to WASI platform

This is the final patch of the patch series for WebAssembly support.