### PR TITLE
Use `__attribute__ ((constructor))` instead of `INIT_ROUTINE` on macOS (Xcode)

### DIFF
--- a/CoreFoundation/Base.subproj/CFRuntime.c
+++ b/CoreFoundation/Base.subproj/CFRuntime.c
@@ -1164,7 +1164,7 @@ _CFThreadRef _CF_pthread_main_thread_np(void) {
 
 
 
-#if TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
+#if TARGET_OS_MAC || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 static void __CFInitialize(void) __attribute__ ((constructor));
 #endif
 #if TARGET_OS_WIN32

--- a/Foundation.xcodeproj/project.pbxproj
+++ b/Foundation.xcodeproj/project.pbxproj
@@ -3955,7 +3955,6 @@
 					/usr/include/libxml2,
 				);
 				INFOPLIST_FILE = Sources/Foundation/Resources/Info.plist;
-				INIT_ROUTINE = "___CFInitialize";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4033,7 +4032,6 @@
 					/usr/include/libxml2,
 				);
 				INFOPLIST_FILE = Sources/Foundation/Resources/Info.plist;
-				INIT_ROUTINE = "___CFInitialize";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
I'm not sure why but it looks like `__CFInitialize` is not called on macOS with Xcode.

ref: https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Tasks/InitializingFrameworks.html