### PR TITLE
Make package SCF depend on Apple swift-foundation repo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,8 +79,8 @@ let package = Package(
             url: "https://github.com/apple/swift-foundation-icu",
             exact: "0.0.5"),
         .package(
-           url: "https://github.com/parkera/swift-foundation",
-           branch: "scf-package"
+           url: "https://github.com/apple/swift-foundation",
+           revision: "543bd69d7dc6a077e1fae856002cf0d169bb9652"
         ),
     ],
     targets: [


### PR DESCRIPTION
This points the `package` branch at the `main` branch of Apple's swift-foundation repo. I use the `revision:` here instead of `branch: "main"` to ensure that the checkout has a new-enough commit of swift-foundation for the support needed.

I confirmed this builds on linux locally