### PR TITLE
Use the main branch of the apple swift-foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -79,8 +79,8 @@ let package = Package(
             url: "https://github.com/apple/swift-foundation-icu",
             exact: "0.0.5"),
         .package(
-           url: "https://github.com/parkera/swift-foundation",
-           branch: "scf-package"
+           url: "https://github.com/apple/swift-foundation",
+           branch: "main"
         ),
     ],
     targets: [


### PR DESCRIPTION
Now that we've merged the [swift-foundation](https://github.com/apple/swift-foundation/pull/514) we can use that branch for this package.