### PR TITLE
build: Repair the build on WASI platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,16 @@
 
 import PackageDescription
 
+let platformsWithThreads: [Platform] = [
+    .iOS,
+    .macOS,
+    .tvOS,
+    .watchOS,
+    .macCatalyst,
+    .driverKit,
+    .android,
+    .linux,
+]
 let buildSettings: [CSetting] = [
     .headerSearchPath("internalInclude"),
     .define("DEBUG", .when(configuration: .debug)),
@@ -10,12 +20,15 @@ let buildSettings: [CSetting] = [
     .define("DEPLOYMENT_RUNTIME_SWIFT"),
     .define("DEPLOYMENT_ENABLE_LIBDISPATCH"),
     .define("HAVE_STRUCT_TIMESPEC"),
-    .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS"),
+    .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS", .when(platforms: platformsWithThreads)),
     .define("_GNU_SOURCE", .when(platforms: [.linux, .android])),
     .define("CF_CHARACTERSET_UNICODE_DATA_L", to: "\"\(Context.packageDirectory)/Sources/CoreFoundation/CFUnicodeData-L.mapping\""),
     .define("CF_CHARACTERSET_UNICODE_DATA_B", to: "\"\(Context.packageDirectory)/Sources/CoreFoundation/CFUnicodeData-B.mapping\""),
     .define("CF_CHARACTERSET_UNICHAR_DB", to: "\"\(Context.packageDirectory)/Sources/CoreFoundation/CFUniCharPropertyDatabase.data\""),
     .define("CF_CHARACTERSET_BITMAP", to: "\"\(Context.packageDirectory)/Sources/CoreFoundation/CFCharacterSetBitmaps.bitmap\""),
+    .define("_WASI_EMULATED_SIGNAL", .when(platforms: [.wasi])),
+    .define("HAVE_STRLCPY", .when(platforms: [.wasi])),
+    .define("HAVE_STRLCAT", .when(platforms: [.wasi])),
     .unsafeFlags([
         "-Wno-shorten-64-to-32",
         "-Wno-deprecated-declarations",
@@ -43,8 +56,11 @@ let interfaceBuildSettings: [CSetting] = [
     .define("DEPLOYMENT_RUNTIME_SWIFT"),
     .define("DEPLOYMENT_ENABLE_LIBDISPATCH"),
     .define("HAVE_STRUCT_TIMESPEC"),
-    .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS"),
+    .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS", .when(platforms: platformsWithThreads)),
     .define("_GNU_SOURCE", .when(platforms: [.linux, .android])),
+    .define("_WASI_EMULATED_SIGNAL", .when(platforms: [.wasi])),
+    .define("HAVE_STRLCPY", .when(platforms: [.wasi])),
+    .define("HAVE_STRLCAT", .when(platforms: [.wasi])),
     .unsafeFlags([
         "-Wno-shorten-64-to-32",
         "-Wno-deprecated-declarations",
@@ -90,7 +106,10 @@ let package = Package(
                 "_CoreFoundation"
             ],
             path: "Sources/Foundation",
-            swiftSettings:  [.define("DEPLOYMENT_RUNTIME_SWIFT"), .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS")]
+            swiftSettings: [
+              .define("DEPLOYMENT_RUNTIME_SWIFT"),
+              .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS", .when(platforms: platformsWithThreads))
+            ]
         ),
         .target(
             name: "FoundationXML",
@@ -101,7 +120,10 @@ let package = Package(
                 "_CFXMLInterface"
             ],
             path: "Sources/FoundationXML",
-            swiftSettings:  [.define("DEPLOYMENT_RUNTIME_SWIFT"), .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS")]
+            swiftSettings: [
+              .define("DEPLOYMENT_RUNTIME_SWIFT"),
+              .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS", .when(platforms: platformsWithThreads))
+            ]
         ),
         .target(
             name: "FoundationNetworking",
@@ -112,7 +134,10 @@ let package = Package(
                 "_CFURLSessionInterface"
             ],
             path: "Sources/FoundationNetworking",
-            swiftSettings: [.define("DEPLOYMENT_RUNTIME_SWIFT"), .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS")]
+            swiftSettings: [
+              .define("DEPLOYMENT_RUNTIME_SWIFT"),
+              .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS", .when(platforms: platformsWithThreads))
+            ]
         ),
         .target(
             name: "_CoreFoundation",

--- a/Sources/CoreFoundation/CFBundle.c
+++ b/Sources/CoreFoundation/CFBundle.c
@@ -596,7 +596,13 @@ static CFBundleRef _CFBundleGetBundleWithIdentifier(CFStringRef bundleID, void *
 
 CFBundleRef CFBundleGetBundleWithIdentifier(CFStringRef bundleID) {
     // Use the frame that called this as a hint
-    return _CFBundleGetBundleWithIdentifier(bundleID, __builtin_return_address(0));
+    void *hint;
+#if TARGET_OS_WASI
+    hint = NULL;
+#else
+    hint = __builtin_frame_address(0);
+#endif
+    return _CFBundleGetBundleWithIdentifier(bundleID, hint);
 }
 
 CFBundleRef _CFBundleGetBundleWithIdentifierWithHint(CFStringRef bundleID, void *pointer) {

--- a/Sources/CoreFoundation/CFString.c
+++ b/Sources/CoreFoundation/CFString.c
@@ -28,7 +28,7 @@
 #include "CFRuntime_Internal.h"
 #include <assert.h>
 #include <unicode/uchar.h>
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include "CFConstantKeys.h"
 #include "CFStringLocalizedFormattingInternal.h"
 #endif


### PR DESCRIPTION
Fixes package-nized build for WASI of `_CoreFoundation`.
```console
$ swift --version
Swift version 6.0-dev (LLVM b7b175a4a1263ea, Swift 07eb52a80dee5a1)
Target: x86_64-unknown-linux-gnu
$ swift experimental-sdk install https://github.com/swiftwasm/swift/releases/download/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-03-29-a/swift-wasm-DEVELOPMENT-SNAPSHOT-2024-03-29-a-ubuntu22.04_x86_64.artifactbundle.zip
$ swift build --experimental-swift-sdk DEVELOPMENT-SNAPSHOT-2024-03-29-a-wasm --target _CoreFoundation
```

The `Foundation` product needs macro with cross-compilation support in SwiftPM, so it's still not working yet.