### PR TITLE
add Sendable conformance to NSLock

### DIFF
--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -166,7 +166,7 @@ extension NSLock {
 }
 
 #if SWIFT_CORELIBS_FOUNDATION_HAS_THREADS
-open class NSConditionLock : NSObject, NSLocking {
+open class NSConditionLock : NSObject, NSLocking, @unchecked Sendable {
     internal var _cond = NSCondition()
     internal var _value: Int
     internal var _thread: _swift_CFThreadRef?
@@ -260,7 +260,7 @@ open class NSConditionLock : NSObject, NSLocking {
 }
 #endif
 
-open class NSRecursiveLock: NSObject, NSLocking {
+open class NSRecursiveLock: NSObject, NSLocking, @unchecked Sendable {
     internal var mutex = _RecursiveMutexPointer.allocate(capacity: 1)
 #if os(macOS) || os(iOS) || os(Windows)
     private var timeoutCond = _ConditionVariablePointer.allocate(capacity: 1)
@@ -382,7 +382,7 @@ open class NSRecursiveLock: NSObject, NSLocking {
     open var name: String?
 }
 
-open class NSCondition: NSObject, NSLocking {
+open class NSCondition: NSObject, NSLocking, @unchecked Sendable {
     internal var mutex = _MutexPointer.allocate(capacity: 1)
     internal var cond = _ConditionVariablePointer.allocate(capacity: 1)
 

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -50,7 +50,7 @@ private typealias _ConditionVariablePointer = UnsafeMutablePointer<pthread_cond_
 #endif
 
 // fix for: https://github.com/apple/swift-corelibs-foundation/issues/4941
-open class NSLock: NSObject, NSLocking, Sendable {
+open class NSLock: NSObject, NSLocking, @unchecked Sendable {
     internal var mutex = _MutexPointer.allocate(capacity: 1)
 #if os(macOS) || os(iOS) || os(Windows)
     private var timeoutCond = _ConditionVariablePointer.allocate(capacity: 1)

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -49,7 +49,8 @@ private typealias _RecursiveMutexPointer = UnsafeMutablePointer<pthread_mutex_t>
 private typealias _ConditionVariablePointer = UnsafeMutablePointer<pthread_cond_t>
 #endif
 
-open class NSLock: NSObject, NSLocking {
+// fix for: https://github.com/apple/swift-corelibs-foundation/issues/4941
+open class NSLock: NSObject, NSLocking, Sendable {
     internal var mutex = _MutexPointer.allocate(capacity: 1)
 #if os(macOS) || os(iOS) || os(Windows)
     private var timeoutCond = _ConditionVariablePointer.allocate(capacity: 1)

--- a/Sources/Foundation/NSLock.swift
+++ b/Sources/Foundation/NSLock.swift
@@ -49,7 +49,6 @@ private typealias _RecursiveMutexPointer = UnsafeMutablePointer<pthread_mutex_t>
 private typealias _ConditionVariablePointer = UnsafeMutablePointer<pthread_cond_t>
 #endif
 
-// fix for: https://github.com/apple/swift-corelibs-foundation/issues/4941
 open class NSLock: NSObject, NSLocking, @unchecked Sendable {
     internal var mutex = _MutexPointer.allocate(capacity: 1)
 #if os(macOS) || os(iOS) || os(Windows)


### PR DESCRIPTION
As per issue: https://github.com/apple/swift-corelibs-foundation/issues/4941  and forum discussion: https://forums.swift.org/t/sendable-conformance-of-nslock-on-linux/71506

Resolves #4941