### PR TITLE
🍒[Swift 5.10] Stop assuming `CFSTR` is a constant-time expression with Clang 15

### DIFF
--- a/CoreFoundation/Locale.subproj/CFLocale.c
+++ b/CoreFoundation/Locale.subproj/CFLocale.c
@@ -1274,7 +1274,7 @@ static bool __CFLocaleCopyLocaleID(CFLocaleRef locale, bool user, CFTypeRef *cf,
 
 
 static bool __CFLocaleCopyCodes(CFLocaleRef locale, bool user, CFTypeRef *cf, CFStringRef context) {
-    static CFStringRef const kCFLocaleCodesKey = CFSTR("__kCFLocaleCodes");
+    CFStringRef const kCFLocaleCodesKey = CFSTR("__kCFLocaleCodes");
     
     bool codesWasAllocated = false;
     CFDictionaryRef codes = NULL;

--- a/CoreFoundation/PlugIn.subproj/CFBundle_Locale.c
+++ b/CoreFoundation/PlugIn.subproj/CFBundle_Locale.c
@@ -148,8 +148,8 @@ const char * const __CFBundleLanguageAbbreviationsArray =
 static CFStringRef _CFBundleGetAlternateNameForLanguage(CFStringRef language) {
     // These are not necessarily common localizations per se, but localizations for which the full language name is still in common use.
     // These are used to provide a fast path for it (other localizations usually use the abbreviation, which is even faster).
-    static CFStringRef const __CFBundleCommonLanguageNamesArray[] = {CFSTR("English"), CFSTR("French"), CFSTR("German"), CFSTR("Italian"), CFSTR("Dutch"), CFSTR("Spanish"), CFSTR("Japanese")};
-    static CFStringRef const __CFBundleCommonLanguageAbbreviationsArray[] = {CFSTR("en"), CFSTR("fr"), CFSTR("de"), CFSTR("it"), CFSTR("nl"), CFSTR("es"), CFSTR("ja")};
+    CFStringRef const __CFBundleCommonLanguageNamesArray[] = {CFSTR("English"), CFSTR("French"), CFSTR("German"), CFSTR("Italian"), CFSTR("Dutch"), CFSTR("Spanish"), CFSTR("Japanese")};
+    CFStringRef const __CFBundleCommonLanguageAbbreviationsArray[] = {CFSTR("en"), CFSTR("fr"), CFSTR("de"), CFSTR("it"), CFSTR("nl"), CFSTR("es"), CFSTR("ja")};
     
     for (CFIndex idx = 0; idx < sizeof(__CFBundleCommonLanguageNamesArray) / sizeof(CFStringRef); idx++) {
         if (CFEqual(language, __CFBundleCommonLanguageAbbreviationsArray[idx])) {


### PR DESCRIPTION
From Clang 15, nested static initializer inside statement-expression is no longer a constant-time expression (See https://reviews.llvm.org/D127201). OSS Foundation defines `CFSTR` as a macro rather than `__builtin___CFStringMakeConstantString` and it uses nested static initializer inside statement-expression, so we can't assume `CFSTR` itself is always a constant-time expression.
This patch removes some `static` qualifiers associated with `CFSTR` to make them acceptable with Clang 15 and later.