### PR TITLE
[Windows] Use `fd_set` according to Winsock2 specifics

### DIFF
--- a/Tests/Foundation/Tests/TestSocketPort.swift
+++ b/Tests/Foundation/Tests/TestSocketPort.swift
@@ -106,11 +106,55 @@ class TestSocketPort : XCTestCase {
         }
     }
     
+    func testSendingMultipleMessagesRemoteToLocal() throws {
+        var localPorts = [SocketPort]()
+        var remotePorts = [SocketPort]()
+        var delegates = [TestPortDelegateWithBlock]()
+
+        let data = Data("I cannot weave".utf8)
+
+        for _ in 0..<128 {
+            let local = try XCTUnwrap(SocketPort(tcpPort: 0))
+            let tcpPort = try UInt16(XCTUnwrap(tcpOrUdpPort(of: local)))
+            let remote = try XCTUnwrap(SocketPort(remoteWithTCPPort: tcpPort, host: "localhost"))
+            
+            let received = expectation(description: "Message received")
+
+            let localDelegate = TestPortDelegateWithBlock { message in
+                XCTAssertEqual(message.components as? [AnyHashable], [data as NSData])
+                received.fulfill()
+            }
+
+            localPorts.append(local)
+            remotePorts.append(remote)
+            delegates.append(localDelegate)
+
+            local.setDelegate(localDelegate)
+            local.schedule(in: .main, forMode: .default)
+            remote.schedule(in: .main, forMode: .default)
+        }
+
+        withExtendedLifetime(delegates) {
+            for remote in remotePorts {
+                let sent = remote.send(before: Date(timeIntervalSinceNow: 5), components: NSMutableArray(array: [data]), from: nil, reserved: 0)
+                XCTAssertTrue(sent)
+            }
+            waitForExpectations(timeout: 5.0)
+        }
+
+        for port in localPorts + remotePorts {
+            port.setDelegate(nil)
+            port.remove(from: .main, forMode: .default)
+            port.invalidate()
+        }
+    }
+
     static var allTests: [(String, (TestSocketPort) -> () throws -> Void)] {
         return [
             ("testRemoteSocketPortsAreUniqued", testRemoteSocketPortsAreUniqued),
             ("testInitPicksATCPPort", testInitPicksATCPPort),
             ("testSendingOneMessageRemoteToLocal", testSendingOneMessageRemoteToLocal),
+            ("testSendingMultipleMessagesRemoteToLocal", testSendingMultipleMessagesRemoteToLocal),
         ]
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/73532.

On Windows, socket handles in a `fd_set` are not represented as bit flags as in Berkeley sockets. While we have no `fd_set` dynamic growth in this implementation, the `FD_SETSIZE` defined as 1024 in `CoreFoundation_Prefix.h` should be enough for majority of tasks.

This also includes a test for `SocketPort` which uses `CFSocket` internally. This test fails (hangs or crashes with memory corruption error) without the fix.
