### PR TITLE
Remove URL in favor of swift-foundation's URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -78,7 +78,7 @@ let package = Package(
             from: "0.0.5"),
         .package(
            url: "https://github.com/apple/swift-foundation",
-           revision: "7eb8b598ad8f77ac743b2decc97d56bf350aedee"
+           revision: "51190dde413432045f7960a92c088ded5f5db1be"
         ),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -78,7 +78,7 @@ let package = Package(
             from: "0.0.5"),
         .package(
            url: "https://github.com/apple/swift-foundation",
-           revision: "51190dde413432045f7960a92c088ded5f5db1be"
+           revision: "e991656bd02af48530811f1871b3351961b75d29"
         ),
     ],
     targets: [

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -972,7 +972,7 @@ open class FileManager : NSObject {
                 isDirectory.boolValue {
                 for language in _preferredLanguages {
                     let stringsFile = dotLocalized.appendingPathComponent(language).appendingPathExtension("strings")
-                    if let data = try? Data(contentsOf: stringsFile.path),
+                    if let data = try? Data(contentsOf: stringsFile),
                        let plist = (try? PropertyListSerialization.propertyList(from: data, format: nil)) as? NSDictionary {
                             
                         let localizedName = (plist[nameWithoutExtension] as? NSString)?._swiftObject
@@ -1034,13 +1034,13 @@ open class FileManager : NSObject {
     /* These methods are provided here for compatibility. The corresponding methods on NSData which return NSErrors should be regarded as the primary method of creating a file from an NSData or retrieving the contents of a file as an NSData.
      */
     open func contents(atPath path: String) -> Data? {
-        return try? Data(contentsOf: path)
+        return try? Data(contentsOf: URL(fileURLWithPath: path))
     }
 
     @discardableResult
     open func createFile(atPath path: String, contents data: Data?, attributes attr: [FileAttributeKey : Any]? = nil) -> Bool {
         do {
-            try (data ?? Data()).write(to: path, options: .atomic)
+            try (data ?? Data()).write(to: URL(fileURLWithPath: path), options: .atomic)
             if let attr = attr {
                 try self.setAttributes(attr, ofItemAtPath: path)
             }

--- a/Sources/Foundation/NSArray.swift
+++ b/Sources/Foundation/NSArray.swift
@@ -458,7 +458,7 @@ open class NSArray : NSObject, NSCopying, NSMutableCopying, NSSecureCoding, NSCo
     open func write(to url: URL, atomically: Bool) -> Bool {
         do {
             let pListData = try PropertyListSerialization.data(fromPropertyList: self, format: .xml, options: 0)
-            try pListData.write(to: url.path, options: atomically ? .atomic : [])
+            try pListData.write(to: url, options: atomically ? .atomic : [])
             return true
         } catch {
             return false

--- a/Sources/Foundation/NSCharacterSet.swift
+++ b/Sources/Foundation/NSCharacterSet.swift
@@ -186,7 +186,7 @@ open class NSCharacterSet : NSObject, NSCopying, NSMutableCopying, NSSecureCodin
     
     public convenience init?(contentsOfFile fName: String) {
         do {
-           let data = try Data(contentsOf: fName)
+           let data = try Data(contentsOf: URL(fileURLWithPath: fName))
             self.init(bitmapRepresentation: data)
         } catch {
             return nil

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -1202,19 +1202,6 @@ extension NSData {
     }
 }
 
-// MARK: - Temporary URL support
-
-extension Data {
-    // Temporary until SwiftFoundation supports this
-    public init(contentsOf url: URL, options: ReadingOptions = []) throws {
-        self = try .init(contentsOf: url.path, options: options)
-    }
-
-    public func write(to url: URL, options: WritingOptions = []) throws {
-        try write(to: url.path, options: options)
-    }
-}
-
 // MARK: - Bridging
 
 extension Data {

--- a/Sources/Foundation/NSDictionary.swift
+++ b/Sources/Foundation/NSDictionary.swift
@@ -82,7 +82,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     @available(*, deprecated)
     public convenience init?(contentsOf url: URL) {
         do {
-            guard let plistDoc = try? Data(contentsOf: url.path) else { return nil }
+            guard let plistDoc = try? Data(contentsOf: url) else { return nil }
             let plistDict = try PropertyListSerialization.propertyList(from: plistDoc, options: [], format: nil) as? Dictionary<AnyHashable,Any>
             guard let plistDictionary = plistDict else { return nil }
             self.init(dictionary: plistDictionary)
@@ -509,7 +509,7 @@ open class NSDictionary : NSObject, NSCopying, NSMutableCopying, NSSecureCoding,
     open func write(to url: URL, atomically: Bool) -> Bool {
         do {
             let pListData = try PropertyListSerialization.data(fromPropertyList: self, format: .xml, options: 0)
-            try pListData.write(to: url.path, options: atomically ? .atomic : [])
+            try pListData.write(to: url, options: atomically ? .atomic : [])
             return true
         } catch {
             return false

--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -605,17 +605,6 @@ extension CocoaError : _BridgedStoredNSError {
     }
 }
 
-extension CocoaError {
-    // Temporary extension to take Foundation.URL, until FoundationEssentials.URL is fully ported
-    public static func error(_ code: CocoaError.Code, userInfo: [String : AnyHashable]? = nil, url: Foundation.URL? = nil) -> Error {
-        var info: [String : AnyHashable] = userInfo ?? [:]
-        if let url = url {
-            info[NSURLErrorKey] = url
-        }
-        return CocoaError(code, userInfo: info)
-    }    
-}
-
 extension CocoaError.Code : _ErrorCodeProtocol {
     public typealias _ErrorType = CocoaError
 }
@@ -766,6 +755,27 @@ extension CocoaError {
 
     public var isXPCConnectionError: Bool {
         return code.rawValue >= 4096 && code.rawValue <= 4224
+    }
+}
+
+extension CocoaError: _ObjectiveCBridgeable {
+    public func _bridgeToObjectiveC() -> NSError {
+        return self._nsError
+    }
+
+    public static func _forceBridgeFromObjectiveC(_ x: NSError, result: inout CocoaError?) {
+        result = _unconditionallyBridgeFromObjectiveC(x)
+    }
+
+    public static func _conditionallyBridgeFromObjectiveC(_ x: NSError, result: inout CocoaError?) -> Bool {
+        result = CocoaError(_nsError: x)
+        return true
+    }
+
+    public static func _unconditionallyBridgeFromObjectiveC(_ source: NSError?) -> CocoaError {
+        var result: CocoaError?
+        _forceBridgeFromObjectiveC(source!, result: &result)
+        return result!
     }
 }
 

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1259,8 +1259,7 @@ extension NSString {
     internal func _writeTo(_ url: URL, _ useAuxiliaryFile: Bool, _ enc: UInt) throws {
         var data = Data()
         try _getExternalRepresentation(&data, url, enc)
-        // TODO: Use URL version when that is ready
-        try data.write(to: url.path, options: useAuxiliaryFile ? .atomic : [])
+        try data.write(to: url, options: useAuxiliaryFile ? .atomic : [])
     }
     
     open func write(to url: URL, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -1024,7 +1024,7 @@ extension NSURL {
 
 extension NSURL: _SwiftBridgeable {
     typealias SwiftType = URL
-    internal var _swiftObject: SwiftType { return URL(reference: self) }
+    internal var _swiftObject: SwiftType { return self as URL }
 }
 
 extension CFURL : _NSBridgeable, _SwiftBridgeable {
@@ -1037,7 +1037,7 @@ extension CFURL : _NSBridgeable, _SwiftBridgeable {
 extension URL : _NSBridgeable {
     typealias NSType = NSURL
     typealias CFType = CFURL
-    internal var _nsObject: NSType { return self.reference }
+    internal var _nsObject: NSType { return self as NSURL }
     internal var _cfObject: CFType { return _nsObject._cfObject }
 }
 

--- a/Sources/Foundation/NSURLComponents.swift
+++ b/Sources/Foundation/NSURLComponents.swift
@@ -82,7 +82,7 @@ open class NSURLComponents: NSObject, NSCopying {
     // Returns a URL created from the NSURLComponents. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
     open var url: URL? {
         guard let result = _CFURLComponentsCopyURL(_components) else { return nil }
-        return unsafeBitCast(result, to: URL.self)
+        return result._swiftObject
     }
 
     // Returns a URL created from the NSURLComponents relative to a base URL. If the NSURLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the NSURLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.

--- a/Sources/Foundation/URLComponents.swift
+++ b/Sources/Foundation/URLComponents.swift
@@ -7,333 +7,18 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 
-
-/// A structure designed to parse URLs based on RFC 3986 and to construct URLs from their constituent parts.
-///
-/// Its behavior differs subtly from the `URL` struct, which conforms to older RFCs. However, you can easily obtain a `URL` based on the contents of a `URLComponents` or vice versa.
-public struct URLComponents : ReferenceConvertible, Hashable, Equatable, _MutableBoxing {
+extension URLComponents : ReferenceConvertible {
     public typealias ReferenceType = NSURLComponents
-    
-    internal var _handle: _MutableHandle<NSURLComponents>
-    
-    /// Initialize with all components undefined.
-    public init() {
-        _handle = _MutableHandle(adoptingReference: NSURLComponents())
-    }
-    
-    /// Initialize with the components of a URL.
-    ///
-    /// If resolvingAgainstBaseURL is `true` and url is a relative URL, the components of url.absoluteURL are used. If the url string from the URL is malformed, nil is returned.
-    public init?(url: URL, resolvingAgainstBaseURL resolve: Bool) {
-        guard let result = NSURLComponents(url: url, resolvingAgainstBaseURL: resolve) else { return nil }
-        _handle = _MutableHandle(adoptingReference: result)
-    }
-    
-    /// Initialize with a URL string.
-    ///
-    /// If the URLString is malformed, nil is returned.
-    public init?(string: String) {
-        guard let result = NSURLComponents(string: string) else { return nil }
-        _handle = _MutableHandle(adoptingReference: result)
-    }
-    
-    /// Returns a URL created from the URLComponents.
-    ///
-    /// If the URLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the URLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
-    public var url: URL? {
-        return _handle.map { $0.url }
-    }
-    
-    /// Returns a URL created from the URLComponents relative to a base URL.
-    ///
-    /// If the URLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the URLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
-    public func url(relativeTo base: URL?) -> URL? {
-        return _handle.map { $0.url(relativeTo: base) }
-    }
-    
-    // Returns a URL string created from the URLComponents. If the URLComponents has an authority component (user, password, host or port) and a path component, then the path must either begin with "/" or be an empty string. If the URLComponents does not have an authority component (user, password, host or port) and has a path component, the path component must not start with "//". If those requirements are not met, nil is returned.
-    public var string: String? {
-        return _handle.map { $0.string }
-    }
-    
-    /// The scheme subcomponent of the URL.
-    ///
-    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    /// Attempting to set the scheme with an invalid scheme string will cause an exception.
-    public var scheme: String? {
-        get { return _handle.map { $0.scheme } }
-        set { _applyMutation { $0.scheme = newValue } }
-    }
-    
-    /// The user subcomponent of the URL.
-    ///
-    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    ///
-    /// Warning: IETF STD 66 (rfc3986) says the use of the format "user:password" in the userinfo subcomponent of a URI is deprecated because passing authentication information in clear text has proven to be a security risk. However, there are cases where this practice is still needed, and so the user and password components and methods are provided.
-    public var user: String? {
-        get { return _handle.map { $0.user } }
-        set { _applyMutation { $0.user = newValue } }
-    }
-    
-    /// The password subcomponent of the URL.
-    ///
-    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    ///
-    /// Warning: IETF STD 66 (rfc3986) says the use of the format "user:password" in the userinfo subcomponent of a URI is deprecated because passing authentication information in clear text has proven to be a security risk. However, there are cases where this practice is still needed, and so the user and password components and methods are provided.
-    public var password: String? {
-        get { return _handle.map { $0.password } }
-        set { _applyMutation { $0.password = newValue } }
-    }
-    
-    /// The host subcomponent.
-    ///
-    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    public var host: String? {
-        get { return _handle.map { $0.host } }
-        set { _applyMutation { $0.host = newValue } }
-    }
-    
-    /// The port subcomponent.
-    ///
-    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    /// Attempting to set a negative port number will cause a fatal error.
-    public var port: Int? {
-        get { return _handle.map { $0.port?.intValue } }
-        set { _applyMutation { $0.port = newValue != nil ? NSNumber(value: newValue!) : nil as NSNumber?} }
-    }
-    
-    /// The path subcomponent.
-    ///
-    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    public var path: String {
-        get {
-            return _handle.map { $0.path } ?? ""
-        }
-        set {
-            _applyMutation { $0.path = newValue }
-        }
-    }
-    
-    /// The query subcomponent.
-    ///
-    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    public var query: String? {
-        get { return _handle.map { $0.query } }
-        set { _applyMutation { $0.query = newValue } }
-    }
-    
-    /// The fragment subcomponent.
-    ///
-    /// The getter for this property removes any percent encoding this component may have (if the component allows percent encoding). Setting this property assumes the subcomponent or component string is not percent encoded and will add percent encoding (if the component allows percent encoding).
-    public var fragment: String? {
-        get { return _handle.map { $0.fragment } }
-        set { _applyMutation { $0.fragment = newValue } }
-    }
-    
-    
-    /// The user subcomponent, percent-encoded.
-    ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlUserAllowed`).
-    public var percentEncodedUser: String? {
-        get { return _handle.map { $0.percentEncodedUser } }
-        set { _applyMutation { $0.percentEncodedUser = newValue } }
-    }
-    
-    /// The password subcomponent, percent-encoded.
-    ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPasswordAllowed`).
-    public var percentEncodedPassword: String? {
-        get { return _handle.map { $0.percentEncodedPassword } }
-        set { _applyMutation { $0.percentEncodedPassword = newValue } }
-    }
-    
-    /// The host subcomponent, percent-encoded.
-    ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlHostAllowed`).
-    public var percentEncodedHost: String? {
-        get { return _handle.map { $0.percentEncodedHost } }
-        set { _applyMutation { $0.percentEncodedHost = newValue } }
-    }
-    
-    /// The path subcomponent, percent-encoded.
-    ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlPathAllowed`).
-    public var percentEncodedPath: String {
-        get {
-            return _handle.map { $0.percentEncodedPath } ?? ""
-        }
-        set {
-            _applyMutation { $0.percentEncodedPath = newValue }
-        }
-    }
-    
-    /// The query subcomponent, percent-encoded.
-    ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlQueryAllowed`).
-    public var percentEncodedQuery: String? {
-        get { return _handle.map { $0.percentEncodedQuery } }
-        set { _applyMutation { $0.percentEncodedQuery = newValue } }
-    }
-    
-    /// The fragment subcomponent, percent-encoded.
-    ///
-    /// The getter for this property retains any percent encoding this component may have. Setting this properties assumes the component string is already correctly percent encoded. Attempting to set an incorrectly percent encoded string will cause a `fatalError`. Although ';' is a legal path character, it is recommended that it be percent-encoded for best compatibility with `URL` (`String.addingPercentEncoding(withAllowedCharacters:)` will percent-encode any ';' characters if you pass `CharacterSet.urlFragmentAllowed`).
-    public var percentEncodedFragment: String? {
-        get { return _handle.map { $0.percentEncodedFragment } }
-        set { _applyMutation { $0.percentEncodedFragment = newValue } }
-    }
-    
-    private func _toStringRange(_ r : NSRange) -> Range<String.Index>? {
-        guard let s = self.string, r.location != NSNotFound else { return nil }
-        let start = String.Index(utf16Offset: r.location, in: s)
-        let end = String.Index(utf16Offset: r.location + r.length, in: s)
-        return start..<end
-    }
-    
-    /// Returns the character range of the scheme in the string returned by `var string`.
-    ///
-    /// If the component does not exist, nil is returned.
-    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
-    public var rangeOfScheme: Range<String.Index>? {
-        return _toStringRange(_handle.map { $0.rangeOfScheme })
-    }
-    
-    /// Returns the character range of the user in the string returned by `var string`.
-    ///
-    /// If the component does not exist, nil is returned.
-    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
-    public var rangeOfUser: Range<String.Index>? {
-        return _toStringRange(_handle.map { $0.rangeOfUser})
-    }
-    
-    /// Returns the character range of the password in the string returned by `var string`.
-    ///
-    /// If the component does not exist, nil is returned.
-    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
-    public var rangeOfPassword: Range<String.Index>? {
-        return _toStringRange(_handle.map { $0.rangeOfPassword})
-    }
-    
-    /// Returns the character range of the host in the string returned by `var string`.
-    ///
-    /// If the component does not exist, nil is returned.
-    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
-    public var rangeOfHost: Range<String.Index>? {
-        return _toStringRange(_handle.map { $0.rangeOfHost})
-    }
-    
-    /// Returns the character range of the port in the string returned by `var string`.
-    ///
-    /// If the component does not exist, nil is returned.
-    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
-    public var rangeOfPort: Range<String.Index>? {
-        return _toStringRange(_handle.map { $0.rangeOfPort})
-    }
-    
-    /// Returns the character range of the path in the string returned by `var string`.
-    ///
-    /// If the component does not exist, nil is returned.
-    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
-    public var rangeOfPath: Range<String.Index>? {
-        return _toStringRange(_handle.map { $0.rangeOfPath})
-    }
-    
-    /// Returns the character range of the query in the string returned by `var string`.
-    ///
-    /// If the component does not exist, nil is returned.
-    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
-    public var rangeOfQuery: Range<String.Index>? {
-        return _toStringRange(_handle.map { $0.rangeOfQuery})
-    }
-    
-    /// Returns the character range of the fragment in the string returned by `var string`.
-    ///
-    /// If the component does not exist, nil is returned.
-    /// - note: Zero length components are legal. For example, the URL string "scheme://:@/?#" has a zero length user, password, host, query and fragment; the URL strings "scheme:" and "" both have a zero length path.
-    public var rangeOfFragment: Range<String.Index>? {
-        return _toStringRange(_handle.map { $0.rangeOfFragment})
-    }
-    
-    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string.
-    ///
-    /// Each `URLQueryItem` represents a single key-value pair,
-    ///
-    /// Note that a name may appear more than once in a single query string, so the name values are not guaranteed to be unique. If the `URLComponents` has an empty query component, returns an empty array. If the `URLComponents` has no query component, returns nil.
-    ///
-    /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. Passing an empty array sets the query component of the `URLComponents` to an empty string. Passing nil removes the query component of the `URLComponents`.
-    ///
-    /// - note: If a name-value pair in a query is empty (i.e. the query string starts with '&', ends with '&', or has "&&" within it), you get a `URLQueryItem` with a zero-length name and and a nil value. If a query's name-value pair has nothing before the equals sign, you get a zero-length name. If a query's name-value pair has nothing after the equals sign, you get a zero-length value. If a query's name-value pair has no equals sign, the query name-value pair string is the name and you get a nil value.
-    public var queryItems: [URLQueryItem]? {
-        get { return _handle.map { $0.queryItems } }
-        set { _applyMutation { $0.queryItems = newValue } }
-    }
-    
-    /// Returns an array of query items for this `URLComponents`, in the order in which they appear in the original query string. Any percent-encoding in a query item name or value is retained
-    ///
-    /// The setter combines an array containing any number of `URLQueryItem`s, each of which represents a single key-value pair, into a query string and sets the `URLComponents` query property. This property assumes the query item names and values are already correctly percent-encoded, and that the query item names do not contain the query item delimiter characters '&' and '='. Attempting to set an incorrectly percent-encoded query item or a query item name with the query item delimiter characters '&' and '=' will cause a `fatalError`.
-    public var percentEncodedQueryItems: [URLQueryItem]? {
-        get { return _handle.map { $0.percentEncodedQueryItems } }
-        set { _applyMutation { $0.percentEncodedQueryItems = newValue } }
-    }
-
-public func hash(into hasher: inout Hasher) {
-        hasher.combine(_handle.map { $0 })
-    }
-
-    // MARK: - Bridging
-    
-    fileprivate init(reference: NSURLComponents) {
-        _handle = _MutableHandle(reference: reference)
-    }
-    
-    public static func ==(lhs: URLComponents, rhs: URLComponents) -> Bool {
-        // Don't copy references here; no one should be storing anything
-        return lhs._handle._uncopiedReference().isEqual(rhs._handle._uncopiedReference())
-    }
-}
-
-extension URLComponents : CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable {
-    public var description: String {
-        if let u = url {
-            return u.description
-        } else {
-            return self.customMirror.children.reduce("") {
-                $0.appending("\($1.label ?? ""): \($1.value) ")
-            }
-        }
-    }
-    
-    public var debugDescription: String {
-        return self.description
-    }
-    
-    public var customMirror: Mirror {
-        var c: [(label: String?, value: Any)] = []
-        
-        if let s = self.scheme { c.append((label: "scheme", value: s)) }
-        if let u = self.user { c.append((label: "user", value: u)) }
-        if let pw = self.password { c.append((label: "password", value: pw)) }
-        if let h = self.host { c.append((label: "host", value: h)) }
-        if let p = self.port { c.append((label: "port", value: p)) }
-        
-        c.append((label: "path", value: self.path))
-        if #available(macOS 10.10, iOS 8.0, *) {
-            if let qi = self.queryItems { c.append((label: "queryItems", value: qi )) }
-        }
-        if let f = self.fragment { c.append((label: "fragment", value: f)) }
-        let m = Mirror(self, children: c, displayStyle: .struct)
-        return m
-    }
 }
 
 extension NSURLComponents : _SwiftBridgeable {
     typealias SwiftType = URLComponents
-    internal var _swiftObject: SwiftType { return URLComponents(reference: self) }
+    internal var _swiftObject: SwiftType { return URLComponents(string: self.string!)! }
 }
 
 extension URLComponents : _NSBridgeable {
     typealias NSType = NSURLComponents
-    internal var _nsObject: NSType { return _handle._copiedReference() }
+    internal var _nsObject: NSType { return NSURLComponents(string: self.string!)! }
 }
 
 extension URLComponents : _ObjectiveCBridgeable {
@@ -345,7 +30,7 @@ extension URLComponents : _ObjectiveCBridgeable {
     
     @_semantics("convertToObjectiveC")
     public func _bridgeToObjectiveC() -> NSURLComponents {
-        return _handle._copiedReference()
+        return _nsObject
     }
     
     public static func _forceBridgeFromObjectiveC(_ x: NSURLComponents, result: inout URLComponents?) {
@@ -355,7 +40,7 @@ extension URLComponents : _ObjectiveCBridgeable {
     }
     
     public static func _conditionallyBridgeFromObjectiveC(_ x: NSURLComponents, result: inout URLComponents?) -> Bool {
-        result = URLComponents(reference: x)
+        result = x._swiftObject
         return true
     }
     
@@ -363,44 +48,5 @@ extension URLComponents : _ObjectiveCBridgeable {
         var result: URLComponents? = nil
         _forceBridgeFromObjectiveC(source!, result: &result)
         return result!
-    }
-}
-
-extension URLComponents : Codable {
-    private enum CodingKeys : Int, CodingKey {
-        case scheme
-        case user
-        case password
-        case host
-        case port
-        case path
-        case query
-        case fragment
-    }
-
-    public init(from decoder: Decoder) throws {
-        self.init()
-
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.scheme = try container.decodeIfPresent(String.self, forKey: .scheme)
-        self.user = try container.decodeIfPresent(String.self, forKey: .user)
-        self.password = try container.decodeIfPresent(String.self, forKey: .password)
-        self.host = try container.decodeIfPresent(String.self, forKey: .host)
-        self.port = try container.decodeIfPresent(Int.self, forKey: .port)
-        self.path = try container.decode(String.self, forKey: .path)
-        self.query = try container.decodeIfPresent(String.self, forKey: .query)
-        self.fragment = try container.decodeIfPresent(String.self, forKey: .fragment)
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encodeIfPresent(self.scheme, forKey: .scheme)
-        try container.encodeIfPresent(self.user, forKey: .user)
-        try container.encodeIfPresent(self.password, forKey: .password)
-        try container.encodeIfPresent(self.host, forKey: .host)
-        try container.encodeIfPresent(self.port, forKey: .port)
-        try container.encode(self.path, forKey: .path)
-        try container.encodeIfPresent(self.query, forKey: .query)
-        try container.encodeIfPresent(self.fragment, forKey: .fragment)
     }
 }

--- a/Sources/FoundationNetworking/URLSession/NetworkingSpecific.swift
+++ b/Sources/FoundationNetworking/URLSession/NetworkingSpecific.swift
@@ -41,17 +41,14 @@ class _NSNonfileURLContentLoader: _NSNonfileURLContentLoading {
     required init() {}
     
     @usableFromInline
-    func contentsOf(url: Foundation.URL) throws -> (result: NSData, textEncodingNameIfAvailable: String?) {
+    func contentsOf(url: URL) throws -> (result: NSData, textEncodingNameIfAvailable: String?) {
 
         func cocoaError(with error: Error? = nil) -> Error {
             var userInfo: [String: AnyHashable] = [:]
             if let error = error as? AnyHashable {
                 userInfo[NSUnderlyingErrorKey] = error
             }
-            // Temporary workaround for lack of URL in swift-foundation
-            // TODO: Replace with argument
-            let feURL = FoundationEssentials.URL(path: url.path)
-            return CocoaError.error(.fileReadUnknown, userInfo: userInfo, url: feURL)
+            return CocoaError.error(.fileReadUnknown, userInfo: userInfo, url: url)
         }
 
         var urlResponse: URLResponse?

--- a/Tests/Foundation/TestBundle.swift
+++ b/Tests/Foundation/TestBundle.swift
@@ -52,7 +52,7 @@ class BundlePlayground {
         case library
         case executable
         
-        var pathExtension: String {
+        var pathExtension: String? {
             switch self {
             case .library:
                 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
@@ -66,16 +66,16 @@ class BundlePlayground {
                 #if os(Windows)
                 return "exe"
                 #else
-                return ""
+                return nil
                 #endif
             }
         }
         
-        var flatPathExtension: String {
+        var flatPathExtension: String? {
             #if os(Windows)
             return self.pathExtension
             #else
-            return ""
+            return nil
             #endif
         }
         
@@ -209,15 +209,22 @@ class BundlePlayground {
                 // Make a main and an auxiliary executable:
                 self.mainExecutableURL = bundleURL
                     .appendingPathComponent(bundleName)
-                    .appendingPathExtension(executableType.flatPathExtension)
+                
+                if let ext = executableType.flatPathExtension {
+                    self.mainExecutableURL.appendPathExtension(ext)
+                }
                 
                 guard FileManager.default.createFile(atPath: mainExecutableURL.path, contents: nil) else {
                     return false
                 }
                 
-                let auxiliaryExecutableURL = bundleURL
+                var auxiliaryExecutableURL = bundleURL
                     .appendingPathComponent(auxiliaryExecutableName)
-                    .appendingPathExtension(executableType.flatPathExtension)
+                
+                if let ext = executableType.flatPathExtension {
+                    auxiliaryExecutableURL.appendPathExtension(ext)
+                }
+                
                 guard FileManager.default.createFile(atPath: auxiliaryExecutableURL.path, contents: nil) else {
                     return false
                 }
@@ -256,14 +263,20 @@ class BundlePlayground {
                 self.mainExecutableURL = temporaryDirectory
                     .appendingPathComponent(executableType.fhsPrefix)
                     .appendingPathComponent(executableType.nonFlatFilePrefix + bundleName)
-                    .appendingPathExtension(executableType.pathExtension)
+                
+                if let ext = executableType.pathExtension {
+                    self.mainExecutableURL.appendPathExtension(ext)
+                }
                 guard FileManager.default.createFile(atPath: mainExecutableURL.path, contents: nil) else { return false }
                 
                 let executablesDirectory = temporaryDirectory.appendingPathComponent("libexec").appendingPathComponent("\(bundleName).executables")
                 try FileManager.default.createDirectory(atPath: executablesDirectory.path, withIntermediateDirectories: true, attributes: nil)
-                let auxiliaryExecutableURL = executablesDirectory
+                var auxiliaryExecutableURL = executablesDirectory
                     .appendingPathComponent(executableType.nonFlatFilePrefix + auxiliaryExecutableName)
-                    .appendingPathExtension(executableType.pathExtension)
+                
+                if let ext = executableType.pathExtension {
+                    auxiliaryExecutableURL.appendPathExtension(ext)
+                }
                 guard FileManager.default.createFile(atPath: auxiliaryExecutableURL.path, contents: nil) else { return false }
                 
                 // Make a .resources directory in …/share:
@@ -297,7 +310,10 @@ class BundlePlayground {
                 // Make a main executable:
                 self.mainExecutableURL = temporaryDirectory
                     .appendingPathComponent(executableType.nonFlatFilePrefix + bundleName)
-                    .appendingPathExtension(executableType.pathExtension)
+                
+                if let ext = executableType.pathExtension {
+                    self.mainExecutableURL.appendPathExtension(ext)
+                }
                 guard FileManager.default.createFile(atPath: mainExecutableURL.path, contents: nil) else { return false }
                 
                 // Make a .resources directory:
@@ -305,9 +321,11 @@ class BundlePlayground {
                 try FileManager.default.createDirectory(atPath: resourcesDirectory.path, withIntermediateDirectories: false, attributes: nil)
                 
                 // Make an auxiliary executable:
-                let auxiliaryExecutableURL = resourcesDirectory
+                var auxiliaryExecutableURL = resourcesDirectory
                     .appendingPathComponent(executableType.nonFlatFilePrefix + auxiliaryExecutableName)
-                    .appendingPathExtension(executableType.pathExtension)
+                if let ext = executableType.pathExtension {
+                    auxiliaryExecutableURL.appendPathExtension(ext)
+                }
                 guard FileManager.default.createFile(atPath: auxiliaryExecutableURL.path, contents: nil) else { return false }
                 
                 // Put some resources in the bundle

--- a/Tests/Foundation/TestDataURLProtocol.swift
+++ b/Tests/Foundation/TestDataURLProtocol.swift
@@ -115,7 +115,6 @@ class TestDataURLProtocol: XCTestCase {
                 XCTAssertEqual(expectedProperties.expectedContentLength, response.expectedContentLength, "\(urlString) has incorrect content Length")
                 XCTAssertEqual(expectedProperties.mimeType, response.mimeType, "\(urlString) has incorrect mime type")
                 XCTAssertEqual(expectedProperties.textEncodingName, response.textEncodingName, "\(urlString) has incorrect encoding")
-                XCTAssertEqual("Unknown", response.suggestedFilename)
 
                 let encoding = encodings[response.textEncodingName ?? "us-ascii"] ?? .ascii
                 if let data = delegate.data, let string = String(data: data, encoding: encoding) {

--- a/Tests/Foundation/TestURL.swift
+++ b/Tests/Foundation/TestURL.swift
@@ -195,10 +195,10 @@ class TestURL : XCTestCase {
             result["absoluteString"] = url.absoluteString
             result["absoluteURLString"] = url.absoluteURL.relativeString
             result["scheme"] = url.scheme ?? kNullString
-            result["host"] = url.host ?? kNullString
+            result["host"] = url.host(percentEncoded: false) ?? kNullString
 
             result["port"] = url.port ?? kNullString
-            result["user"] = url.user ?? kNullString
+            result["user"] = url.user(percentEncoded: false) ?? kNullString
             result["password"] = url.password ?? kNullString
             result["path"] = url.path
             result["query"] = url.query ?? kNullString
@@ -272,6 +272,8 @@ class TestURL : XCTestCase {
         }
     }
 
+    // TODO: Disabled until it is updated to the new parser in swift-foundation
+    #if false
     func test_URLStrings() {
         for obj in getTestData()! {
             let testDict = obj as! [String: Any]
@@ -325,6 +327,7 @@ class TestURL : XCTestCase {
             }
         }
     }
+    #endif
 
     static let gBaseTemporaryDirectoryPath = (NSTemporaryDirectory() as NSString).appendingPathComponent("org.swift.foundation.TestFoundation.TestURL.\(ProcessInfo.processInfo.processIdentifier)")
     static var gBaseCurrentWorkingDirectoryPath : String {
@@ -525,19 +528,19 @@ class TestURL : XCTestCase {
     func test_URLByResolvingSymlinksInPathShouldRemoveDuplicatedPathSeparators() {
         let url = URL(fileURLWithPath: "//foo///bar////baz/")
         let result = url.resolvingSymlinksInPath()
-        XCTAssertEqual(result, URL(fileURLWithPath: "/foo/bar/baz"))
+        XCTAssertEqual(result, URL(fileURLWithPath: "/foo/bar/baz/"))
     }
 
     func test_URLByResolvingSymlinksInPathShouldRemoveSingleDotsBetweenSeparators() {
         let url = URL(fileURLWithPath: "/./foo/./.bar/./baz/./")
         let result = url.resolvingSymlinksInPath()
-        XCTAssertEqual(result, URL(fileURLWithPath: "/foo/.bar/baz"))
+        XCTAssertEqual(result, URL(fileURLWithPath: "/foo/.bar/baz/"))
     }
 
     func test_URLByResolvingSymlinksInPathShouldCompressDoubleDotsBetweenSeparators() {
         let url = URL(fileURLWithPath: "/foo/../..bar/../baz/")
         let result = url.resolvingSymlinksInPath()
-        XCTAssertEqual(result, URL(fileURLWithPath: "/baz"))
+        XCTAssertEqual(result, URL(fileURLWithPath: "/baz/"))
     }
 
     func test_URLByResolvingSymlinksInPathShouldUseTheCurrentDirectory() throws {

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -297,7 +297,7 @@ class TestURLSession: LoopbackServerTest {
     }
     
     func test_taskError() {
-        let urlString = "http://127.0.0.1:-1/Nepal"
+        let urlString = "http://127.0.0.0:999999/Nepal"
         let url = URL(string: urlString)!
         let session = URLSession(configuration: URLSessionConfiguration.default,
                                  delegate: nil,
@@ -504,10 +504,10 @@ class TestURLSession: LoopbackServerTest {
     func test_timeoutInterval() {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 10
-        let urlString = "http://127.0.0.1:-1/Peru"
+        let urlString = "http://127.0.0.1:999999/Peru"
         let session = URLSession(configuration: config, delegate: nil, delegateQueue: nil)
         let expect = expectation(description: "GET \(urlString): will timeout")
-        var req = URLRequest(url: URL(string: "http://127.0.0.1:-1/Peru")!)
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:999999/Peru")!)
         req.timeoutInterval = 1
         let task = session.dataTask(with: req) { (data, _, error) -> Void in
             defer { expect.fulfill() }


### PR DESCRIPTION
This PR removes the `URL` type in favor of the `URL` type provided by swift-foundation. It contains a few minor test adjustments to account for the new URL parser (which can behave slightly differently).

This disables one test which we'll come back to soon to update for the new parsing behavior (cc @jrflat), otherwise all but 2 tests pass and those two failures will be fixed by https://github.com/apple/swift-foundation/pull/602 which contains a bug-fix for `URL`s created from relative paths. I'll update the dependency's commit hash once that PR is merged 