### PR TITLE
[5.10] Removing checks for deleted timezones

### DIFF
--- a/Darwin/Foundation-swiftoverlay-Tests/TestTimeZone.swift
+++ b/Darwin/Foundation-swiftoverlay-Tests/TestTimeZone.swift
@@ -52,8 +52,8 @@ class TestTimeZone : XCTestCase {
     func test_AnyHashableContainingTimeZone() {
         let values: [TimeZone] = [
             TimeZone(identifier: "America/Los_Angeles")!,
-            TimeZone(identifier: "Europe/Kiev")!,
-            TimeZone(identifier: "Europe/Kiev")!,
+            TimeZone(identifier: "Europe/Kyiv")!,
+            TimeZone(identifier: "Europe/Kyiv")!,
         ]
         let anyHashables = values.map(AnyHashable.init)
         expectEqual(TimeZone.self, type(of: anyHashables[0].base))
@@ -66,8 +66,8 @@ class TestTimeZone : XCTestCase {
     func test_AnyHashableCreatedFromNSTimeZone() {
         let values: [NSTimeZone] = [
             NSTimeZone(name: "America/Los_Angeles")!,
-            NSTimeZone(name: "Europe/Kiev")!,
-            NSTimeZone(name: "Europe/Kiev")!,
+            NSTimeZone(name: "Europe/Kyiv")!,
+            NSTimeZone(name: "Europe/Kyiv")!,
         ]
         let anyHashables = values.map(AnyHashable.init)
         expectEqual(TimeZone.self, type(of: anyHashables[0].base))

--- a/Tests/Foundation/Tests/TestCalendar.swift
+++ b/Tests/Foundation/Tests/TestCalendar.swift
@@ -270,7 +270,7 @@ class TestCalendar: XCTestCase {
 
     func test_nextDate() throws {
         var calendar = Calendar.current
-        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "US/Pacific"))
+        calendar.timeZone = try XCTUnwrap(TimeZone(identifier: "America/Los_Angeles"))
         let date_20200101 = try XCTUnwrap(calendar.date(from: DateComponents(year: 2020, month: 01, day: 1)))
 
         do {

--- a/Tests/Foundation/Tests/TestNSCalendar.swift
+++ b/Tests/Foundation/Tests/TestNSCalendar.swift
@@ -393,9 +393,11 @@ class TestNSCalendar: XCTestCase {
         try yield(to: block, (.chinese,             "zh_CN",   "Asia/Hong_Kong",      "2015-04-02 07:13:22 +0800"))
         try yield(to: block, (.chinese,             "zh_CN",   "Asia/Hong_Kong",      "2014-10-16 06:12:10 +0800"))
 
-#if !os(Windows)
+#if !os(Windows) && !os(Linux)
         // TODO: these are deprecated aliases which are unavailable on Windows,
         // it is unclear if the support for the old names need to be validated.
+        // TODO: these aliases have been removed from recent versions of Linux
+        // as well
         try yield(to: block, (.hebrew,              "he_IL",   "Israel",              "2018-12-24 05:40:43 +0200"))
         try yield(to: block, (.hebrew,              "he_IL",   "Israel",              "2019-03-22 09:23:26 +0200"))
 #endif
@@ -505,8 +507,9 @@ class TestNSCalendar: XCTestCase {
         try yield(to: block, (.gregorian, "en_US", "America/Los_Angeles", "2013-03-26 10:04:16 -0700", "2013-03-26 00:00:00 -0700"))
         try yield(to: block, (.gregorian, "pt_BR", "America/Sao_Paulo", "2013-10-20 13:10:20 -0200", "2013-10-20 01:00:00 -0200")) // DST jump forward at midnight
         try yield(to: block, (.gregorian, "pt_BR", "America/Sao_Paulo", "2014-02-15 23:59:59 -0300", "2014-02-15 00:00:00 -0200")) // DST jump backward
-#if !os(Windows)
-        // TODO: these are deprecated aliases which are unavailable on Windows,
+#if !os(Windows) && !os(Linux)
+        // TODO: these are deprecated aliases which are unavailable on Windows
+        // and updated Linux distributions,
         // it is unclear if the support for the old names need to be validated.
         try yield(to: block, (.gregorian, "pt_BR", "Brazil/East", "2013-10-20 13:10:20 -0200", "2013-10-20 01:00:00 -0200")) // DST jump forward at midnight
         try yield(to: block, (.gregorian, "pt_BR", "Brazil/East", "2014-02-15 23:59:59 -0300", "2014-02-15 00:00:00 -0200")) // DST jump backward
@@ -751,7 +754,7 @@ class TestNSCalendar: XCTestCase {
         try yield(to: block, (.islamic,               "ar_SA",   "Asia/Riyadh",         "2015-05-29 00:00:00 +0300",   "2015-05-31 00:00:00 +0300")) // islamic
         try yield(to: block, (.islamicCivil,          "ar_SA",   "Asia/Riyadh",         "2015-05-29 00:00:00 +0300",   "2015-05-31 00:00:00 +0300")) // islamic-civil
         try yield(to: block, (.chinese,               "zh_CN",   "Asia/Hong_Kong",      "2015-01-03 00:00:00 +0800",   "2015-01-05 00:00:00 +0800")) // chinese
-#if !os(Windows)
+#if !os(Windows) && !os(Linux)
         // TODO: these are deprecated aliases which are unavailable on Windows,
         // it is unclear if the support for the old names need to be validated.
         try yield(to: block, (.hebrew,                "he_IL",   "Israel",              "2018-03-23 00:00:00 +0200",   "2018-03-25 00:00:00 +0300")) // weekend with DST jump

--- a/Tests/Foundation/Tests/TestTimeZone.swift
+++ b/Tests/Foundation/Tests/TestTimeZone.swift
@@ -257,13 +257,13 @@ class TestTimeZone: XCTestCase {
     }
 
     func test_isDaylightSavingTime() throws {
-        let eukv = try XCTUnwrap(TimeZone(identifier: "Europe/Kiev"))
-        
+        let eulon = try XCTUnwrap(TimeZone(identifier: "Europe/London"))
+
         let dateNoDST = Date(timeIntervalSince1970: 1585432800.0) // March 29, 2020
         let dateDST = Date(timeIntervalSince1970: 1585515600.0) // March 30, 2020
-        
-        XCTAssertFalse(eukv.isDaylightSavingTime(for: dateNoDST))
-        XCTAssertTrue(eukv.isDaylightSavingTime(for: dateDST))
+
+        XCTAssertFalse(eulon.isDaylightSavingTime(for: dateNoDST))
+        XCTAssertTrue(eulon.isDaylightSavingTime(for: dateDST))
     }
 
     static var allTests: [(String, (TestTimeZone) -> () throws -> Void)] {


### PR DESCRIPTION
Linux distros that have picked up newer copies of the `tzdata` database have dropped some of the timezones tested in corelibs-foundation. Removing them, or replacing with the equivalent timezone replacement, according to the contents of `/usr/share/zoneinfo` on Ubuntu 23.10.

Removed timezones include:
 - Israel               -> Asia/Jerusalem
 - US/Pacific      -> America/Los_Angeles
 - Brazil/East     -> America/Sao_Paulo
 - Europe/Kiev     -> Europe/Kyiv