### PR TITLE
Add upcall for FoundationEssentials to initialize NSNumbers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -82,7 +82,7 @@ let package = Package(
         ),
         .package(
            url: "https://github.com/apple/swift-foundation",
-           revision: "db63ab39bb4f07eeb3ccf19fa7a9f928a7ca3972"
+           revision: "3297fb33b49ba2d1161ba12757891c7b91c73a3e"
         ),
     ],
     targets: [

--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -9,6 +9,7 @@
 
 
 @_implementationOnly import _CoreFoundation
+@_spi(SwiftCorelibsFoundation) @_exported import FoundationEssentials
 
 internal let kCFNumberSInt8Type = CFNumberType.sInt8Type
 internal let kCFNumberSInt16Type = CFNumberType.sInt16Type
@@ -1172,3 +1173,18 @@ protocol _NSNumberCastingWithoutBridging {
 }
 
 extension NSNumber: _NSNumberCastingWithoutBridging {}
+
+// Called by FoundationEssentials
+internal final class _FoundationNSNumberInitializer : _NSNumberInitializer {
+    public static func initialize(value: some BinaryInteger) -> Any {
+        if let int64 = Int64(exactly: value) {
+            return NSNumber(value: int64)
+        } else {
+            return NSNumber(value: UInt64(value))
+        }
+    }
+    
+    public static func initialize(value: Bool) -> Any {
+        NSNumber(value: value)
+    }
+}

--- a/Tests/Foundation/TestFileManager.swift
+++ b/Tests/Foundation/TestFileManager.swift
@@ -1785,6 +1785,17 @@ class TestFileManager : XCTestCase {
         }
     }
     
+    func testNSNumberUpcall() throws {
+        let url = writableTestDirectoryURL.appending(component: "foo", directoryHint: .notDirectory)
+        try FileManager.default.createDirectory(at: writableTestDirectoryURL, withIntermediateDirectories: true)
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data("foo".utf8)))
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        let size = attrs[.size]
+        XCTAssertNotNil(size as? NSNumber)
+        XCTAssertNotNil(size as? UInt64)
+        XCTAssertNotNil(size as? Double) // Ensure implicit conversion to unexpected types works
+    }
+    
     // -----
     
     var writableTestDirectoryURL: URL!


### PR DESCRIPTION
This allows the changes in https://github.com/apple/swift-foundation/pull/641 to initialize NSNumbers in FoundationEssentials