### PR TITLE
Add async URLSession methods

### DIFF
--- a/Sources/FoundationNetworking/DataURLProtocol.swift
+++ b/Sources/FoundationNetworking/DataURLProtocol.swift
@@ -91,8 +91,7 @@ internal class _DataURLProtocol: URLProtocol {
             urlClient.urlProtocolDidFinishLoading(self)
         } else {
             let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)
-            if let session = self.task?.session as? URLSession, let delegate = session.delegate as? URLSessionTaskDelegate,
-                let task = self.task {
+            if let task = self.task, let session = task.actualSession, let delegate = task.delegate {
                 delegate.urlSession(session, task: task, didCompleteWithError: error)
             }
         }

--- a/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
@@ -119,11 +119,9 @@ internal extension _FTPURLProtocol {
         switch session.behaviour(for: self.task!) {
         case .noDelegate:
             break
-        case .taskDelegate:
+        case .taskDelegate, .dataCompletionHandlerWithTaskDelegate, .downloadCompletionHandlerWithTaskDelegate:
             self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         case .dataCompletionHandler:
-            break
-        case .dataCompletionHandlerWithTaskDelegate:
             break
         case .downloadCompletionHandler:
             break

--- a/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
@@ -123,6 +123,8 @@ internal extension _FTPURLProtocol {
             self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         case .dataCompletionHandler:
             break
+        case .dataCompletionHandlerWithTaskDelegate:
+            break
         case .downloadCompletionHandler:
             break
         }

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -539,6 +539,8 @@ internal class _HTTPURLProtocol: _NativeProtocol {
             }
         case .dataCompletionHandler:
             break
+        case .dataCompletionHandlerWithTaskDelegate:
+            break
         case .downloadCompletionHandler:
             break
         }

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -475,7 +475,7 @@ internal class _HTTPURLProtocol: _NativeProtocol {
 
         guard let session = task?.session as? URLSession else { fatalError() }
 
-        if let delegate = session.delegate as? URLSessionTaskDelegate {
+        if let delegate = task?.delegate {
             // At this point we need to change the internal state to note
             // that we're waiting for the delegate to call the completion
             // handler. Then we'll call the delegate callback
@@ -524,7 +524,9 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         switch session.behaviour(for: self.task!) {
         case .noDelegate:
             break
-        case .taskDelegate:
+        case .taskDelegate,
+             .dataCompletionHandlerWithTaskDelegate,
+             .downloadCompletionHandlerWithTaskDelegate:
             //TODO: There's a problem with libcurl / with how we're using it.
             // We're currently unable to pause the transfer / the easy handle:
             // https://curl.haxx.se/mail/lib-2016-03/0222.html
@@ -538,8 +540,6 @@ internal class _HTTPURLProtocol: _NativeProtocol {
                 self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             }
         case .dataCompletionHandler:
-            break
-        case .dataCompletionHandlerWithTaskDelegate:
             break
         case .downloadCompletionHandler:
             break

--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -338,7 +338,8 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
             // Data will be forwarded to the delegate as we receive it, we don't
             // need to do anything about it.
             return .ignore
-        case .dataCompletionHandler:
+        case .dataCompletionHandler,
+             .dataCompletionHandlerWithTaskDelegate:
             // Data needs to be concatenated in-memory such that we can pass it
             // to the completion handler upon completion.
             return .inMemory(nil)

--- a/Sources/FoundationNetworking/URLSession/TaskRegistry.swift
+++ b/Sources/FoundationNetworking/URLSession/TaskRegistry.swift
@@ -49,6 +49,8 @@ extension URLSession {
             case dataCompletionHandlerWithTaskDelegate(DataTaskCompletion, URLSessionTaskDelegate?)
             /// Default action for all events, except for completion.
             case downloadCompletionHandler(DownloadTaskCompletion)
+            /// Default action for all asynchronous events.
+            case downloadCompletionHandlerWithTaskDelegate(DownloadTaskCompletion, URLSessionTaskDelegate?)
         }
         
         fileprivate var tasks: [Int: URLSessionTask] = [:]

--- a/Sources/FoundationNetworking/URLSession/TaskRegistry.swift
+++ b/Sources/FoundationNetworking/URLSession/TaskRegistry.swift
@@ -45,6 +45,8 @@ extension URLSession {
             case callDelegate
             /// Default action for all events, except for completion.
             case dataCompletionHandler(DataTaskCompletion)
+            /// Default action for all asynchronous events.
+            case dataCompletionHandlerWithTaskDelegate(DataTaskCompletion, URLSessionTaskDelegate?)
             /// Default action for all events, except for completion.
             case downloadCompletionHandler(DownloadTaskCompletion)
         }

--- a/Sources/FoundationNetworking/URLSession/URLSessionDelegate.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionDelegate.swift
@@ -134,24 +134,54 @@ public protocol URLSessionTaskDelegate : URLSessionDelegate {
 
 extension URLSessionTaskDelegate {
     public func urlSession(_ session: URLSession, task: URLSessionTask, willPerformHTTPRedirection response: HTTPURLResponse, newRequest request: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
-        completionHandler(request)
+        // If the task's delegate does not implement this function, check if the session's delegate does
+        if self === task.delegate, let sessionDelegate = session.delegate as? URLSessionTaskDelegate, self !== sessionDelegate {
+            sessionDelegate.urlSession(session, task: task, willPerformHTTPRedirection: response, newRequest: request, completionHandler: completionHandler)
+        } else {
+            // Default handling
+            completionHandler(request)
+        }
     }
     
     public func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        completionHandler(.performDefaultHandling, nil)
+        if self === task.delegate, let sessionDelegate = session.delegate as? URLSessionTaskDelegate, self !== sessionDelegate {
+            sessionDelegate.urlSession(session, task: task, didReceive: challenge, completionHandler: completionHandler)
+        } else {
+            completionHandler(.performDefaultHandling, nil)
+        }
     }
     
     public func urlSession(_ session: URLSession, task: URLSessionTask, needNewBodyStream completionHandler: @escaping (InputStream?) -> Void) {
-        completionHandler(nil)
+        if self === task.delegate, let sessionDelegate = session.delegate as? URLSessionTaskDelegate, self !== sessionDelegate {
+            sessionDelegate.urlSession(session, task: task, needNewBodyStream: completionHandler)
+        } else {
+            completionHandler(nil)
+        }
     }
     
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) { }
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
+        if self === task.delegate, let sessionDelegate = session.delegate as? URLSessionTaskDelegate, self !== sessionDelegate {
+            sessionDelegate.urlSession(session, task: task, didSendBodyData: bytesSent, totalBytesSent: totalBytesSent, totalBytesExpectedToSend: totalBytesExpectedToSend)
+        }
+    }
     
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) { }
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if self === task.delegate, let sessionDelegate = session.delegate as? URLSessionTaskDelegate, self !== sessionDelegate {
+            sessionDelegate.urlSession(session, task: task, didCompleteWithError: error)
+        }
+    }
     
-    public func urlSession(_ session: URLSession, task: URLSessionTask, willBeginDelayedRequest request: URLRequest, completionHandler: @escaping (URLSession.DelayedRequestDisposition, URLRequest?) -> Void) { }
+    public func urlSession(_ session: URLSession, task: URLSessionTask, willBeginDelayedRequest request: URLRequest, completionHandler: @escaping (URLSession.DelayedRequestDisposition, URLRequest?) -> Void) {
+        if self === task.delegate, let sessionDelegate = session.delegate as? URLSessionTaskDelegate, self !== sessionDelegate {
+            sessionDelegate.urlSession(session, task: task, willBeginDelayedRequest: request, completionHandler: completionHandler)
+        }
+    }
     
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) { }
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+        if self === task.delegate, let sessionDelegate = session.delegate as? URLSessionTaskDelegate, self !== sessionDelegate {
+            sessionDelegate.urlSession(session, task: task, didFinishCollecting: metrics)
+        }
+    }
 }
 
 /*

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -92,6 +92,16 @@ class TestURLSession: LoopbackServerTest {
         task.resume()
         waitForExpectations(timeout: 12)
     }
+
+    func test_dataFromURLDelegate() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/UK"
+        let (data, response) = try await URLSession.shared.data(from: URL(string: urlString)!, delegate: nil)
+        guard let httpResponse = response as? HTTPURLResponse else { return }
+        XCTAssertEqual(200, httpResponse.statusCode, "HTTP response code is not 200")
+        let expectedResult = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertEqual("London", expectedResult, "Did not receive expected value")
+    }
     
     func test_dataTaskWithHttpInputStream() throws {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/jsonBody"
@@ -2100,6 +2110,7 @@ class TestURLSession: LoopbackServerTest {
         ]
         if #available(macOS 12.0, *) {
             retVal.append(contentsOf: [
+                ("test_dataFromURLDelegate", asyncTest(test_dataFromURLDelegate)),
                 ("test_webSocket", asyncTest(test_webSocket)),
                 ("test_webSocketSpecificProtocol", asyncTest(test_webSocketSpecificProtocol)),
                 ("test_webSocketAbruptClose", asyncTest(test_webSocketAbruptClose)),

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -93,16 +93,41 @@ class TestURLSession: LoopbackServerTest {
         waitForExpectations(timeout: 12)
     }
 
-    func test_dataFromURLDelegate() async throws {
+    func test_asyncDataFromURL() async throws {
         guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/UK"
         let (data, response) = try await URLSession.shared.data(from: URL(string: urlString)!, delegate: nil)
-        guard let httpResponse = response as? HTTPURLResponse else { return }
+        guard let httpResponse = response as? HTTPURLResponse else {
+            XCTFail("Did not get response")
+            return
+        }
         XCTAssertEqual(200, httpResponse.statusCode, "HTTP response code is not 200")
-        let expectedResult = String(data: data, encoding: .utf8) ?? ""
-        XCTAssertEqual("London", expectedResult, "Did not receive expected value")
+        let result = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertEqual("London", result, "Did not receive expected value")
     }
-    
+
+    func test_asyncDataFromURLWithDelegate() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+        class CapitalDataTaskDelegate: NSObject, URLSessionDataDelegate {
+            var capital: String = "unknown"
+            public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+                capital = String(data: data, encoding: .utf8)!
+            }
+        }
+        let delegate = CapitalDataTaskDelegate()
+
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/UK"
+        let (data, response) = try await URLSession.shared.data(from: URL(string: urlString)!, delegate: delegate)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            XCTFail("Did not get response")
+            return
+        }
+        XCTAssertEqual(200, httpResponse.statusCode, "HTTP response code is not 200")
+        let result = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertEqual("London", result, "Did not receive expected value")
+        XCTAssertEqual("London", delegate.capital)
+    }
+
     func test_dataTaskWithHttpInputStream() throws {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/jsonBody"
         let url = try XCTUnwrap(URL(string: urlString))
@@ -274,6 +299,44 @@ class TestURLSession: LoopbackServerTest {
         }
         task.resume()
         waitForExpectations(timeout: 12)
+    }
+
+    func test_asyncDownloadFromURL() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt"
+        let (location, response) = try await URLSession.shared.download(from: URL(string: urlString)!)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            XCTFail("Did not get response")
+            return
+        }
+        XCTAssertEqual(200, httpResponse.statusCode, "HTTP response code is not 200")
+        XCTAssertNotNil(location, "Download location was nil")
+    }
+
+    func test_asyncDownloadFromURLWithDelegate() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+        class AsyncDownloadDelegate : NSObject, URLSessionDownloadDelegate {
+            func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+                XCTFail("Should not be called for async downloads")
+            }
+
+            var totalBytesWritten = Int64(0)
+            public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64,
+                                   totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) -> Void {
+                self.totalBytesWritten = totalBytesWritten
+            }
+        }
+        let delegate = AsyncDownloadDelegate()
+
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt"
+        let (location, response) = try await URLSession.shared.download(from: URL(string: urlString)!, delegate: delegate)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            XCTFail("Did not get response")
+            return
+        }
+        XCTAssertEqual(200, httpResponse.statusCode, "HTTP response code is not 200")
+        XCTAssertNotNil(location, "Download location was nil")
+        XCTAssertTrue(delegate.totalBytesWritten > 0)
     }
 
     func test_gzippedDownloadTask() {
@@ -1621,6 +1684,21 @@ class TestURLSession: LoopbackServerTest {
         XCTAssertNil(session.delegate)
     }
 
+    func test_sessionDelegateCalledIfTaskDelegateDoesNotImplement() throws {
+        let expectation = XCTestExpectation(description: "task finished")
+        let delegate = SessionDelegate(with: expectation)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        
+        class EmptyTaskDelegate: NSObject, URLSessionTaskDelegate { }
+        let url = URL(string: "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt")!
+        let request = URLRequest(url: url)
+        let task = session.dataTask(with: request)
+        task.delegate = EmptyTaskDelegate()
+        task.resume()
+
+        wait(for: [expectation], timeout: 5)
+    }
+
     func test_getAllTasks() throws {
         let expect = expectation(description: "Tasks URLSession.getAllTasks")
 
@@ -2098,6 +2176,7 @@ class TestURLSession: LoopbackServerTest {
             ("test_checkErrorTypeAfterInvalidateAndCancel", test_checkErrorTypeAfterInvalidateAndCancel),
             ("test_taskCountAfterInvalidateAndCancel", test_taskCountAfterInvalidateAndCancel),
             ("test_sessionDelegateAfterInvalidateAndCancel", test_sessionDelegateAfterInvalidateAndCancel),
+            ("test_sessionDelegateCalledIfTaskDelegateDoesNotImplement", test_sessionDelegateCalledIfTaskDelegateDoesNotImplement),
             /* ⚠️ */ ("test_getAllTasks", testExpectedToFail(test_getAllTasks, "This test causes later ones to crash")),
             /* ⚠️ */ ("test_getTasksWithCompletion", testExpectedToFail(test_getTasksWithCompletion, "Flaky tests")),
             /* ⚠️ */ ("test_invalidResumeDataForDownloadTask",
@@ -2110,7 +2189,10 @@ class TestURLSession: LoopbackServerTest {
         ]
         if #available(macOS 12.0, *) {
             retVal.append(contentsOf: [
-                ("test_dataFromURLDelegate", asyncTest(test_dataFromURLDelegate)),
+                ("test_asyncDataFromURL", asyncTest(test_asyncDataFromURL)),
+                ("test_asyncDataFromURLWithDelegate", asyncTest(test_asyncDataFromURLWithDelegate)),
+                ("test_asyncDownloadFromURL", asyncTest(test_asyncDownloadFromURL)),
+                ("test_asyncDownloadFromURLWithDelegate", asyncTest(test_asyncDownloadFromURLWithDelegate)),
                 ("test_webSocket", asyncTest(test_webSocket)),
                 ("test_webSocketSpecificProtocol", asyncTest(test_webSocketSpecificProtocol)),
                 ("test_webSocketAbruptClose", asyncTest(test_webSocketAbruptClose)),
@@ -2306,7 +2388,6 @@ extension SessionDelegate: URLSessionDataDelegate {
         completionHandler(.allow)
     }
 }
-
 
 class DataTask : NSObject {
     let syncQ = dispatchQueueMake("org.swift.TestFoundation.TestURLSession.DataTask.syncQ")


### PR DESCRIPTION
Thanks to @b1ackturtle for providing the foundation of this work in #4705! 

This PR implements the remaining async `URLSession` methods and the `URLSessionTask.delegate` property, allowing a delegate to be set in the async methods (or in a non-async context before resumption). `URLSessionTask.delegate` returns the explicitly set delegate if present, otherwise returns the session delegate `as? URLSessionTaskDelegate`. It's now used wherever we previously casted the session delegate to `URLSessionTaskDelegate`. To accompany this change, functions in `extension URLSessionTaskDelegate` (which are called if not implemented by the task's delegate) now check if the session's delegate implements it and call the session's delegate if that's the case.