### PR TITLE
Remove additional unnecessary FileManager code

### DIFF
--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -181,24 +181,6 @@ extension FileManager {
         return (attributes: result, blockSize: finalBlockSize)
     #endif // os(WASI)
     }
-
-    /* destinationOfSymbolicLinkAtPath:error: returns a String containing the path of the item pointed at by the symlink specified by 'path'. If this method returns 'nil', an NSError will be thrown.
-
-        This method replaces pathContentOfSymbolicLinkAtPath:
-     */
-    internal func _destinationOfSymbolicLink(atPath path: String) throws -> String {
-        let bufferSize = Int(PATH_MAX + 1)
-        let buffer = try [Int8](unsafeUninitializedCapacity: bufferSize) { buffer, initializedCount in
-            let len = try _fileSystemRepresentation(withPath: path) { (path) -> Int in
-                return readlink(path, buffer.baseAddress!, bufferSize)
-            }
-            guard len >= 0 else {
-                throw _NSErrorWithErrno(errno, reading: true, path: path)
-            }
-            initializedCount = len
-        }
-        return self.string(withFileSystemRepresentation: buffer, length: buffer.count)
-    }
         
     internal func _recursiveDestinationOfSymbolicLink(atPath path: String) throws -> String {
         #if os(WASI)
@@ -207,7 +189,7 @@ extension FileManager {
         throw _NSErrorWithErrno(ENOTSUP, reading: true, path: path)
         #else
         // Throw error if path is not a symbolic link:
-        let path = try _destinationOfSymbolicLink(atPath: path)
+        let path = try destinationOfSymbolicLink(atPath: path)
         
         let bufSize = Int(PATH_MAX + 1)
         var buf = [Int8](repeating: 0, count: bufSize)

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -457,7 +457,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
 
         let fm = FileManager.default
-        let permissions = try? fm._permissionsOfItem(atPath: path)
+        let permissions = try? fm.attributesOfItem(atPath: path)[.posixPermissions] as? Int
 
         if writeOptionsMask.contains(.atomic) {
             let (newFD, auxFilePath) = try _NSCreateTemporaryFile(path)

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -1208,7 +1208,7 @@ fileprivate extension URLResourceValuesStorage {
             if let storage = fileAttributesStorage {
                 return storage
             } else {
-                let storage = try fm._attributesOfItem(atPath: path, includingPrivateAttributes: true)
+                let storage = try fm._attributesOfItemIncludingPrivate(atPath: path)
                 fileAttributesStorage = storage
                 return storage
             }
@@ -1314,7 +1314,7 @@ fileprivate extension URLResourceValuesStorage {
             case .isSystemImmutableKey:
                 result[key] = try attribute(._systemImmutable) as? Bool == true
             case .isUserImmutableKey:
-                result[key] = try attribute(._userImmutable) as? Bool == true
+                result[key] = try attribute(.immutable) as? Bool == true
             case .isHiddenKey:
                 result[key] = try attribute(._hidden) as? Bool == true
             case .hasHiddenExtensionKey:
@@ -1522,7 +1522,7 @@ fileprivate extension URLResourceValuesStorage {
                 switch key {
                     
                 case .isUserImmutableKey:
-                    try prepareToSetFileAttribute(._userImmutable, value: value as? Bool)
+                    try prepareToSetFileAttribute(.immutable, value: value as? Bool)
 
                 case .isSystemImmutableKey:
                     try prepareToSetFileAttribute(._systemImmutable, value: value as? Bool)
@@ -1560,7 +1560,7 @@ fileprivate extension URLResourceValuesStorage {
             
             // _setAttributes(…) needs to figure out the correct order to apply these attributes in, so set them all together at the end.
             if !attributesToSet.isEmpty {
-                try fm._setAttributes(attributesToSet, ofItemAtPath: path, includingPrivateAttributes: true)
+                try fm._setAttributesIncludingPrivate(attributesToSet, ofItemAtPath: path)
                 unsuccessfulKeys.formSymmetricDifference(keysThatSucceedBySettingAttributes)
             }
             

--- a/Tests/Foundation/TestFileManager.swift
+++ b/Tests/Foundation/TestFileManager.swift
@@ -1335,7 +1335,7 @@ class TestFileManager : XCTestCase {
         }
         XCTAssertThrowsError(try fm.copyItem(atPath: "/tmp/t", toPath: "")) {
             let code = ($0 as? CocoaError)?.code
-            XCTAssertEqual(code, .fileNoSuchFile)
+            XCTAssertEqual(code, .fileReadNoSuchFile)
         }
 
         #if false
@@ -1364,7 +1364,7 @@ class TestFileManager : XCTestCase {
         }
         XCTAssertThrowsError(try fm.linkItem(atPath: "/tmp/t", toPath: "")) {
             let code = ($0 as? CocoaError)?.code
-            XCTAssertEqual(code, .fileNoSuchFile)
+            XCTAssertEqual(code, .fileReadNoSuchFile)
         }
 
         XCTAssertThrowsError(try fm.createSymbolicLink(atPath: "", withDestinationPath: "")) {

--- a/Tests/Foundation/TestNSData.swift
+++ b/Tests/Foundation/TestNSData.swift
@@ -210,7 +210,7 @@ class TestNSData: XCTestCase {
                 let url = URL(fileURLWithPath: NSTemporaryDirectory() + "meow")
                 try data.write(to: url)
                 let fileManager = FileManager.default
-                let permission = try fileManager._permissionsOfItem(atPath: url.path)
+                let permission = try fileManager.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int
 #if canImport(Darwin)
                 let expected = Int(S_IRUSR) | Int(S_IWUSR) | Int(S_IRGRP) | Int(S_IWGRP) | Int(S_IROTH) | Int(S_IWOTH)
 #else
@@ -233,7 +233,7 @@ class TestNSData: XCTestCase {
                 let url = URL(fileURLWithPath: NSTemporaryDirectory() + "meow")
                 try data.write(to: url, options: .atomic)
                 let fileManager = FileManager.default
-                let permission = try fileManager._permissionsOfItem(atPath: url.path)
+                let permission = try fileManager.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int
 #if canImport(Darwin)
                 let expected = Int(S_IRUSR) | Int(S_IWUSR) | Int(S_IRGRP) | Int(S_IWGRP) | Int(S_IROTH) | Int(S_IWOTH)
 #else


### PR DESCRIPTION
This PR removes more FileManager code that is duplicated from swift-foundation. It removes a handful of functions that are no longer necessary, removes the private `._userImmutable` file attribute since it is the same as the API `.immutable` attribute, and updates the private file attribute fetching/setting functions to call down to the public API functions to handle all API attributes instead of duplicating code for the API attributes.

All tests pass locally on linux with this change