### PR TITLE
Fix test_webSocket hang

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -865,6 +865,12 @@ open class URLSessionWebSocketTask : URLSessionTask {
                     }
                 }
                 self.receiveCompletionHandlers.removeAll()
+                for handler in self.pongCompletionHandlers {
+                    session.delegateQueue.addOperation {
+                        handler(taskError)
+                    }
+                }
+                self.pongCompletionHandlers.removeAll()
                 self._getProtocol { urlProtocol in
                     self.workQueue.async {
                         if self.handshakeCompleted && self.state != .completed {

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -2064,8 +2064,15 @@ class TestURLSession: LoopbackServerTest {
             XCTFail("Unexpected Data Message")
         }
         
-        try await task.sendPing()
-        
+        do {
+            try await task.sendPing()
+            // Server hasn't closed the connection yet
+        } catch {
+            // Server closed the connection before we could process the pong
+            let urlError = try XCTUnwrap(error as? URLError)
+            XCTAssertEqual(urlError._nsError.code, NSURLErrorNetworkConnectionLost)
+        }
+
         wait(for: [delegate.expectation], timeout: 50)
         
         do {


### PR DESCRIPTION
Because the test server sends a close message shortly after sending a pong, the connection might close before our task handles the pong and calls its completion handler. In this case, the pong completion handler is never called, so `try await task.sendPing()` hangs indefinitely.

This PR cleans up `pongCompletionHandlers` on error/close and minimally fixes the test to allow the case where the server closes the connection before the pong is handled.