### PR TITLE
[5.10] Fix test_webSocket hang

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -849,6 +849,12 @@ open class URLSessionWebSocketTask : URLSessionTask {
                     }
                 }
                 self.receiveCompletionHandlers.removeAll()
+                for handler in self.pongCompletionHandlers {
+                    session.delegateQueue.addOperation {
+                        handler(taskError)
+                    }
+                }
+                self.pongCompletionHandlers.removeAll()
                 self._getProtocol { urlProtocol in
                     self.workQueue.async {
                         if self.handshakeCompleted && self.state != .completed {

--- a/Tests/Foundation/Tests/TestURLSession.swift
+++ b/Tests/Foundation/Tests/TestURLSession.swift
@@ -1893,8 +1893,15 @@ class TestURLSession: LoopbackServerTest {
             XCTFail("Unexpected Data Message")
         }
         
-        try await task.sendPing()
-        
+        do {
+            try await task.sendPing()
+            // Server hasn't closed the connection yet
+        } catch {
+            // Server closed the connection before we could process the pong
+            let urlError = try XCTUnwrap(error as? URLError)
+            XCTAssertEqual(urlError._nsError.code, NSURLErrorNetworkConnectionLost)
+        }
+
         wait(for: [delegate.expectation], timeout: 50)
         
         do {


### PR DESCRIPTION
Cherry-pick of #4973 for `release/5.10` to unblock 5.10 toolchain build on Fedora40