### PR TITLE
[wasm] Do not set permissions in `Data.write`

### DIFF
--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -457,7 +457,12 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
         }
 
         let fm = FileManager.default
+#if os(WASI)
+        // WASI does not have permission concept
+        let permissions: Int? = nil
+#else
         let permissions = try? fm._permissionsOfItem(atPath: path)
+#endif
 
         if writeOptionsMask.contains(.atomic) {
             let (newFD, auxFilePath) = try _NSCreateTemporaryFile(path)


### PR DESCRIPTION
This fixes https://github.com/swiftwasm/swift/issues/5584.

This PR does not affect platforms other than WASI.