### PR TITLE
Include CFBase.h in CoreFoundation_Prefix.h

### DIFF
--- a/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h
+++ b/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h
@@ -58,6 +58,7 @@
 #define TARGET_OS_WATCH 0
 #endif
 
+#include "CFBase.h"
 
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
This fixes a Windows build failure I encountered when building a Windows toolchain with this branch. We use `CF_EXPORT` within a windows-only code path of `CoreFoundation_Prefix.h` and `CF_EXPORT` is defined in `CFBase.h`. `CFBase.h` is included from this file on the `main` branch, so this PR restores that include which should correct this build failure.

The project still builds successfully for linux with this change