### PR TITLE
[CMake] Copy headers to known directory for direct client test builds

### DIFF
--- a/Sources/CoreFoundation/CMakeLists.txt
+++ b/Sources/CoreFoundation/CMakeLists.txt
@@ -117,6 +117,12 @@ target_link_libraries(CoreFoundation
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS CoreFoundation)
 
+# Copy Headers to known directory for direct client (XCTest) test builds
+file(COPY
+        include/
+    DESTINATION
+        ${CMAKE_BINARY_DIR}/_CModulesForClients/CoreFoundation)
+
 install(DIRECTORY
             include/
         DESTINATION


### PR DESCRIPTION
This copies the public headers to a known location in the build tree so that direct clients (before installation) can specify that directory as an include path when not building via a CMake dependency