### PR TITLE
[Linux] Enable build-ids.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ endif()
 include(SwiftSupport)
 include(GNUInstallDirs)
 include(XCTest)
+include(CheckLinkerFlag)
+
+check_linker_flag(C "LINKER:-build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
 
 set(CF_DEPLOYMENT_SWIFT YES CACHE BOOL "Build for Swift" FORCE)
 

--- a/CoreFoundation/CMakeLists.txt
+++ b/CoreFoundation/CMakeLists.txt
@@ -433,6 +433,10 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   endif()
 endif()
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(CoreFoundation PRIVATE "LINKER:-build-id=sha1")
+endif()
+
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   if((NS_CURL_ASSUME_FEATURES_MISSING) OR (CURL_VERSION_STRING VERSION_LESS "7.32.0"))
     add_compile_definitions($<$<COMPILE_LANGUAGE:C>:NS_CURL_MISSING_XFERINFOFUNCTION>)

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -237,6 +237,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL WASI)
       "SHELL:-Xfrontend -public-autolink-library -Xfrontend wasi-emulated-getpid")
 endif()
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(Foundation PRIVATE "LINKER:-build-id=sha1")
+endif()
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS Foundation)
 _install_target(Foundation)

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -98,6 +98,9 @@ if(NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows")
   target_link_options(FoundationNetworking PRIVATE "SHELL:-no-toolchain-stdlib-rpath")
 endif()
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(FoundationNetworking PRIVATE "LINKER:-build-id=sha1")
+endif()
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationNetworking)
 _install_target(FoundationNetworking)

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -50,5 +50,9 @@ if(CMAKE_SYSTEM_NAME STREQUAL WASI)
            -Xcc -D_WASI_EMULATED_MMAN")
 endif()
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(FoundationXML PRIVATE "LINKER:-build-id=sha1")
+endif()
+
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationXML)
 _install_target(FoundationXML)


### PR DESCRIPTION
We should use build IDs on Linux so that we can identify the built artefacts, and also so that we can match them up with debug information should we choose to separate it.

rdar://130582768