### PR TITLE
[Linux] Enable build-ids.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ else()
 endif()
 FetchContent_MakeAvailable(SwiftFoundationICU SwiftFoundation)
 
+include(CheckLinkerFlag)
+
+check_linker_flag(C "LINKER:--build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
+
 # Precompute module triple for installation
 if(NOT SwiftFoundation_MODULE_TRIPLE)
     set(module_triple_command "${CMAKE_Swift_COMPILER}" -print-target-info)

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -171,5 +171,9 @@ set_target_properties(Foundation PROPERTIES
 target_link_libraries(Foundation PUBLIC
     swiftDispatch)
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(Foundation PRIVATE "LINKER:--build-id=sha1")
+endif()
+
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS Foundation)
 _foundation_install_target(Foundation)

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -71,5 +71,9 @@ target_link_options(FoundationNetworking PRIVATE
 set_target_properties(FoundationNetworking PROPERTIES
     INSTALL_RPATH "$ORIGIN")
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(FoundationNetworking PRIVATE "LINKER:--build-id=sha1")
+endif()
+
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationNetworking)
 _foundation_install_target(FoundationNetworking)

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -46,5 +46,9 @@ target_link_options(FoundationXML PRIVATE
 set_target_properties(FoundationXML PROPERTIES
     INSTALL_RPATH "$ORIGIN")
 
+if(LINKER_SUPPORTS_BUILD_ID)
+  target_link_options(FoundationXML PRIVATE "LINKER:--build-id=sha1")
+endif()
+
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationXML)
 _foundation_install_target(FoundationXML)


### PR DESCRIPTION
We should use build IDs on Linux so that we can identify the built artefacts, and also so that we can match them up with debug information should we choose to separate it.

rdar://130582768