### PR TITLE
[CMake] Include GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
         "-I/usr/lib/swift") # dispatch
 endif()
 
+include(GNUInstallDirs)
 include(FoundationSwiftSupport)
 
 add_subdirectory(Sources)


### PR DESCRIPTION
The GNUInstallDirs module sets `CMAKE_INSTALL_BINDIR` which is used on Windows as the destination for installed `.dll` files. This addresses issues that I saw when building a Windows toolchain where the `.dll` files were not installed into the toolchain previously, but with this change are correctly installed into the bin directory.