### PR TITLE
Use FSR for Process executable path on Windows

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -499,7 +499,7 @@ open class Process: NSObject {
         }
 
 #if os(Windows)
-        var command: [String] = [launchPath]
+        var command: [String] = [try FileManager.default._fileSystemRepresentation(withPath: launchPath) { String(decodingCString: $0, as: UTF16.self) }]
         if let arguments = self.arguments {
           command.append(contentsOf: arguments)
         }

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -958,9 +958,12 @@ open class Process: NSObject {
 
         // Launch
         var pid = pid_t()
-        guard _CFPosixSpawn(&pid, launchPath, fileActions, &spawnAttrs, argv, envp) == 0 else {
-            throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
-        }
+        
+        try FileManager.default._fileSystemRepresentation(withPath: launchPath, { fsRep in
+            guard _CFPosixSpawn(&pid, fsRep, fileActions, &spawnAttrs, argv, envp) == 0 else {
+                throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
+            }
+        })
         posix_spawnattr_destroy(&spawnAttrs)
 
         // Close the write end of the input and output pipes.


### PR DESCRIPTION
Within `Process`, the `launchPath` here is equivalent to `executableURL.path`. Just before launching the process, we call `.withCString(encodedAs: UTF16.self)` to convert the invocation to UTF-16. However, now that `URL` is re-cored on swift-foundation's `URL`, Windows paths are represented following RFC8089 which contains a leading `/` before a drive letter. The various file system representation functions remove this preceding slash before calling to an SDK API, however `Process` did not do this resulting in a path such as `/C:/Users/jmschonfeld/foo.exe` being passed to `CreateProcessW` which failed to find the file. This standardizes the path to its file system representation before it is combined with the various arguments and converted to UTF-16 later.

This fixes a failure that occurred during a windows toolchain build where SwiftPM (using the new Foundation) was unable to invoke `swiftc.exe` due to this issue.