### PR TITLE
Avoiding linking CF from outside of Foundation

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -149,8 +149,9 @@ target_compile_options(Foundation PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:Swift>:${_Foundation_swift_build_flags}>")
 
 target_link_libraries(Foundation
-    PUBLIC
+    PRIVATE
         CoreFoundation
+    PUBLIC
         FoundationEssentials
         FoundationInternationalization)
 

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -51,7 +51,6 @@ target_compile_options(FoundationNetworking PRIVATE
 
 target_link_libraries(FoundationNetworking
     PRIVATE
-        CoreFoundation
         _CFURLSessionInterface
     PUBLIC
         Foundation)
@@ -59,8 +58,6 @@ target_link_libraries(FoundationNetworking
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationNetworking PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFURLSessionInterface>")
-    target_compile_options(FoundationNetworking PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend CoreFoundation>")
     target_compile_options(FoundationNetworking PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend curl>")
 endif()

--- a/Sources/FoundationNetworking/HTTPCookieStorage.swift
+++ b/Sources/FoundationNetworking/HTTPCookieStorage.swift
@@ -13,7 +13,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 
 /*!
     @enum HTTPCookie.AcceptPolicy

--- a/Sources/FoundationNetworking/URLSession/BodySource.swift
+++ b/Sources/FoundationNetworking/URLSession/BodySource.swift
@@ -22,7 +22,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFURLSessionInterface
 import Dispatch
 

--- a/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
@@ -13,7 +13,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 import Dispatch
 
 internal class _FTPURLProtocol: _NativeProtocol {

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPMessage.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPMessage.swift
@@ -22,7 +22,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 
 internal extension _HTTPURLProtocol._ResponseHeaderLines {
     /// Create an `NSHTTPRULResponse` from the lines.

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -13,7 +13,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFURLSessionInterface
 import Dispatch
 

--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -23,7 +23,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 import Dispatch
 
 internal let enableLibcurlDebugOutput: Bool = {

--- a/Sources/FoundationNetworking/URLSession/TaskRegistry.swift
+++ b/Sources/FoundationNetworking/URLSession/TaskRegistry.swift
@@ -22,7 +22,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 import Dispatch
 
 extension URLSession {

--- a/Sources/FoundationNetworking/URLSession/TransferState.swift
+++ b/Sources/FoundationNetworking/URLSession/TransferState.swift
@@ -22,7 +22,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 
 
 

--- a/Sources/FoundationNetworking/URLSession/URLSession.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSession.swift
@@ -167,7 +167,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 
 extension URLSession {
     public enum DelayedRequestDisposition {

--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -20,7 +20,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 
 private class Bag<Element> {
     var values: [Element] = []

--- a/Sources/FoundationNetworking/URLSession/URLSessionTaskMetrics.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTaskMetrics.swift
@@ -20,7 +20,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 
 open class URLSessionTaskMetrics : NSObject {
     public internal(set) var transactionMetrics: [URLSessionTaskTransactionMetrics] = []

--- a/Sources/FoundationNetworking/URLSession/WebSocket/WebSocketURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/WebSocket/WebSocketURLProtocol.swift
@@ -13,7 +13,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFURLSessionInterface
 import Dispatch
 

--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -23,7 +23,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFURLSessionInterface
 import Dispatch
 

--- a/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
@@ -22,7 +22,6 @@ import SwiftFoundation
 import Foundation
 #endif
 
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFURLSessionInterface
 import Dispatch
 

--- a/Sources/FoundationNetworking/URLSession/libcurl/libcurlHelpers.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/libcurlHelpers.swift
@@ -17,7 +17,6 @@
 // -----------------------------------------------------------------------------
 
 
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFURLSessionInterface
 
 //TODO: Move things in this file?

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -26,7 +26,6 @@ target_compile_options(FoundationXML PRIVATE
 
 target_link_libraries(FoundationXML
     PRIVATE
-        CoreFoundation
         _CFXMLInterface
     PUBLIC
         Foundation)
@@ -34,8 +33,6 @@ target_link_libraries(FoundationXML
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationXML PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFXMLInterface>")
-    target_compile_options(FoundationXML PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend CoreFoundation>")
     target_compile_options(FoundationXML PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend xml2>")
 endif()

--- a/Sources/FoundationXML/XMLDTD.swift
+++ b/Sources/FoundationXML/XMLDTD.swift
@@ -12,7 +12,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFXMLInterface
 
 /*!

--- a/Sources/FoundationXML/XMLDTDNode.swift
+++ b/Sources/FoundationXML/XMLDTDNode.swift
@@ -12,7 +12,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFXMLInterface
 
 /*!

--- a/Sources/FoundationXML/XMLDocument.swift
+++ b/Sources/FoundationXML/XMLDocument.swift
@@ -12,7 +12,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFXMLInterface
 
 // Input options

--- a/Sources/FoundationXML/XMLElement.swift
+++ b/Sources/FoundationXML/XMLElement.swift
@@ -12,7 +12,6 @@ import SwiftFoundation
 #else
 import Foundation
 #endif
-@_implementationOnly import CoreFoundation
 @_implementationOnly import _CFXMLInterface
 
 /*!

--- a/Sources/FoundationXML/XMLNode.swift
+++ b/Sources/FoundationXML/XMLNode.swift
@@ -15,7 +15,6 @@ import _CFXMLInterface
 import Foundation
 @_implementationOnly import _CFXMLInterface
 #endif
-@_implementationOnly import CoreFoundation
 
 // initWithKind options
 //  NSXMLNodeOptionsNone

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -14,7 +14,6 @@ import _CFXMLInterface
 import Foundation
 @_implementationOnly import _CFXMLInterface
 #endif
-@_implementationOnly import CoreFoundation
 
 extension XMLParser {
     public enum ExternalEntityResolvingPolicy : UInt {

--- a/Sources/_CFURLSessionInterface/CMakeLists.txt
+++ b/Sources/_CFURLSessionInterface/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(_CFURLSessionInterface STATIC CFURLSessionInterface.c)
 target_include_directories(_CFURLSessionInterface
     PUBLIC
         include
+        ../CoreFoundation/include
     PRIVATE
         ../CoreFoundation/internalInclude)
 
@@ -26,7 +27,6 @@ target_compile_options(_CFURLSessionInterface PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:C>:${_Foundation_common_build_flags}>")
 
 target_link_libraries(_CFURLSessionInterface PRIVATE
-    CoreFoundation
     dispatch
     CURL::libcurl)
 

--- a/Sources/_CFXMLInterface/CMakeLists.txt
+++ b/Sources/_CFXMLInterface/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(_CFXMLInterface STATIC CFXMLInterface.c)
 target_include_directories(_CFXMLInterface
     PUBLIC
         include
+        ../CoreFoundation/include
     PRIVATE
         ../CoreFoundation/internalInclude
         /usr/include/libxml2/)
@@ -25,7 +26,6 @@ target_compile_options(_CFXMLInterface PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:C>:${_Foundation_common_build_flags}>")
 
 target_link_libraries(_CFXMLInterface PRIVATE
-    CoreFoundation
     dispatch
     LibXml2::LibXml2)
 


### PR DESCRIPTION
CoreFoundation expects to only be linked from Foundation itself. This resulted in linker failures where CoreFoundation failed to find certain symbols provided by Foundation when it was statically linked into FoundationNetworking on Windows. This removes CoreFoundation from the linked libraries list of FoundationNetworking/FoundationXML, but does add CoreFoundation's include paths to those targets so that it can use headers that have macros defined.