### PR TITLE
Allocate buffer of correct size in `NSURL.fileSystemRepresentation` on Windows

### DIFF
--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -486,9 +486,12 @@ open class NSURL : NSObject, NSSecureCoding, NSCopying {
 #if os(Windows)
         if let resolved = CFURLCopyAbsoluteURL(_cfObject),
                 let representation = CFURLCopyFileSystemPath(resolved, kCFURLWindowsPathStyle)?._swiftObject {
-            let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: representation.count + 1)
-            representation.withCString { buffer.initialize(from: $0, count: representation.count + 1) }
-            buffer[representation.count] = 0
+            let buffer = representation.withCString {
+                let len = strlen($0)
+                let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: len + 1)
+                buffer.initialize(from: $0, count: len + 1)
+                return buffer
+            }
             return UnsafePointer(buffer)
         }
 #else


### PR DESCRIPTION
As the `String.withCString` function provides utf-8 encoded content, we should not use `String.count` for receiving buffer length. `NSURL.fileSystemRepresentation` is used in `FileHandle(forReadingFrom:)`, and it fails with file urls containing non-ascii (e.g. cyrillic) characters.