### PR TITLE
[6.0] Android: add better nullability checks for nullability annotations added in NDK 26

### DIFF
--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -321,10 +321,15 @@ open class FileHandle : NSObject {
             if options.contains(.alwaysMapped) {
                 // Filesizes are often 64bit even on 32bit systems
                 let mapSize = min(length, Int(clamping: statbuf.st_size))
+              #if canImport(Android)
+                // Bionic mmap() now returns _Nonnull, so the force unwrap below isn't needed.
                 let data = mmap(nil, mapSize, PROT_READ, MAP_PRIVATE, _fd, 0)
+              #else
+                let data = mmap(nil, mapSize, PROT_READ, MAP_PRIVATE, _fd, 0)!
+              #endif
                 // Swift does not currently expose MAP_FAILURE
                 if data != UnsafeMutableRawPointer(bitPattern: -1) {
-                    return NSData.NSDataReadResult(bytes: data!, length: mapSize) { buffer, length in
+                    return NSData.NSDataReadResult(bytes: data, length: mapSize) { buffer, length in
                         munmap(buffer, length)
                     }
                 }

--- a/Sources/Foundation/FileManager.swift
+++ b/Sources/Foundation/FileManager.swift
@@ -579,13 +579,13 @@ open class FileManager : NSObject {
 #elseif os(WASI)
         let type = FileAttributeType(statMode: mode_t(s.st_mode))
 #else
-        if let pwd = getpwuid(s.st_uid), pwd.pointee.pw_name != nil {
-            let name = String(cString: pwd.pointee.pw_name)
+        if let pwd = getpwuid(s.st_uid), let pwd_name = pwd.pointee.pw_name {
+            let name = String(cString: pwd_name)
             result[.ownerAccountName] = name
         }
 
-        if let grd = getgrgid(s.st_gid), grd.pointee.gr_name != nil {
-            let name = String(cString: grd.pointee.gr_name)
+        if let grd = getgrgid(s.st_gid), let grd_name = grd.pointee.gr_name {
+            let name = String(cString: grd_name)
             result[.groupOwnerAccountName] = name
         }
 

--- a/Tests/Foundation/Tests/TestFileHandle.swift
+++ b/Tests/Foundation/Tests/TestFileHandle.swift
@@ -111,7 +111,7 @@ class TestFileHandle : XCTestCase {
 #else
         var fds: [Int32] = [-1, -1]
         fds.withUnsafeMutableBufferPointer { (pointer) -> Void in
-            pipe(pointer.baseAddress)
+            pipe(pointer.baseAddress!)
         }
         
         close(fds[1])

--- a/Tests/Foundation/Tests/TestTimeZone.swift
+++ b/Tests/Foundation/Tests/TestTimeZone.swift
@@ -160,7 +160,7 @@ class TestTimeZone: XCTestCase {
         var lt = tm()
         localtime_r(&t, &lt)
         let zoneName = NSTimeZone.system.abbreviation() ?? "Invalid Abbreviation"
-        let expectedName = String(cString: lt.tm_zone, encoding: .ascii) ?? "Invalid Zone"
+        let expectedName = String(cString: lt.tm_zone!, encoding: .ascii) ?? "Invalid Zone"
         XCTAssertEqual(zoneName, expectedName, "expected name \"\(expectedName)\" is not equal to \"\(zoneName)\"")
     }
 #endif


### PR DESCRIPTION
__Explanation:__ This is needed because [Bionic recently added a bunch of these annotations](https://android.googlesource.com/platform/bionic/+/25725717861813c18189c2699cf663bdb984d1b9%5E%21/#F0).

__Scope:__ Additional nullability checks and force unwraps only

__Issue:__ None

__Original PR:__ This is a cut-down #4850, which will have to be reworked for the `swift-foundation` merge.

__Risk:__ Low

__Testing:__ I made sure this pull doesn't break anything by testing it with the previous NDK 25c also. I used this patch with others to build the Swift toolchain for my Android CI, finagolfin/swift-android-sdk#122, and [the Termux app for Android](https://github.com/termux/termux-packages/commit/d10fd452662d3c39c0f19a901433bce8711b4688#diff-b8f3b540c354923485cb06eba2d66237536f89e88fd51e170495ddd8f5d32622R44), which now uses NDK 26b.

__Reviewer:__ @compnerd