### PR TITLE
Add fcntl.h include, required for some linux platforms

### DIFF
--- a/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
@@ -78,6 +78,7 @@
 #include <errno.h>
 #include <features.h>
 #include <termios.h>
+#include <fcntl.h>
 
 #ifdef __GLIBC_PREREQ
 #if __GLIBC_PREREQ(2, 28) == 0


### PR DESCRIPTION
Amazon Linux, at least, and probably others, requires the `fcntl.h` include to use the various constants in `statx`.