### PR TITLE
Enable importing the Synchronization module

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -160,14 +160,14 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend CoreFoundation>")
     target_compile_options(Foundation PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _FoundationICU>")
+    target_compile_options(Foundation PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
 endif()
-
-target_link_options(Foundation PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
 
 set_target_properties(Foundation PROPERTIES
     INSTALL_RPATH "$ORIGIN"
-    BUILD_RPATH "$<TARGET_FILE_DIR:swiftDispatch>")
+    BUILD_RPATH "$<TARGET_FILE_DIR:swiftDispatch>"
+    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 target_link_libraries(Foundation PUBLIC
     swiftDispatch)

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -60,13 +60,13 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFURLSessionInterface>")
     target_compile_options(FoundationNetworking PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend curl>")
+    target_compile_options(FoundationNetworking PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
 endif()
 
-target_link_options(FoundationNetworking PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
-
 set_target_properties(FoundationNetworking PROPERTIES
-    INSTALL_RPATH "$ORIGIN")
+    INSTALL_RPATH "$ORIGIN"
+    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 if(LINKER_SUPPORTS_BUILD_ID)
   target_link_options(FoundationNetworking PRIVATE "LINKER:--build-id=sha1")

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFXMLInterface>")
     target_compile_options(FoundationXML PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend xml2>")
-    target_compile_options(FoundationNetworking PRIVATE
+    target_compile_options(FoundationXML PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
 endif()
 

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -35,13 +35,13 @@ if(NOT BUILD_SHARED_LIBS)
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFXMLInterface>")
     target_compile_options(FoundationXML PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend xml2>")
+    target_compile_options(FoundationNetworking PRIVATE
+        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend swiftSynchronization>")
 endif()
 
-target_link_options(FoundationXML PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
-
 set_target_properties(FoundationXML PROPERTIES
-    INSTALL_RPATH "$ORIGIN")
+    INSTALL_RPATH "$ORIGIN"
+    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 if(LINKER_SUPPORTS_BUILD_ID)
   target_link_options(FoundationXML PRIVATE "LINKER:--build-id=sha1")

--- a/Sources/plutil/CMakeLists.txt
+++ b/Sources/plutil/CMakeLists.txt
@@ -18,11 +18,9 @@ add_executable(plutil
 target_link_libraries(plutil PRIVATE
 	Foundation)
 
-target_link_options(plutil PRIVATE
-    "SHELL:-no-toolchain-stdlib-rpath")
-
 set_target_properties(plutil PROPERTIES
-	INSTALL_RPATH "$ORIGIN/../lib/swift/${SWIFT_SYSTEM_NAME}")
+	INSTALL_RPATH "$ORIGIN/../lib/swift/${SWIFT_SYSTEM_NAME}"
+    INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS plutil)
 install(TARGETS plutil


### PR DESCRIPTION
Just like https://github.com/apple/swift-foundation/pull/742, we need to make the same changes to the SCL-F modules. We retain the compiler-added rpaths for libraries in the build folder and now overwrite them with `$ORIGIN` when installing, and we also add a public auto link to `swiftSynchronization` to ensure that our libraries pull in `libswiftSynchronization.a` in the static swift SDK.