### PR TITLE
Foundation: install the import libraries for public dependencies

### DIFF
--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -178,3 +178,7 @@ endif()
 
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS Foundation)
 _foundation_install_target(Foundation)
+install(FILES
+    $<TARGET_LINKER_FILE:FoundationEssentials>
+    $<TARGET_LINKER_FILE:FoundationInternationalization>
+  DESTINATION lib)


### PR DESCRIPTION
When building against Foundation in a multi-stage build, we would fail to build due to the import libraries being missing. These are required on platforms such as Windows and AIX (and theoretically on macOS if we generated TBDs).