### PR TITLE
Allow custom dispatch include path in SwiftPM package build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,19 @@
 
 import PackageDescription
 
+var dispatchIncludeFlags: CSetting
+if let environmentPath = Context.environment["DISPATCH_INCLUDE_PATH"] {
+    dispatchIncludeFlags = .unsafeFlags([
+        "-I\(environmentPath)",
+        "-I\(environmentPath)/Block"
+    ])
+} else {
+    dispatchIncludeFlags = .unsafeFlags([
+        "-I/usr/lib/swift",
+        "-I/usr/lib/swift/Block"
+    ], .when(platforms: [.linux, .android]))
+}
+
 let coreFoundationBuildSettings: [CSetting] = [
     .headerSearchPath("internalInclude"),
     .define("DEBUG", .when(configuration: .debug)),
@@ -30,8 +43,7 @@ let coreFoundationBuildSettings: [CSetting] = [
         "\(Context.packageDirectory)/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h",
         // /EHsc for Windows
     ]),
-    .unsafeFlags(["-I/usr/lib/swift"], .when(platforms: [.linux, .android])), // dispatch
-    .unsafeFlags(["-I/usr/lib/swift/Block"], .when(platforms: [.linux, .android])) // Block.h
+    dispatchIncludeFlags
 ]
 
 // For _CFURLSessionInterface, _CFXMLInterface
@@ -59,8 +71,7 @@ let interfaceBuildSettings: [CSetting] = [
         "-fcf-runtime-abi=swift"
         // /EHsc for Windows
     ]),
-    .unsafeFlags(["-I/usr/lib/swift"], .when(platforms: [.linux, .android])), // dispatch
-    .unsafeFlags(["-I/usr/lib/swift/Block"], .when(platforms: [.linux, .android])) // Block.h
+    dispatchIncludeFlags
 ]
 
 let swiftBuildSettings: [SwiftSetting] = [


### PR DESCRIPTION
This adds a `DISPATCH_INCLUDE_PATH` environment variable that allows specifying the location at which the package build can find dispatch headers. On linux/android this path still defaults to `/usr/lib/swift`. This will allow us to build the tests of this package via SwiftPM in the toolchain build where we build against a just-built toolchain (and `/usr/lib/swift` doesn't exist).