### PR TITLE
Re-enable tests requiring isoLatin1/macOSRoman

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -102,7 +102,7 @@ var dependencies: [Package.Dependency] {
                 from: "0.0.9"),
             .package(
                 url: "https://github.com/apple/swift-foundation",
-                revision: "d59046871c6b69a13595f18d334afa1553e0ba50")
+                revision: "acae3d26b69113cec2db7772b4144ab9558241db")
         ]
     }
 }

--- a/Tests/Foundation/TestDataURLProtocol.swift
+++ b/Tests/Foundation/TestDataURLProtocol.swift
@@ -79,9 +79,9 @@ class TestDataURLProtocol: XCTestCase {
             ("data:;charset=utf-16;base64,2D3caCAN2D3caCAN2D3cZyAN2D3cZw==", "👨‍👨‍👧‍👧", (expectedContentLength: 22, mimeType: "text/plain", textEncodingName: "utf-16")),
             ("data:;charset=utf-16le;base64,Pdho3A0gPdho3A0gPdhn3A0gPdhn3A==", "👨‍👨‍👧‍👧", (expectedContentLength: 22, mimeType: "text/plain", textEncodingName: "utf-16le")),
             ("data:;charset=utf-16be;base64,2D3caCAN2D3caCAN2D3cZyAN2D3cZw==", "👨‍👨‍👧‍👧", (expectedContentLength: 22, mimeType: "text/plain", textEncodingName: "utf-16be")),
-//            ("data:application/json;charset=iso-8859-1;key=value,,123", ",123", (expectedContentLength: 4, mimeType: "application/json", textEncodingName: "iso-8859-1")),
+            ("data:application/json;charset=iso-8859-1;key=value,,123", ",123", (expectedContentLength: 4, mimeType: "application/json", textEncodingName: "iso-8859-1")),
             ("data:;charset=utf-8;charset=utf-16;image/png,abc", "abc", (expectedContentLength: 3, mimeType: "text/plain", textEncodingName: "utf-8")),
-//            ("data:a/b;key=value;charset=macroman,blahblah", "blahblah", (expectedContentLength: 8, mimeType: "a/b", textEncodingName: "macroman")),
+            ("data:a/b;key=value;charset=macroman,blahblah", "blahblah", (expectedContentLength: 8, mimeType: "a/b", textEncodingName: "macroman")),
         ]
 
         let callbacks = [


### PR DESCRIPTION
Now that swift-foundation has support for `isoLatin1` and `macOSRoman`, we can enable this piece of the test that relied on those encodings.