### PR TITLE
Make completion-based send/receive functions public in `URLSessionWebSocketTask`

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -830,7 +830,8 @@ open class URLSessionWebSocketTask : URLSessionTask, @unchecked Sendable  {
         }
     }
     
-    private func send(_ message: Message, completionHandler: @Sendable @escaping (Error?) -> Void) {
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public func send(_ message: Message, completionHandler: @Sendable @escaping (Error?) -> Void) {
         self.workQueue.async {
             self.sendBuffer.append((message, completionHandler))
             self.doPendingWork()
@@ -846,7 +847,8 @@ open class URLSessionWebSocketTask : URLSessionTask, @unchecked Sendable  {
         }
     }
 
-    private func receive(completionHandler: @Sendable @escaping (Result<Message, Error>) -> Void) {
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    public func receive(completionHandler: @Sendable @escaping (Result<Message, Error>) -> Void) {
         self.workQueue.async {
             self.receiveCompletionHandlers.append(completionHandler)
             self.doPendingWork()


### PR DESCRIPTION
Completion-based [send](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask/3281790-send) and [receive](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask/3281789-receive) are public in Apple Foundation.

Perhaps, availability should be added to the containing type, but I added it here for consistency with async counterparts.