### PR TITLE
[Windows] Add default dispatch header search path to standalone builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,14 +96,15 @@ endif()
 find_package(dispatch CONFIG)
 if(NOT dispatch_FOUND)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-        set(DISPATCH_INCLUDE_PATH "/usr/lib/swift" CACHE STRING "A path to where you can find libdispatch headers")
-        message("-- dispatch_DIR not found, using dispatch from SDK at ${DISPATCH_INCLUDE_PATH}")
-        list(APPEND _Foundation_common_build_flags
-            "-I${DISPATCH_INCLUDE_PATH}"
-            "-I${DISPATCH_INCLUDE_PATH}/Block")
-    else()
-        message(FATAL_ERROR "-- dispatch_DIR is required on this platform")
+        set(DEFAULT_DISPATCH_INCLUDE_PATH "/usr/lib/swift")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        set(DEFAULT_DISPATCH_INCLUDE_PATH "$ENV{SDKROOT}usr/include")
     endif()
+    set(DISPATCH_INCLUDE_PATH "${DEFAULT_DISPATCH_INCLUDE_PATH}" CACHE STRING "A path to where you can find libdispatch headers")
+    message("-- dispatch_DIR not found, using dispatch from SDK at ${DISPATCH_INCLUDE_PATH}")
+    list(APPEND _Foundation_common_build_flags
+        "-I${DISPATCH_INCLUDE_PATH}"
+        "-I${DISPATCH_INCLUDE_PATH}/Block")
 endif()
 find_package(LibXml2 REQUIRED)
 find_package(CURL REQUIRED)

--- a/Package.swift
+++ b/Package.swift
@@ -3,17 +3,25 @@
 
 import PackageDescription
 
-var dispatchIncludeFlags: CSetting
+var dispatchIncludeFlags: [CSetting]
 if let environmentPath = Context.environment["DISPATCH_INCLUDE_PATH"] {
-    dispatchIncludeFlags = .unsafeFlags([
+    dispatchIncludeFlags = [.unsafeFlags([
         "-I\(environmentPath)",
         "-I\(environmentPath)/Block"
-    ])
+    ])]
 } else {
-    dispatchIncludeFlags = .unsafeFlags([
-        "-I/usr/lib/swift",
-        "-I/usr/lib/swift/Block"
-    ], .when(platforms: [.linux, .android]))
+    dispatchIncludeFlags = [
+        .unsafeFlags([
+            "-I/usr/lib/swift",
+            "-I/usr/lib/swift/Block"
+        ], .when(platforms: [.linux, .android]))
+    ]
+    if let sdkRoot = Context.environment["SDKROOT"] {
+        dispatchIncludeFlags.append(.unsafeFlags([
+            "-I\(sdkRoot)usr\\include",
+            "-I\(sdkRoot)usr\\include\\Block",
+        ], .when(platforms: [.windows])))
+    }
 }
 
 let coreFoundationBuildSettings: [CSetting] = [
@@ -43,9 +51,8 @@ let coreFoundationBuildSettings: [CSetting] = [
         "-include",
         "\(Context.packageDirectory)/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h",
         // /EHsc for Windows
-    ]),
-    dispatchIncludeFlags
-]
+    ])
+] + dispatchIncludeFlags
 
 // For _CFURLSessionInterface, _CFXMLInterface
 let interfaceBuildSettings: [CSetting] = [
@@ -71,9 +78,8 @@ let interfaceBuildSettings: [CSetting] = [
         "-fno-common",
         "-fcf-runtime-abi=swift"
         // /EHsc for Windows
-    ]),
-    dispatchIncludeFlags
-]
+    ])
+] + dispatchIncludeFlags
 
 let swiftBuildSettings: [SwiftSetting] = [
     .define("DEPLOYMENT_RUNTIME_SWIFT"),


### PR DESCRIPTION
When building this package via SwiftPM on Windows, we need to include dispatch headers from the appropriate directory in the SDK. We cannot rely on an absolute path such as `/usr/lib/swift` on linux, so instead we use a reasonable default based on the SDKROOT environment variable. I believe this environment variable should be set automatically in a VS developer shell with Swift installed to point to the `Windows.sdk` directory within the currently active swift installation. This allows us to find dispatch in many cases and get closer to a working package build on Windows (while still allowing manual overriding via the `DISPATCH_INCLUDE_PATH` environment variable)