### PR TITLE
[6.0] Fix local CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,10 +92,21 @@ if(NOT SwiftFoundation_MODULE_TRIPLE)
     mark_as_advanced(SwiftFoundation_MODULE_TRIPLE)
 endif()
 
-# System dependencies (fail fast if dependencies are missing)
+# System dependencies
+find_package(dispatch CONFIG)
+if(NOT dispatch_FOUND)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
+        set(DISPATCH_INCLUDE_PATH "/usr/lib/swift" CACHE STRING "A path to where you can find libdispatch headers")
+        message("-- dispatch_DIR not found, using dispatch from SDK at ${DISPATCH_INCLUDE_PATH}")
+        list(APPEND _Foundation_common_build_flags
+            "-I${DISPATCH_INCLUDE_PATH}"
+            "-I${DISPATCH_INCLUDE_PATH}/Block")
+    else()
+        message(FATAL_ERROR "-- dispatch_DIR is required on this platform")
+    endif()
+endif()
 find_package(LibXml2 REQUIRED)
 find_package(CURL REQUIRED)
-find_package(dispatch CONFIG REQUIRED)
 
 # Common build flags (_CFURLSessionInterface, _CFXMLInterface, CoreFoundation)
 list(APPEND _Foundation_common_build_flags
@@ -148,8 +159,7 @@ list(APPEND _Foundation_swift_build_flags
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND _Foundation_common_build_flags
-        "-D_GNU_SOURCE"
-        "-I/usr/lib/swift") # dispatch
+        "-D_GNU_SOURCE")
 endif()
 
 include(GNUInstallDirs)

--- a/Sources/CoreFoundation/CMakeLists.txt
+++ b/Sources/CoreFoundation/CMakeLists.txt
@@ -105,6 +105,9 @@ target_include_directories(CoreFoundation
     PRIVATE
         internalInclude)
 
+target_compile_options(CoreFoundation INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap>")
+
 target_compile_options(CoreFoundation PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:C>:${_Foundation_common_build_flags}>")
 

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -166,11 +166,14 @@ endif()
 
 set_target_properties(Foundation PROPERTIES
     INSTALL_RPATH "$ORIGIN"
-    BUILD_RPATH "$<TARGET_FILE_DIR:swiftDispatch>"
     INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
-target_link_libraries(Foundation PUBLIC
-    swiftDispatch)
+if(dispatch_FOUND)
+    set_target_properties(Foundation PROPERTIES
+        BUILD_RPATH "$<TARGET_FILE_DIR:swiftDispatch>")
+    target_link_libraries(Foundation PUBLIC
+        swiftDispatch)
+endif()
 
 if(LINKER_SUPPORTS_BUILD_ID)
   target_link_options(Foundation PRIVATE "LINKER:--build-id=sha1")

--- a/Sources/_CFURLSessionInterface/CMakeLists.txt
+++ b/Sources/_CFURLSessionInterface/CMakeLists.txt
@@ -23,6 +23,10 @@ target_include_directories(_CFURLSessionInterface
 
 target_precompile_headers(_CFURLSessionInterface PRIVATE ${CMAKE_SOURCE_DIR}/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h)
 
+target_compile_options(_CFURLSessionInterface INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/../CoreFoundation/include/module.modulemap>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap>")
+
 target_compile_options(_CFURLSessionInterface PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:C>:${_Foundation_common_build_flags}>")
 

--- a/Sources/_CFXMLInterface/CMakeLists.txt
+++ b/Sources/_CFXMLInterface/CMakeLists.txt
@@ -22,6 +22,10 @@ target_include_directories(_CFXMLInterface
         ../CoreFoundation/internalInclude
         /usr/include/libxml2/)
 
+target_compile_options(_CFXMLInterface INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/../CoreFoundation/include/module.modulemap>"
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/module.modulemap>")
+
 target_compile_options(_CFXMLInterface PRIVATE
     "SHELL:$<$<COMPILE_LANGUAGE:C>:${_Foundation_common_build_flags}>")
 


### PR DESCRIPTION
Explanation: Allows building the project via CMake outside of the toolchain
Scope: Should only resolve an issue in local, non-toolchain CMake builds
Original PR: https://github.com/apple/swift-corelibs-foundation/pull/5032
Risk: Minimal - minor change to CMake that has been tested
Testing: Testing done via swift-ci toolchain builds and local, standalone CMake builds
Reviewer: @iCharlesHu