### PR TITLE
[6.0] Fix SwiftPM build dispatch include path on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,14 +96,15 @@ endif()
 find_package(dispatch CONFIG)
 if(NOT dispatch_FOUND)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
-        set(DISPATCH_INCLUDE_PATH "/usr/lib/swift" CACHE STRING "A path to where you can find libdispatch headers")
-        message("-- dispatch_DIR not found, using dispatch from SDK at ${DISPATCH_INCLUDE_PATH}")
-        list(APPEND _Foundation_common_build_flags
-            "-I${DISPATCH_INCLUDE_PATH}"
-            "-I${DISPATCH_INCLUDE_PATH}/Block")
-    else()
-        message(FATAL_ERROR "-- dispatch_DIR is required on this platform")
+        set(DEFAULT_DISPATCH_INCLUDE_PATH "/usr/lib/swift")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        set(DEFAULT_DISPATCH_INCLUDE_PATH "$ENV{SDKROOT}usr/include")
     endif()
+    set(DISPATCH_INCLUDE_PATH "${DEFAULT_DISPATCH_INCLUDE_PATH}" CACHE STRING "A path to where you can find libdispatch headers")
+    message("-- dispatch_DIR not found, using dispatch from SDK at ${DISPATCH_INCLUDE_PATH}")
+    list(APPEND _Foundation_common_build_flags
+        "-I${DISPATCH_INCLUDE_PATH}"
+        "-I${DISPATCH_INCLUDE_PATH}/Block")
 endif()
 find_package(LibXml2 REQUIRED)
 find_package(CURL REQUIRED)

--- a/Package.swift
+++ b/Package.swift
@@ -3,17 +3,25 @@
 
 import PackageDescription
 
-var dispatchIncludeFlags: CSetting
+var dispatchIncludeFlags: [CSetting]
 if let environmentPath = Context.environment["DISPATCH_INCLUDE_PATH"] {
-    dispatchIncludeFlags = .unsafeFlags([
+    dispatchIncludeFlags = [.unsafeFlags([
         "-I\(environmentPath)",
         "-I\(environmentPath)/Block"
-    ])
+    ])]
 } else {
-    dispatchIncludeFlags = .unsafeFlags([
-        "-I/usr/lib/swift",
-        "-I/usr/lib/swift/Block"
-    ], .when(platforms: [.linux, .android]))
+    dispatchIncludeFlags = [
+        .unsafeFlags([
+            "-I/usr/lib/swift",
+            "-I/usr/lib/swift/Block"
+        ], .when(platforms: [.linux, .android]))
+    ]
+    if let sdkRoot = Context.environment["SDKROOT"] {
+        dispatchIncludeFlags.append(.unsafeFlags([
+            "-I\(sdkRoot)usr\\include",
+            "-I\(sdkRoot)usr\\include\\Block",
+        ], .when(platforms: [.windows])))
+    }
 }
 
 let coreFoundationBuildSettings: [CSetting] = [
@@ -43,9 +51,8 @@ let coreFoundationBuildSettings: [CSetting] = [
         "-include",
         "\(Context.packageDirectory)/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h",
         // /EHsc for Windows
-    ]),
-    dispatchIncludeFlags
-]
+    ])
+] + dispatchIncludeFlags
 
 // For _CFURLSessionInterface, _CFXMLInterface
 let interfaceBuildSettings: [CSetting] = [
@@ -71,9 +78,8 @@ let interfaceBuildSettings: [CSetting] = [
         "-fno-common",
         "-fcf-runtime-abi=swift"
         // /EHsc for Windows
-    ]),
-    dispatchIncludeFlags
-]
+    ])
+] + dispatchIncludeFlags
 
 let swiftBuildSettings: [SwiftSetting] = [
     .define("DEPLOYMENT_RUNTIME_SWIFT"),


### PR DESCRIPTION
Explanation: Allows building the standalone project on Windows without pre-building corelibs-libdispatch
Scope: Should only modify standalone, local builds on Windows
Original PR: https://github.com/apple/swift-corelibs-foundation/pull/5033
Risk: Minimal - minor change to CMake/package manifest that only affects local, standalone builds
Testing: Testing done via swift-ci toolchain builds and local, standalone CMake/SwiftPM builds
Reviewer: @iCharlesHu