### PR TITLE
Fix CoreFoundation module install path for static build

### DIFF
--- a/Sources/CoreFoundation/CMakeLists.txt
+++ b/Sources/CoreFoundation/CMakeLists.txt
@@ -126,10 +126,16 @@ file(COPY
     DESTINATION
         ${CMAKE_BINARY_DIR}/_CModulesForClients/CoreFoundation)
 
+if(NOT BUILD_SHARED_LIBS)
+    set(swift swift_static)
+else()
+    set(swift swift)
+endif()
+
 install(DIRECTORY
             include/
         DESTINATION
-            lib/swift/CoreFoundation)
+            lib/${swift}/CoreFoundation)
 
 if(NOT BUILD_SHARED_LIBS)
     install(TARGETS CoreFoundation


### PR DESCRIPTION
The CoreFoundation target had a hard-coded module install path of `lib/swift/CoreFoundation`, instead of conditionalizing it for the static build (which goes to `lib/swift_static`). While we don't expect clients to use `CoreFoundation` directly (and they shouldn't), this restores the module to unbreak existing clients that are doing this.

This resolves https://github.com/apple/swift-http-types/issues/61