### PR TITLE
Make sure that the once used for Process is static

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -226,9 +226,9 @@ private func quoteWindowsCommandLine(_ commandLine: [String]) -> String {
 #endif
 
 open class Process: NSObject, @unchecked Sendable {
+    static let once = Mutex(false)
+    
     private static func setup() {
-        let once = Mutex(false)
-        
         once.withLock {
             if !$0 {
                 let thread = Thread {


### PR DESCRIPTION
Do not re-add sources to the run loop for each call to `setup`. Regression from #5000.