### PR TITLE
[6.0] Fix CoreFoundation install path

### DIFF
--- a/Sources/CoreFoundation/CMakeLists.txt
+++ b/Sources/CoreFoundation/CMakeLists.txt
@@ -126,10 +126,16 @@ file(COPY
     DESTINATION
         ${CMAKE_BINARY_DIR}/_CModulesForClients/CoreFoundation)
 
+if(NOT BUILD_SHARED_LIBS)
+    set(swift swift_static)
+else()
+    set(swift swift)
+endif()
+
 install(DIRECTORY
             include/
         DESTINATION
-            lib/swift/CoreFoundation)
+            lib/${swift}/CoreFoundation)
 
 if(NOT BUILD_SHARED_LIBS)
     install(TARGETS CoreFoundation


### PR DESCRIPTION
Explanation: Re-adds the CoreFoundation module to the static swift SDK
Scope: Should only change the static swift build and fixes a regression
Original PR: https://github.com/apple/swift-corelibs-foundation/pull/5037
Risk: Minimal - minor change to fix a regression that should effectively be additive
Testing: Testing done via swift-ci toolchain builds and local, standalone CMake builds
Reviewer: @iCharlesHu