### PR TITLE
Fix incorrect help documentation of XCTestMain

### DIFF
--- a/Sources/XCTest/Public/XCTestMain.swift
+++ b/Sources/XCTest/Public/XCTestMain.swift
@@ -124,7 +124,7 @@ public func XCTMain(
 
               OPTIONS:
 
-              -l, --list-test              List tests line by line to standard output
+              -l, --list-tests             List tests line by line to standard output
                   --dump-tests-json        List tests in JSON to standard output
 
               TESTCASES:


### PR DESCRIPTION
The option `--list-test` is incorrect. The correct option is [`--list-tests`](https://github.com/apple/swift-corelibs-foundation/blob/9c8bac47f032a431dde757112591e3dd60dba461/Sources/XCTest/Private/ArgumentParser.swift#L60).

This is the same as https://github.com/apple/swift-corelibs-xctest/pull/499.