### PR TITLE
Update to use dynamic replacement for _NSNumberInitializer

### DIFF
--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -1176,7 +1176,7 @@ protocol _NSNumberCastingWithoutBridging {
 extension NSNumber: _NSNumberCastingWithoutBridging {}
 
 // Called by FoundationEssentials
-internal final class _FoundationNSNumberInitializer : _NSNumberInitializer {
+internal struct _FoundationNSNumberInitializer : _NSNumberInitializer {
     public static func initialize(value: some BinaryInteger) -> Any {
         if let int64 = Int64(exactly: value) {
             return NSNumber(value: int64)
@@ -1188,4 +1188,9 @@ internal final class _FoundationNSNumberInitializer : _NSNumberInitializer {
     public static func initialize(value: Bool) -> Any {
         NSNumber(value: value)
     }
+}
+
+@_dynamicReplacement(for: _nsNumberInitializer())
+private func _nsNumberInitializer_corelibs_foundation() -> _NSNumberInitializer.Type? {
+    return _FoundationNSNumberInitializer.self
 }


### PR DESCRIPTION
In https://github.com/apple/swift-foundation/pull/756 we transitioned the `FoundationEssentials` --> `FoundationInternationalization` upcalls from `_typeByName` to `@_dynamicReplacement` functions to avoid accidentally looking up types from the toolchain in local builds. In that PR, I also added a `dynamic` function for `Foundation` to override for its `NSNumber` initializer. This PR implements that dynamic replacement so that we can remove the final `_typeByName` lookup in `FoundationEssentials`