### PR TITLE
[6.0] Update to use dynamic replacement for _NSNumberInitializer

### DIFF
--- a/Sources/Foundation/NSNumber.swift
+++ b/Sources/Foundation/NSNumber.swift
@@ -1176,7 +1176,7 @@ protocol _NSNumberCastingWithoutBridging {
 extension NSNumber: _NSNumberCastingWithoutBridging {}
 
 // Called by FoundationEssentials
-internal final class _FoundationNSNumberInitializer : _NSNumberInitializer {
+internal struct _FoundationNSNumberInitializer : _NSNumberInitializer {
     public static func initialize(value: some BinaryInteger) -> Any {
         if let int64 = Int64(exactly: value) {
             return NSNumber(value: int64)
@@ -1188,4 +1188,9 @@ internal final class _FoundationNSNumberInitializer : _NSNumberInitializer {
     public static func initialize(value: Bool) -> Any {
         NSNumber(value: value)
     }
+}
+
+@_dynamicReplacement(for: _nsNumberInitializer())
+private func _nsNumberInitializer_corelibs_foundation() -> _NSNumberInitializer.Type? {
+    return _FoundationNSNumberInitializer.self
 }


### PR DESCRIPTION
Explanation: Removes a `_typeByName` lookup in a FoundationEssentials up-call that can result in confusion between the toolchain and local builds
Scope: Should only impact up-calls from `FileManager` in `FoundationEssentials` to initialize `NSNumber`s
Original PR: https://github.com/apple/swift-corelibs-foundation/pull/5045
Risk: Low - small in scope and covered by unit tests
Testing: Testing done via swift-ci testing
Reviewer: @parkera 