### PR TITLE
Implement hook for data reading from remote URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,10 +105,10 @@ var dependencies: [Package.Dependency] {
         [
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
-                from: "0.0.9"),
+                branch: "main"),
             .package(
                 url: "https://github.com/apple/swift-foundation",
-                revision: "acae3d26b69113cec2db7772b4144ab9558241db")
+                branch: "main")
         ]
     }
 }

--- a/Sources/FoundationNetworking/URLSession/NetworkingSpecific.swift
+++ b/Sources/FoundationNetworking/URLSession/NetworkingSpecific.swift
@@ -35,6 +35,16 @@ internal func NSRequiresConcreteImplementation(_ fn: String = #function, file: S
     fatalError("\(fn) must be overridden", file: file, line: line)
 }
 
+extension Data {
+    @_dynamicReplacement(for: init(_contentsOfRemote:options:))
+    private init(_contentsOfRemote_foundationNetworking url: URL, options: Data.ReadingOptions = []) throws {
+        let (nsData, _) = try _NSNonfileURLContentLoader().contentsOf(url: url)
+        self = withExtendedLifetime(nsData) {
+            return Data(bytes: nsData.bytes, count: nsData.length)
+        }
+    }
+}
+
 @usableFromInline
 class _NSNonfileURLContentLoader: _NSNonfileURLContentLoading, @unchecked Sendable {
     @usableFromInline

--- a/Tests/Foundation/TestURL.swift
+++ b/Tests/Foundation/TestURL.swift
@@ -781,7 +781,7 @@ class TestURL : XCTestCase {
             // Tests the up-call to FoundationNetworking to perform the network request
             try Data(contentsOf: URL(string: "https://swift.org")!)
         } catch {
-            if let cocoaCode = (error as? CocoaError).code {
+            if let cocoaCode = (error as? CocoaError)?.code {
                 // Just ensure that we supported this feature, even if the request failed
                 XCTAssertNotEqual(cocoaCode, .featureUnsupported)
             }

--- a/Tests/Foundation/TestURL.swift
+++ b/Tests/Foundation/TestURL.swift
@@ -776,9 +776,16 @@ class TestURL : XCTestCase {
         }
     }
     
-    func test_dataFromNonFileURL() throws {
-        // Tests the up-call to FoundationNetworking to perform the network request
-        XCTAssertNoThrow(try Data(contentsOf: URL(string: "https://swift.org")!))
+    func test_dataFromNonFileURL() {
+        do {
+            // Tests the up-call to FoundationNetworking to perform the network request
+            try Data(contentsOf: URL(string: "https://swift.org")!)
+        } catch {
+            if let cocoaCode = (error as? CocoaError).code {
+                // Just ensure that we supported this feature, even if the request failed
+                XCTAssertNotEqual(cocoaCode, .featureUnsupported)
+            }
+        }
     }
 
     // MARK: -

--- a/Tests/Foundation/TestURL.swift
+++ b/Tests/Foundation/TestURL.swift
@@ -775,6 +775,11 @@ class TestURL : XCTestCase {
             throw error
         }
     }
+    
+    func test_dataFromNonFileURL() throws {
+        // Tests the up-call to FoundationNetworking to perform the network request
+        XCTAssertNoThrow(try Data(contentsOf: URL(string: "https://swift.org")!))
+    }
 
     // MARK: -
 


### PR DESCRIPTION
This implements the hook added in https://github.com/apple/swift-foundation/pull/820 to support reading from a remote URL, and also adds a unit test to verify the behavior is functional.