### PR TITLE
[6.0] build: Repair the build on WASI platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,6 @@ list(APPEND _Foundation_common_build_flags
     "-DCF_BUILDING_CF"
     "-DDEPLOYMENT_ENABLE_LIBDISPATCH"
     "-DHAVE_STRUCT_TIMESPEC"
-    "-DSWIFT_CORELIBS_FOUNDATION_HAS_THREADS"
     "-Wno-shorten-64-to-32"
     "-Wno-deprecated-declarations"
     "-Wno-unreachable-code"
@@ -126,6 +125,18 @@ list(APPEND _Foundation_common_build_flags
     "-Wno-int-conversion"
     "-Wno-switch"
     "-fblocks")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
+  list(APPEND _Foundation_common_build_flags
+    "-D_WASI_EMULATED_SIGNAL"
+    "-DHAVE_STRLCPY"
+    "-DHAVE_STRLCAT"
+  )
+else()
+  list(APPEND _Foundation_common_build_flags
+    "-DSWIFT_CORELIBS_FOUNDATION_HAS_THREADS"
+  )
+endif()
 
 if(NOT "${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
     list(APPEND _Foundation_common_build_flags
@@ -154,9 +165,20 @@ set(_Foundation_swift_build_flags)
 list(APPEND _Foundation_swift_build_flags
     "-swift-version 6"
     "-DDEPLOYMENT_RUNTIME_SWIFT"
-    "-DSWIFT_CORELIBS_FOUNDATION_HAS_THREADS"
     "-Xfrontend"
     "-require-explicit-sendable")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
+  list(APPEND _Foundation_swift_build_flags
+    "-D_WASI_EMULATED_SIGNAL"
+    "-DHAVE_STRLCPY"
+    "-DHAVE_STRLCAT"
+  )
+else()
+  list(APPEND _Foundation_swift_build_flags
+    "-DSWIFT_CORELIBS_FOUNDATION_HAS_THREADS"
+  )
+endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND _Foundation_common_build_flags

--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let platformsWithThreads: [Platform] = [
     .driverKit,
     .android,
     .linux,
+    .windows,
 ]
 var dispatchIncludeFlags: [CSetting]
 if let environmentPath = Context.environment["DISPATCH_INCLUDE_PATH"] {

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,16 @@
 
 import PackageDescription
 
+let platformsWithThreads: [Platform] = [
+    .iOS,
+    .macOS,
+    .tvOS,
+    .watchOS,
+    .macCatalyst,
+    .driverKit,
+    .android,
+    .linux,
+]
 var dispatchIncludeFlags: [CSetting]
 if let environmentPath = Context.environment["DISPATCH_INCLUDE_PATH"] {
     dispatchIncludeFlags = [.unsafeFlags([
@@ -31,8 +41,11 @@ let coreFoundationBuildSettings: [CSetting] = [
     .define("DEPLOYMENT_ENABLE_LIBDISPATCH"),
     .define("DEPLOYMENT_RUNTIME_SWIFT"),
     .define("HAVE_STRUCT_TIMESPEC"),
-    .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS"),
+    .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS", .when(platforms: platformsWithThreads)),
     .define("_GNU_SOURCE", .when(platforms: [.linux, .android])),
+    .define("_WASI_EMULATED_SIGNAL", .when(platforms: [.wasi])),
+    .define("HAVE_STRLCPY", .when(platforms: [.wasi])),
+    .define("HAVE_STRLCAT", .when(platforms: [.wasi])),
     .unsafeFlags([
         "-Wno-shorten-64-to-32",
         "-Wno-deprecated-declarations",
@@ -61,8 +74,11 @@ let interfaceBuildSettings: [CSetting] = [
     .define("CF_BUILDING_CF"),
     .define("DEPLOYMENT_ENABLE_LIBDISPATCH"),
     .define("HAVE_STRUCT_TIMESPEC"),
-    .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS"),
+    .define("SWIFT_CORELIBS_FOUNDATION_HAS_THREADS", .when(platforms: platformsWithThreads)),
     .define("_GNU_SOURCE", .when(platforms: [.linux, .android])),
+    .define("_WASI_EMULATED_SIGNAL", .when(platforms: [.wasi])),
+    .define("HAVE_STRLCPY", .when(platforms: [.wasi])),
+    .define("HAVE_STRLCAT", .when(platforms: [.wasi])),
     .unsafeFlags([
         "-Wno-shorten-64-to-32",
         "-Wno-deprecated-declarations",

--- a/Sources/CoreFoundation/CFBundle.c
+++ b/Sources/CoreFoundation/CFBundle.c
@@ -596,7 +596,13 @@ static CFBundleRef _CFBundleGetBundleWithIdentifier(CFStringRef bundleID, void *
 
 CFBundleRef CFBundleGetBundleWithIdentifier(CFStringRef bundleID) {
     // Use the frame that called this as a hint
-    return _CFBundleGetBundleWithIdentifier(bundleID, __builtin_return_address(0));
+    void *hint;
+#if TARGET_OS_WASI
+    hint = NULL;
+#else
+    hint = __builtin_frame_address(0);
+#endif
+    return _CFBundleGetBundleWithIdentifier(bundleID, hint);
 }
 
 CFBundleRef _CFBundleGetBundleWithIdentifierWithHint(CFStringRef bundleID, void *pointer) {

--- a/Sources/CoreFoundation/CFString.c
+++ b/Sources/CoreFoundation/CFString.c
@@ -28,7 +28,7 @@
 #include "CFRuntime_Internal.h"
 #include <assert.h>
 #include <_foundation_unicode/uchar.h>
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
 #include "CFConstantKeys.h"
 #include "CFStringLocalizedFormattingInternal.h"
 #endif


### PR DESCRIPTION
Cherry picked from https://github.com/apple/swift-corelibs-foundation/pull/5052

**Explanation**: these patches restore support for WASI that was available in `swift-corelibs-foundation` before it was recored.
**Scope**: Isolated to WASI codepaths.
**Risk**: Low due to isolated scope.
**Testing**: Tested manually for WASI, on CI with the existing test suite for other platforms.
**Issue**: rdar://133231577
**Reviewer**: @kateinoigakukun, @jmschonfeld