### PR TITLE
NFC: Add `.index-build` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ project.xcworkspace
 
 Build
 .build
+.index-build
 .configuration
 
 *.swp


### PR DESCRIPTION
These files are created by SourceKit-LSP when background indexing is enabled.