### PR TITLE
[6.0] Disable test_connectTimeout

### DIFF
--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -609,6 +609,8 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
     }
 
     func test_connectTimeout() async throws {
+        throw XCTSkip("This test is disabled (flaky when all tests are run together)")
+        #if false
         // Reconfigure http server for this specific scenario:
         // a slow request keeps web server busy, while other
         // request times out on connection attempt.
@@ -646,6 +648,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         Self.stopServer()
         Self.options = .default
         Self.startServer()
+        #endif
     }
     
     func test_repeatedRequestsStress() async throws {


### PR DESCRIPTION
Cherry picked from https://github.com/apple/swift-corelibs-foundation/pull/5046

Explanation: Disable flaky test on Linux while we investigate a more robust way to test connection timeout
Scope: Disables one TestURLSession test case
Risk: Minimal
Testing: swift-ci and local package testing on Ubuntu 22.04 and Amazon Linux 2
Reviewer: @parkera 