### PR TITLE
CMake: Fix missing librt target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ if(NOT SwiftFoundation_MODULE_TRIPLE)
 endif()
 
 # System dependencies
+find_package(LibRT)
 find_package(dispatch CONFIG)
 if(NOT dispatch_FOUND)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")

--- a/cmake/modules/FindLibRT.cmake
+++ b/cmake/modules/FindLibRT.cmake
@@ -4,7 +4,7 @@
 #
 # Find librt library and headers.
 #
-# The mdoule defines the following variables:
+# The module defines the following variables:
 #
 # ::
 #


### PR DESCRIPTION
When building the static SDK, dispatch is built as a static archive, so its dependency on librt is exposed as part of its link interface. This shows up in the `dispatchConfig.cmake` file imported by `find_package(dispatch CONFIG)`.

```
CMake Error at build/x86_64/dispatch/cmake/modules/dispatchExports.cmake:71 (set_target_properties):
  The link interface of target "dispatch" contains:

    RT::rt

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```

It would be great if the dispatch config could include that target to ensure that everyone is using the same librt, it does not, so we have to find and include it ourselves.