### PR TITLE
[6.0] Implement Data reading hook for remote content

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,10 +105,10 @@ var dependencies: [Package.Dependency] {
         [
             .package(
                 url: "https://github.com/apple/swift-foundation-icu",
-                from: "0.0.9"),
+                branch: "release/6.0"),
             .package(
                 url: "https://github.com/apple/swift-foundation",
-                revision: "d59046871c6b69a13595f18d334afa1553e0ba50")
+                branch: "release/6.0")
         ]
     }
 }

--- a/Sources/FoundationNetworking/URLSession/NetworkingSpecific.swift
+++ b/Sources/FoundationNetworking/URLSession/NetworkingSpecific.swift
@@ -35,6 +35,16 @@ internal func NSRequiresConcreteImplementation(_ fn: String = #function, file: S
     fatalError("\(fn) must be overridden", file: file, line: line)
 }
 
+extension Data {
+    @_dynamicReplacement(for: init(_contentsOfRemote:options:))
+    private init(_contentsOfRemote_foundationNetworking url: URL, options: Data.ReadingOptions = []) throws {
+        let (nsData, _) = try _NSNonfileURLContentLoader().contentsOf(url: url)
+        self = withExtendedLifetime(nsData) {
+            return Data(bytes: nsData.bytes, count: nsData.length)
+        }
+    }
+}
+
 @usableFromInline
 class _NSNonfileURLContentLoader: _NSNonfileURLContentLoading, @unchecked Sendable {
     @usableFromInline

--- a/Tests/Foundation/TestURL.swift
+++ b/Tests/Foundation/TestURL.swift
@@ -775,6 +775,18 @@ class TestURL : XCTestCase {
             throw error
         }
     }
+    
+    func test_dataFromNonFileURL() {
+        do {
+            // Tests the up-call to FoundationNetworking to perform the network request
+            try Data(contentsOf: URL(string: "https://swift.org")!)
+        } catch {
+            if let cocoaCode = (error as? CocoaError)?.code {
+                // Just ensure that we supported this feature, even if the request failed
+                XCTAssertNotEqual(cocoaCode, .featureUnsupported)
+            }
+        }
+    }
 
     // MARK: -
 


### PR DESCRIPTION
Explanation: Implements the hook defined in https://github.com/apple/swift-foundation/pull/826 to allow for `Data(contentsOf:)` to fetch from a remote URL when FoundationNetworking is loaded
Scope: Should only impact calling Data(contentsOf:) with a non-file URL, turning an error into non-regressed behavior
Original PR: https://github.com/apple/swift-corelibs-foundation/pull/5049
Risk: Minimal - fixes a regression where the current behavior is just to throw, and fairly limited scope
Testing: Testing done via swift-ci testing and local testing
Reviewer: @iCharlesHu @parkera 