### PR TITLE
Enable WMO for release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 if(POLICY CMP0157)
     set(CMAKE_Swift_COMPILATION_MODE "$<IF:$<CONFIG:Release>,wholemodule,incremental>")
 else()
-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:Swift>,$<IF:$<CONFIG:Release>>>:-wmo>)
+    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:Swift>,$<CONFIG:Release>>:-wmo>)
 endif()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
         "-D_GNU_SOURCE")
 endif()
 
+# Enable whole module optimization for release builds & incremental for debug builds
+if(POLICY CMP0157)
+    set(CMAKE_Swift_COMPILATION_MODE "$<IF:$<CONFIG:Release>,wholemodule,incremental>")
+else()
+    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:Swift>,$<IF:$<CONFIG:Release>>>:-wmo>)
+endif()
+
 include(GNUInstallDirs)
 include(FoundationSwiftSupport)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,13 @@ if(NOT SWIFT_SYSTEM_NAME)
   endif()
 endif()
 
+# Enable whole module optimization for release builds & incremental for debug builds
+if(POLICY CMP0157)
+    set(CMAKE_Swift_COMPILATION_MODE "$<IF:$<CONFIG:Release>,wholemodule,incremental>")
+else()
+    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:Swift>,$<IF:$<CONFIG:Release>>>:-wmo>)
+endif()
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -183,13 +190,6 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")
     list(APPEND _Foundation_common_build_flags
         "-D_GNU_SOURCE")
-endif()
-
-# Enable whole module optimization for release builds & incremental for debug builds
-if(POLICY CMP0157)
-    set(CMAKE_Swift_COMPILATION_MODE "$<IF:$<CONFIG:Release>,wholemodule,incremental>")
-else()
-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:Swift>,$<IF:$<CONFIG:Release>>>:-wmo>)
 endif()
 
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,11 +41,14 @@ if(NOT SWIFT_SYSTEM_NAME)
   endif()
 endif()
 
-# Enable whole module optimization for release builds & incremental for debug builds
-if(POLICY CMP0157)
-    set(CMAKE_Swift_COMPILATION_MODE "$<IF:$<CONFIG:Release>,wholemodule,incremental>")
-else()
-    add_compile_options($<$<AND:$<COMPILE_LANGUAGE:Swift>,$<CONFIG:Release>>:-wmo>)
+# Don't enable WMO on Windows due to linker failures
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+    # Enable whole module optimization for release builds & incremental for debug builds
+    if(POLICY CMP0157)
+        set(CMAKE_Swift_COMPILATION_MODE "$<IF:$<CONFIG:Release>,wholemodule,incremental>")
+    else()
+        add_compile_options($<$<AND:$<COMPILE_LANGUAGE:Swift>,$<CONFIG:Release>>:-wmo>)
+    endif()
 endif()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)


### PR DESCRIPTION
This enables whole module optimization for Foundation, FoundationNetworking, and FoundationXML for release builds. We've found that this added optimization results in a significant performance improvements for FoundationEssentials (https://github.com/apple/swift-foundation/pull/832) and will be applying the same optimization to the SCL-F suite of libraries