### PR TITLE
[XMLParser] Fix reentrancy issue around `currentParser`

### DIFF
--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -412,9 +412,6 @@ open class XMLParser : NSObject {
     
     // initializes the parser with the specified URL.
     public convenience init?(contentsOf url: URL) {
-#if os(WASI)
-        return nil
-#else
         setupXMLParsing()
         if url.isFileURL {
             if let stream = InputStream(url: url) {
@@ -432,7 +429,6 @@ open class XMLParser : NSObject {
                 return nil
             }
         }
-#endif
     }
     
     // create the parser from data
@@ -448,7 +444,6 @@ open class XMLParser : NSObject {
         _CFXMLInterfaceDestroyContext(_parserContext)
     }
     
-#if !os(WASI)
     //create a parser that incrementally pulls data from the specified stream and parses it.
     public init(stream: InputStream) {
         setupXMLParsing()
@@ -456,7 +451,6 @@ open class XMLParser : NSObject {
         _handler = _CFXMLInterfaceCreateSAXHandler()
         _parserContext = nil
     }
-#endif
     
     open weak var delegate: XMLParserDelegate?
     

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -462,34 +462,57 @@ open class XMLParser : NSObject {
     
     open var allowedExternalEntityURLs: Set<URL>?
 
-    /// The current parser is stored in a task local variable to allow for
-    /// concurrent parsing in different tasks with different parsers.
-    ///
-    /// Rationale for `@unchecked Sendable`:
-    /// While the ``XMLParser`` class itself is not `Sendable`, `TaskLocal`
-    /// requires the value type to be `Sendable`. The sendability requirement
-    /// of `TaskLocal` is only for the "default" value and values set with
-    /// `withValue` will not be shared between tasks.
-    /// So as long as 1. the default value is safe to be shared between tasks
-    /// and 2. the `Sendable` conformance of `_CurrentParser` is not used
-    /// outside of `TaskLocal`, it is safe to mark it as `@unchecked Sendable`.
-    private struct _CurrentParser: @unchecked Sendable {
-        let parser: XMLParser?
-
-        static var `default`: _CurrentParser {
-            return _CurrentParser(parser: nil)
+    /// The current parser context for the current thread.
+    private class _CurrentParserContext {
+        var _stack: [XMLParser] = []
+        var _current: XMLParser? {
+            return _stack.last
         }
     }
 
-    @TaskLocal
-    private static var _currentParser: _CurrentParser = .default
-
-    internal static func currentParser() -> XMLParser? {
-        return _currentParser.parser
+    #if os(WASI)
+    /// The current parser associated with the current thread. (assuming no multi-threading)
+    /// FIXME: Unify the implementation with the other platforms once we unlock `threadDictionary`
+    ///        or migrate to `FoundationEssentials._ThreadLocal`.
+    private static nonisolated(unsafe) var _currentParserContext: _CurrentParserContext?
+    #else
+    /// The current parser associated with the current thread.
+    private static var _currentParserContext: _CurrentParserContext? {
+        get {
+            return Thread.current.threadDictionary["__CurrentNSXMLParser"] as? _CurrentParserContext
+        }
+        set {
+            Thread.current.threadDictionary["__CurrentNSXMLParser"] = newValue
+        }
     }
-    
+    #endif
+
+    /// The current parser associated with the current thread.
+    internal static func currentParser() -> XMLParser? {
+        if let ctx = _currentParserContext {
+            return ctx._current
+        }
+        return nil
+    }
+
+    /// Execute the given closure with the current parser set to the given parser.
     internal static func withCurrentParser<R>(_ parser: XMLParser, _ body: () -> R) -> R {
-        return self.$_currentParser.withValue(_CurrentParser(parser: parser), operation: body)
+        var ctx: _CurrentParserContext
+        if let current = _currentParserContext {
+            // Use the existing context if it exists
+            ctx = current
+        } else {
+            // Create a new context in TLS
+            ctx = _CurrentParserContext()
+            _currentParserContext = ctx
+        }
+        // Push the parser onto the stack
+        ctx._stack.append(parser)
+        defer {
+            // Pop the parser off the stack
+            ctx._stack.removeLast()
+        }
+        return body()
     }
     
     internal func _handleParseResult(_ parseResult: Int32) -> Bool {


### PR DESCRIPTION
Instead of thread-local storage, use `TaskLocal` to store the current
parser. This solves three issues:

1. If someone calls `XMLParser.parse()` with a new parser instance in
   a delegate method call, it overwrote the current parser and wrote
   it back after the call as `nil`, not the previous current parser.
   This reentrancy issue can be a problem especially when someone uses
   external entity resolving since the feature depends on the current
   parser tracking. Using `TaskLocal` solves this issue since it tracks
   values as a stack and restores the previous value at the end of the
   `withValue` call.
2. Since jobs of different tasks can be scheduled on the same thread,
   different tasks can refer to the same thread-local storage. This
   wouldn't be a problem for now since the `parse()` method doesn't
   have any suspention points and different tasks can't run on the same
   thread during the parsing. However, it's better to use `TaskLocal`
   to leverage the concurrency model of Swift.
3. The global variable `_currentParser` existed in the WASI platform
   path but it's unsafe in the Swift concurrency model. It wouldn't be a
   problem on WASI since it's always single-threaded, we should avoid
   platform-specific assumption as much as possible.


The issue was revealed in https://github.com/apple/swift-corelibs-foundation/pull/5057#discussion_r1709934773