### PR TITLE
Remove the workaround for WASI errno conflict

### DIFF
--- a/Sources/Foundation/NSPathUtilities.swift
+++ b/Sources/Foundation/NSPathUtilities.swift
@@ -12,13 +12,6 @@
 import WinSDK
 #elseif os(WASI)
 import WASILibc
-// CoreFoundation brings <errno.h> but it conflicts with WASILibc.errno
-// definition, so we need to explicitly select the one from WASILibc.
-// This is defined as "internal" since this workaround also used in other files.
-internal var errno: Int32 {
-    get { WASILibc.errno }
-    set { WASILibc.errno = newValue }
-}
 #endif
 
 #if os(Windows)


### PR DESCRIPTION
As we have fixed the conflict in the WASILibc overlay module while porting swift-foundation, we can remove the workaround from corelibs-foundation too.