### PR TITLE
Include userInfo in Error descriptions

### DIFF
--- a/Sources/Foundation/NSError.swift
+++ b/Sources/Foundation/NSError.swift
@@ -182,7 +182,11 @@ open class NSError : NSObject, NSCopying, NSSecureCoding, NSCoding, @unchecked S
     }
     
     override open var description: String {
-        return "Error Domain=\(domain) Code=\(code) \"\(localizedFailureReason ?? "(null)")\""
+        var result = "Error Domain=\(domain) Code=\(code) \"\(localizedFailureReason ?? "(null)")\""
+        if !userInfo.isEmpty {
+            result += "UserInfo={\(userInfo.map { "\($0)=\($1)"}.joined(separator: ", "))}"
+        }
+        return result
     }
     
     // -- NSObject Overrides --


### PR DESCRIPTION
This more closely matches Darwin behavior, and makes it significantly easier to debug issues like "File was not found" which presently include no reference whatsoever to the actual file path.