### PR TITLE
Repair the Windows SwiftPM build

### DIFF
--- a/Sources/CoreFoundation/CFRuntime.c
+++ b/Sources/CoreFoundation/CFRuntime.c
@@ -1380,6 +1380,16 @@ static CFBundleRef RegisterCoreFoundationBundle(void) {
 #define DLL_THREAD_DETACH    3
 #define DLL_PROCESS_DETACH   0
 
+#if CF_WINDOWS_EXECUTABLE_INITIALIZER
+static void __CFWindowsExecutableInitializer(void) __attribute__ ((constructor)) __attribute__ ((used));
+
+void __CFWindowsExecutableInitializer(void) {
+    static CFBundleRef cfBundle = NULL;
+    __CFInitialize();
+    cfBundle = RegisterCoreFoundationBundle();
+}
+#endif
+
 int DllMain( HINSTANCE hInstance, DWORD dwReason, LPVOID pReserved ) {
     static CFBundleRef cfBundle = NULL;
     if (dwReason == DLL_PROCESS_ATTACH) {

--- a/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
+++ b/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
@@ -18,8 +18,8 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "CFURLSessionInterface.h"
 #include "CFInternal.h"
+#include "CFURLSessionInterface.h"
 #include "CFString.h"
 #include <curl/curl.h>
 

--- a/Tests/Foundation/TestBundle.swift
+++ b/Tests/Foundation/TestBundle.swift
@@ -42,8 +42,16 @@ internal func testBundleName() -> String {
     return testBundle().infoDictionary!["CFBundleName"] as! String
 }
 
-internal func xdgTestHelperURL() -> URL {
+internal func xdgTestHelperURL() throws -> URL {
+    #if os(Windows)
+    // Adding the xdgTestHelper as a dependency of TestFoundation causes its object files (including the main function) to be linked into the test runner executable as well
+    // While this works on Linux due to special linker functionality, this doesn't work on Windows and results in a collision between the two main symbols
+    // SwiftPM also cannot support depending on this executable (to ensure it is built) without also linking its objects into the test runner
+    // For those reasons, using the xdgTestHelper on Windows is currently unsupported and tests that rely on it must be skipped
+    throw XCTSkip("xdgTestHelper is not supported during testing on Windows")
+    #else
     testBundle().bundleURL.deletingLastPathComponent().appendingPathComponent("xdgTestHelper")
+    #endif
 }
 
 

--- a/Tests/Foundation/TestBundle.swift
+++ b/Tests/Foundation/TestBundle.swift
@@ -48,7 +48,7 @@ internal func xdgTestHelperURL() throws -> URL {
     // While this works on Linux due to special linker functionality, this doesn't work on Windows and results in a collision between the two main symbols
     // SwiftPM also cannot support depending on this executable (to ensure it is built) without also linking its objects into the test runner
     // For those reasons, using the xdgTestHelper on Windows is currently unsupported and tests that rely on it must be skipped
-    throw XCTSkip("xdgTestHelper is not supported during testing on Windows")
+    throw XCTSkip("xdgTestHelper is not supported during testing on Windows (test executables are not supported by SwiftPM on Windows)")
     #else
     testBundle().bundleURL.deletingLastPathComponent().appendingPathComponent("xdgTestHelper")
     #endif

--- a/Tests/Foundation/TestFileManager.swift
+++ b/Tests/Foundation/TestFileManager.swift
@@ -1251,7 +1251,7 @@ class TestFileManager : XCTestCase {
             environment[entry.key] = entry.value
         }
         
-        let helper = xdgTestHelperURL()
+        let helper = try xdgTestHelperURL()
         let (stdout, _) = try runTask([ helper.path, "--nspathfor", method, identifier ],
                                       environment: environment)
         

--- a/Tests/Foundation/TestHTTPCookieStorage.swift
+++ b/Tests/Foundation/TestHTTPCookieStorage.swift
@@ -334,7 +334,7 @@ class TestHTTPCookieStorage: XCTestCase {
 
         // Test by setting the environmental variable
         let task = Process()
-        task.executableURL = xdgTestHelperURL()
+        task.executableURL = try xdgTestHelperURL()
         task.arguments = ["--xdgcheck"]
         var environment = ProcessInfo.processInfo.environment
         let testPath = NSHomeDirectory() + "/TestXDG"


### PR DESCRIPTION
We currently run unit tests via SwiftPM on linux, but have not yet enabled this on Windows due to the Windows build failing. This is a large step forward towards getting the Windows build working via SwiftPM as it resolves a few main issues:

1. Dependencies like libxml2 and curl (which depends on zlib) are found via `pkgconfig` on Linux, however the same functionality does not exist on Windows operating systems. Additionally, we cannot find these libraries in the toolchain like Dispatch because, unlike libdispatch, curl/libxml2 are not distributed in the toolchain (they only exist as static libraries linked into FoundationNetworking/FoundationXML respectively. Instead, on windows we require that the header include and library search paths are provided via environment variables. While this doesn't make this easy for local development, it does allow us to run these tests in Windows toolchain CI where we have already built copies of libxml2/curl for use in the toolchain, and we can provide paths into the build directory for this projects
2. We also need to ensure that `__CFInitialize` properly runs. In the SwiftPM build, Foundation is statically linked into the test executable. This means that the `DllMain` that the toolchain build relies upon will not be invoked. Instead, we use an `__attribute__((constructor))` to initialize CF when the executable is launched
3. We disable any tests that rely on the `xdgTestHelper` executable. There is no way within SwiftPM to specify a dependency on the `xdgTestHelper` without linking its `main.swift.o` object file into the test executable. This happens to work on Linux due to a linker feature we've implemented on that platform, but causes symbol collisions on Windows due to the lack of this linker feature. Since there is no official support for this feature in SwiftPM packages, we must instead disable these tests.

The tests don't run successfully yet (we crash in the `DateFormatter` tests due to a `CFTimeZone` issue that I'm investigating), but with this I can at least successfully launch the tests which is a great start.