### PR TITLE
[main] Fixing post-swift-foundation corelibs-foundation MUSL static SDK builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,8 +95,28 @@ endif()
 FetchContent_MakeAvailable(SwiftFoundationICU SwiftFoundation)
 
 include(CheckLinkerFlag)
+include(CheckSymbolExists)
 
 check_linker_flag(C "LINKER:--build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
+
+check_symbol_exists("strlcat" "string.h" HAVE_STRLCAT)
+check_symbol_exists("strlcpy" "string.h" HAVE_STRLCPY)
+check_symbol_exists("issetugid" "unistd.h" HAVE_ISSETUGID)
+add_compile_definitions(
+  $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${HAVE_STRLCAT}>>:HAVE_STRLCAT>
+  $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${HAVE_STRLCPY}>>:HAVE_STRLCPY>
+  $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${HAVE_ISSETUGID}>>:HAVE_ISSETUGID>)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR ANDROID)
+  add_compile_definitions($<$<COMPILE_LANGUAGE:C>:_GNU_SOURCE>)
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  check_symbol_exists(sched_getaffinity "sched.h" HAVE_SCHED_GETAFFINITY)
+  add_compile_definitions($<$<COMPILE_LANGUAGE:C>:HAVE_SCHED_GETAFFINITY>)
+endif()
+
+add_compile_options($<$<COMPILE_LANGUAGE:C>:-fblocks>)
 
 # Precompute module triple for installation
 if(NOT SwiftFoundation_MODULE_TRIPLE)
@@ -114,6 +134,7 @@ endif()
 
 # We know libdispatch is always unavailable on WASI
 if(NOT CMAKE_SYSTEM_NAME STREQUAL WASI)
+    find_package(LibRT)
     find_package(dispatch CONFIG)
     if(NOT dispatch_FOUND)
         if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Android")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,12 @@ include(CheckSymbolExists)
 
 check_linker_flag(C "LINKER:--build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
 
+# Detect if the system libc defines symbols for these functions.
+# If it is not availble, swift-corelibs-foundation has its own implementations
+# that will be used. If it is available, it should not redefine them.
+# Note: SwiftPM does not have the ability to introspect the contents of the SDK
+#       and therefore will always include these functions in the build and will
+#       cause build failures on platforms that define these functions.
 check_symbol_exists("strlcat" "string.h" HAVE_STRLCAT)
 check_symbol_exists("strlcpy" "string.h" HAVE_STRLCPY)
 check_symbol_exists("issetugid" "unistd.h" HAVE_ISSETUGID)
@@ -107,16 +113,10 @@ add_compile_definitions(
   $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${HAVE_STRLCPY}>>:HAVE_STRLCPY>
   $<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:${HAVE_ISSETUGID}>>:HAVE_ISSETUGID>)
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux OR ANDROID)
-  add_compile_definitions($<$<COMPILE_LANGUAGE:C>:_GNU_SOURCE>)
-endif()
-
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   check_symbol_exists(sched_getaffinity "sched.h" HAVE_SCHED_GETAFFINITY)
   add_compile_definitions($<$<COMPILE_LANGUAGE:C>:HAVE_SCHED_GETAFFINITY>)
 endif()
-
-add_compile_options($<$<COMPILE_LANGUAGE:C>:-fblocks>)
 
 # Precompute module triple for installation
 if(NOT SwiftFoundation_MODULE_TRIPLE)

--- a/Sources/Foundation/Port.swift
+++ b/Sources/Foundation/Port.swift
@@ -113,6 +113,12 @@ fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM.rawValue)
 fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
 #endif
 
+#if canImport(Musl)
+import Musl
+fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)
+fileprivate let FOUNDATION_IPPROTO_TCP = Int32(IPPROTO_TCP)
+#endif
+
 #if canImport(Glibc) && os(Android) || os(OpenBSD)
 import Glibc
 fileprivate let FOUNDATION_SOCK_STREAM = Int32(SOCK_STREAM)

--- a/cmake/modules/FindLibRT.cmake
+++ b/cmake/modules/FindLibRT.cmake
@@ -4,7 +4,7 @@
 #
 # Find librt library and headers.
 #
-# The mdoule defines the following variables:
+# The module defines the following variables:
 #
 # ::
 #


### PR DESCRIPTION
Putting back definitions and flags that were dropped when doing the Swift-Foundation re-core that are necessary when building for the static SDK. This is primarily checks for symbol availability.

This will not affect SwiftPM builds, which will continue to define `strlcpy` and `strlcat` everywhere, even on systems that define them in the libc, resulting in build failures. The CMake build will work in these environments.

6.0: https://github.com/apple/swift-corelibs-foundation/pull/5060