### PR TITLE
Add stub for Testing module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -323,16 +323,22 @@ let package = Package(
                 .swiftLanguageMode(.v6)
             ]
         ),
-        .target(
             // swift-corelibs-foundation has a copy of XCTest's sources so:
             // (1) we do not depend on the toolchain's XCTest, which depends on toolchain's Foundation, which we cannot pull in at the same time as a Foundation package
             // (2) we do not depend on a swift-corelibs-xctest Swift package, which depends on Foundation, which causes a circular dependency in swiftpm
             // We believe Foundation is the only project that needs to take this rather drastic measure.
+            // We also have a stub for swift-testing for the same purpose, but without an implementation since this package has no swift-testing style tests
+        .target(
             name: "XCTest",
             dependencies: [
                 "Foundation"
             ],
             path: "Sources/XCTest"
+        ),
+        .target(
+            name: "Testing",
+            dependencies: [],
+            path: "Sources/Testing"
         ),
         .testTarget(
             name: "TestFoundation",
@@ -341,6 +347,7 @@ let package = Package(
                 "FoundationXML",
                 "FoundationNetworking",
                 "XCTest",
+                "Testing",
                 .target(name: "xdgTestHelper", condition: .when(platforms: [.linux]))
             ],
             resources: [

--- a/Sources/Testing/Testing.swift
+++ b/Sources/Testing/Testing.swift
@@ -1,0 +1,25 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(WASI)
+import WASILibc
+#elseif canImport(CRT)
+import CRT
+#endif
+
+
+// This function is used to mimic a bare minimum of the swift-testing library. Since this package has no swift-testing tests, we simply exit.
+// The test runner will automatically call this function when running tests, so it must exit gracefully rather than using `fatalError()`.
+public func __swiftPMEntryPoint(passing _: (any Sendable)? = nil) async -> Never {
+		exit(0)
+}

--- a/Sources/Testing/Testing.swift
+++ b/Sources/Testing/Testing.swift
@@ -21,5 +21,5 @@ import CRT
 // This function is used to mimic a bare minimum of the swift-testing library. Since this package has no swift-testing tests, we simply exit.
 // The test runner will automatically call this function when running tests, so it must exit gracefully rather than using `fatalError()`.
 public func __swiftPMEntryPoint(passing _: (any Sendable)? = nil) async -> Never {
-		exit(0)
+    exit(0)
 }


### PR DESCRIPTION
Now that swift-testing is present in the toolchain, SwiftPM builds of the test target in this package will automatically import `Testing`, causing our test target to link the `Testing` library in the toolchain. This is problematic, because the `Testing` module links Foundation (from the toolchain) which results in a variety of issues and crashes when running our tests caused by the presence of two Foundations (classes of the same name are indistinguishable and one implementation is nondeterministically picked leading to failures when bridging). To resolve this, we will use the same solution we found for XCTest - to vendor a small copy of the library within our project that will be picked up instead of the toolchain version. In our case, we only need a small stub because we don't actually use the `Testing` module yet.

In the future, now that SwiftPM supports cycles in package dependencies as long as there is no target-level cycle, we could update the package build to use the package build of swift-testing (which we could have rely on the package build of Foundation thus ensuring only one Foundation is present) but for now this simple solution gets us building and testing again.