### PR TITLE
[6.0] Add stub for Testing module

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -241,16 +241,22 @@ let package = Package(
                 .swiftLanguageVersion(.v6)
             ]
         ),
-        .target(
             // swift-corelibs-foundation has a copy of XCTest's sources so:
             // (1) we do not depend on the toolchain's XCTest, which depends on toolchain's Foundation, which we cannot pull in at the same time as a Foundation package
             // (2) we do not depend on a swift-corelibs-xctest Swift package, which depends on Foundation, which causes a circular dependency in swiftpm
             // We believe Foundation is the only project that needs to take this rather drastic measure.
+            // We also have a stub for swift-testing for the same purpose, but without an implementation since this package has no swift-testing style tests
+        .target(
             name: "XCTest",
             dependencies: [
                 "Foundation"
             ],
             path: "Sources/XCTest"
+        ),
+        .target(
+            name: "Testing",
+            dependencies: [],
+            path: "Sources/Testing"
         ),
         .testTarget(
             name: "TestFoundation",
@@ -259,6 +265,7 @@ let package = Package(
                 "FoundationXML",
                 "FoundationNetworking",
                 .targetItem(name: "XCTest", condition: .when(platforms: [.linux])),
+                "Testing",
                 "xdgTestHelper"
             ],
             resources: [

--- a/Sources/Testing/Testing.swift
+++ b/Sources/Testing/Testing.swift
@@ -1,0 +1,25 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif os(WASI)
+import WASILibc
+#elseif canImport(CRT)
+import CRT
+#endif
+
+
+// This function is used to mimic a bare minimum of the swift-testing library. Since this package has no swift-testing tests, we simply exit.
+// The test runner will automatically call this function when running tests, so it must exit gracefully rather than using `fatalError()`.
+public func __swiftPMEntryPoint(passing _: (any Sendable)? = nil) async -> Never {
+    exit(0)
+}


### PR DESCRIPTION
Explanation: A test-only change that repairs our SwiftPM test build so that we can run tests on the release/6.0 branch (we only expect to be able to run tests locally on linux on this branch, but this allows us to continue doing so)
Scope: Only impacts building for testing via SwiftPM
Original PR: https://github.com/apple/swift-corelibs-foundation/pull/5077
Risk: Minimal - this only impacts testing and will have no impact on the normal build
Testing: Testing done via local testing and testing in swift-ci
Reviewer: @compnerd @itingliu