### PR TITLE
Add one more XCTAssert for isLeapMonth in TestDate.swift

### DIFF
--- a/Tests/Foundation/TestDate.swift
+++ b/Tests/Foundation/TestDate.swift
@@ -134,6 +134,7 @@ class TestDate : XCTestCase {
         XCTAssertEqual(recreatedComponents.weekOfMonth, 2)
         XCTAssertEqual(recreatedComponents.weekOfYear, 45)
         XCTAssertEqual(recreatedComponents.yearForWeekOfYear, 2017)
+        XCTAssertEqual(recreatedComponents.isLeapMonth, false)
         
         // Quarter is now supported by Calendar
         XCTAssertEqual(recreatedComponents.quarter, 4)


### PR DESCRIPTION
`isLeapMonth` is a component in `Date`. Add one more XCTAssert for `isLeapMonth` in `test_recreateDateComponentsFromDate`.