### PR TITLE
_CFXMLInterface: account for possible `nullptr` return

### DIFF
--- a/Sources/_CFXMLInterface/CFXMLInterface.c
+++ b/Sources/_CFXMLInterface/CFXMLInterface.c
@@ -1073,7 +1073,10 @@ CFStringRef _CFXMLNodeCopyPrefix(_CFXMLNodePtr node) {
     xmlChar* result = NULL;
     xmlChar* unused = xmlSplitQName2(_getQName((xmlNodePtr)node), &result);
 
-    CFStringRef resultString = __CFSwiftXMLParserBridgeCF.CFStringCreateWithCString(NULL, (const char*)result, kCFStringEncodingUTF8);
+    CFStringRef resultString = NULL;
+    if (result) {
+      resultString = __CFSwiftXMLParserBridgeCF.CFStringCreateWithCString(NULL, (const char*)result, kCFStringEncodingUTF8);
+    }
     xmlFree(result);
     xmlFree(unused);
 


### PR DESCRIPTION
`xmlSplitQName2` may return `nullptr` for the result, which when passed to `CFStringCreateWithCString` would attempt to perform `strlen(nullptr)` which is ill-defined. When updating libxml2 on Windows, we would perform an invalid memory access due to the `strlen` invocation inside `CFStringCreateWithCString`. Protect against this case, returning `NULL` instead.