### PR TITLE
Revert "[Linux] Enable build-ids. (#4995)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,6 @@ FetchContent_MakeAvailable(SwiftFoundationICU SwiftFoundation)
 include(CheckLinkerFlag)
 include(CheckSymbolExists)
 
-check_linker_flag(C "LINKER:--build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
-
 # Detect if the system libc defines symbols for these functions.
 # If it is not availble, swift-corelibs-foundation has its own implementations
 # that will be used. If it is available, it should not redefine them.

--- a/Sources/Foundation/CMakeLists.txt
+++ b/Sources/Foundation/CMakeLists.txt
@@ -175,9 +175,5 @@ if(dispatch_FOUND)
         swiftDispatch)
 endif()
 
-if(LINKER_SUPPORTS_BUILD_ID)
-  target_link_options(Foundation PRIVATE "LINKER:--build-id=sha1")
-endif()
-
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS Foundation)
 _foundation_install_target(Foundation)

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -77,9 +77,5 @@ set_target_properties(FoundationNetworking PROPERTIES
     INSTALL_RPATH "$ORIGIN"
     INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
-if(LINKER_SUPPORTS_BUILD_ID)
-  target_link_options(FoundationNetworking PRIVATE "LINKER:--build-id=sha1")
-endif()
-
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationNetworking)
 _foundation_install_target(FoundationNetworking)

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -50,9 +50,5 @@ set_target_properties(FoundationXML PROPERTIES
     INSTALL_RPATH "$ORIGIN"
     INSTALL_REMOVE_ENVIRONMENT_RPATH ON)
 
-if(LINKER_SUPPORTS_BUILD_ID)
-  target_link_options(FoundationXML PRIVATE "LINKER:--build-id=sha1")
-endif()
-
 set_property(GLOBAL APPEND PROPERTY Foundation_EXPORTS FoundationXML)
 _foundation_install_target(FoundationXML)


### PR DESCRIPTION
This reverts commit f186ff8801cf2ec5e5e530d08207dd17375e1cbb. This is incorrectly being applied to Windows builds as well.