### PR TITLE
Fix WebSocket buffered read and add support for fragmented messages

### DIFF
--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -375,10 +375,10 @@ extension _EasyHandle {
     }
     
     // Only valid to call within a didReceive(data:size:nmemb:) call
-    func getWebSocketFlags() -> WebSocketFlags {
+    func getWebSocketMeta() -> (Int64, Int64, WebSocketFlags) {
         let metadataPointer = CFURLSessionEasyHandleWebSocketsMetadata(rawHandle)
         let flags = WebSocketFlags(rawValue: metadataPointer.pointee.flags)
-        return flags
+        return (metadataPointer.pointee.offset, metadataPointer.pointee.bytesLeft, flags)
     }
     
     func receiveWebSocketsData() throws -> (Data, WebSocketFlags) {

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -914,6 +914,8 @@ public class TestURLSessionServer: CustomStringConvertible {
                                "Connection: Upgrade"]
         
         let expectFullRequestResponseTests: Bool
+        let bufferedSendingTests: Bool
+        let fragmentedTests: Bool
         let sendClosePacket: Bool
         let completeUpgrade: Bool
         
@@ -921,14 +923,32 @@ public class TestURLSessionServer: CustomStringConvertible {
         switch uri {
         case "/web-socket":
             expectFullRequestResponseTests = true
+            bufferedSendingTests = false
+            fragmentedTests = false
+            completeUpgrade = true
+            sendClosePacket = true
+        case "/web-socket/buffered-sending":
+            expectFullRequestResponseTests = true
+            bufferedSendingTests = true
+            fragmentedTests = false
+            completeUpgrade = true
+            sendClosePacket = true
+        case "/web-socket/fragmented":
+            expectFullRequestResponseTests = true
+            bufferedSendingTests = false
+            fragmentedTests = true
             completeUpgrade = true
             sendClosePacket = true
         case "/web-socket/semi-abrupt-close":
             expectFullRequestResponseTests = false
+            bufferedSendingTests = false
+            fragmentedTests = false
             completeUpgrade = true
             sendClosePacket = false
         case "/web-socket/abrupt-close":
             expectFullRequestResponseTests = false
+            bufferedSendingTests = false
+            fragmentedTests = false
             completeUpgrade = false
             sendClosePacket = false
         default:
@@ -944,6 +964,8 @@ public class TestURLSessionServer: CustomStringConvertible {
             }
             responseHeaders.append("Sec-WebSocket-Protocol: \(expectedProtocol)")
             expectFullRequestResponseTests = false
+            bufferedSendingTests = false
+            fragmentedTests = false
             completeUpgrade = true
             sendClosePacket = true
         }
@@ -978,10 +1000,41 @@ public class TestURLSessionServer: CustomStringConvertible {
                     NSLog("Invalid string frame")
                     throw InternalServerError.badBody
                 }
-                
-                // Send a string message
-                let sendStringFrame = Data([0x81, UInt8(stringPayload.count)]) + stringPayload
-                try httpServer.tcpSocket.writeRawData(sendStringFrame)
+
+                if bufferedSendingTests {
+                    // Send a string message in chunks of 2 bytes
+                    let sendStringFrame = Data([0x81, UInt8(stringPayload.count)]) + stringPayload
+                    let bufferSize = 2 // Let's assume the server has a buffer size of 2 bytes
+                    for i in stride(from: 0, to: sendStringFrame.count, by: bufferSize) {
+                        let end = min(i + bufferSize, sendStringFrame.count)
+                        let chunk = sendStringFrame.subdata(in: i..<end)
+                        try httpServer.tcpSocket.writeRawData(chunk)
+                        Thread.sleep(forTimeInterval: 0.1) // Sleep to simulate buffered sending
+                    }
+                }
+                else if fragmentedTests {
+                    // Send a string message fragmented by 1 byte
+                    for (i, byte) in stringPayload.enumerated() {
+                        var frame = Data()
+                        let isFirst = i == 0
+                        let isLast = i == stringPayload.count - 1
+
+                        let finBit: UInt8 = isLast ? 0x80 : 0x00
+                        let opcode: UInt8 = isFirst ? 0x1 : 0x0 // 0x1 = text, 0x0 = continuation
+                        let header: UInt8 = finBit | opcode
+
+                        frame.append(header)
+                        frame.append(0x01) // payload length 1, unmasked
+                        frame.append(byte)
+
+                        try httpServer.tcpSocket.writeRawData(frame)
+                    }
+                }
+                else {
+                    // Send a string message
+                    let sendStringFrame = Data([0x81, UInt8(stringPayload.count)]) + stringPayload
+                    try httpServer.tcpSocket.writeRawData(sendStringFrame)
+                }
                 
                 // Receive a data message
                 guard let dataFrame = try httpServer.tcpSocket.readData(),
@@ -991,10 +1044,40 @@ public class TestURLSessionServer: CustomStringConvertible {
                     NSLog("Invalid data frame")
                     throw InternalServerError.badBody
                 }
-                
-                // Send a data message
-                let sendDataFrame = Data([0x82, UInt8(dataPayload.count)]) + dataPayload
-                try httpServer.tcpSocket.writeRawData(sendDataFrame)
+
+                if bufferedSendingTests {
+                    let sendDataFrame = Data([0x82, UInt8(dataPayload.count)]) + dataPayload
+                    let bufferSize = 2 // Let's assume the server has a buffer size of 2 bytes
+                    for i in stride(from: 0, to: sendDataFrame.count, by: bufferSize) {
+                        let end = min(i + bufferSize, sendDataFrame.count)
+                        let chunk = sendDataFrame.subdata(in: i..<end)
+                        try httpServer.tcpSocket.writeRawData(chunk)
+                        Thread.sleep(forTimeInterval: 0.1) // Sleep to simulate buffered sending
+                    }
+                }
+                else if fragmentedTests {
+                    // Send a data message fragmented by 1 byte
+                    for (i, byte) in dataPayload.enumerated() {
+                        var frame = Data()
+                        let isFirst = i == 0
+                        let isLast = i == dataPayload.count - 1
+
+                        let finBit: UInt8 = isLast ? 0x80 : 0x00
+                        let opcode: UInt8 = isFirst ? 0x2 : 0x0 // 0x2 = text, 0x0 = continuation
+                        let header: UInt8 = finBit | opcode
+
+                        frame.append(header)
+                        frame.append(0x01) // payload length 1, unmasked
+                        frame.append(byte)
+
+                        try httpServer.tcpSocket.writeRawData(frame)
+                    }
+                }
+                else {
+                    // Send a data message
+                    let sendDataFrame = Data([0x82, UInt8(dataPayload.count)]) + dataPayload
+                    try httpServer.tcpSocket.writeRawData(sendDataFrame)
+                }
                 
                 // Receive a ping
                 guard let pingFrame = try httpServer.tcpSocket.readData(),

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -2101,59 +2101,64 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
             print("libcurl lacks WebSockets support, skipping \(#function)")
             return
         }
-        
-        let urlString = "ws://127.0.0.1:\(TestURLSession.serverPort)/web-socket"
-        let url = try XCTUnwrap(URL(string: urlString))
-        let request = URLRequest(url: url)
-        
-        let delegate = SessionDelegate(with: expectation(description: "\(urlString): Connect"))
-        let task = delegate.runWebSocketTask(with: request, timeoutInterval: 4)
-        
-        // We interleave sending and receiving, as the test HTTPServer implementation is barebones, and can't handle receiving more than one frame at a time.  So, this back-and-forth acts as a gating mechanism
-        try await task.send(.string("Hello"))
-        
-        let stringMessage = try await task.receive()
-        switch stringMessage {
-        case .string(let str):
-            XCTAssert(str == "Hello")
-        default:
-            XCTFail("Unexpected String Message")
-        }
-        
-        try await task.send(.data(Data([0x20, 0x22, 0x10, 0x03])))
-        
-        let dataMessage = try await task.receive()
-        switch dataMessage {
-        case .data(let data):
-            XCTAssert(data == Data([0x20, 0x22, 0x10, 0x03]))
-        default:
-            XCTFail("Unexpected Data Message")
-        }
-        
-        do {
-            try await task.sendPing()
-            // Server hasn't closed the connection yet
-        } catch {
-            // Server closed the connection before we could process the pong
-            let urlError = try XCTUnwrap(error as? URLError)
-            XCTAssertEqual(urlError._nsError.code, NSURLErrorNetworkConnectionLost)
+
+        func testWebSocket(withURL urlString: String) async throws -> Void {
+            let url = try XCTUnwrap(URL(string: urlString))
+            let request = URLRequest(url: url)
+
+            let delegate = SessionDelegate(with: expectation(description: "\(urlString): Connect"))
+            let task = delegate.runWebSocketTask(with: request, timeoutInterval: 4)
+
+            // We interleave sending and receiving, as the test HTTPServer implementation is barebones, and can't handle receiving more than one frame at a time.  So, this back-and-forth acts as a gating mechanism
+            try await task.send(.string("Hello"))
+
+            let stringMessage = try await task.receive()
+            switch stringMessage {
+            case .string(let str):
+                XCTAssert(str == "Hello")
+            default:
+                XCTFail("Unexpected String Message")
+            }
+
+            try await task.send(.data(Data([0x20, 0x22, 0x10, 0x03])))
+
+            let dataMessage = try await task.receive()
+            switch dataMessage {
+            case .data(let data):
+                XCTAssert(data == Data([0x20, 0x22, 0x10, 0x03]))
+            default:
+                XCTFail("Unexpected Data Message")
+            }
+
+            do {
+                try await task.sendPing()
+                // Server hasn't closed the connection yet
+            } catch {
+                // Server closed the connection before we could process the pong
+                let urlError = try XCTUnwrap(error as? URLError)
+                XCTAssertEqual(urlError._nsError.code, NSURLErrorNetworkConnectionLost)
+            }
+
+            await fulfillment(of: [delegate.expectation], timeout: 50)
+
+            do {
+                _ = try await task.receive()
+                XCTFail("Expected to throw when receiving on closed task")
+            } catch {
+                let urlError = try XCTUnwrap(error as? URLError)
+                XCTAssertEqual(urlError._nsError.code, NSURLErrorNetworkConnectionLost)
+            }
+
+            let callbacks = [ "urlSession(_:webSocketTask:didOpenWithProtocol:)",
+                              "urlSession(_:webSocketTask:didCloseWith:reason:)",
+                              "urlSession(_:task:didCompleteWithError:)" ]
+            XCTAssertEqual(delegate.callbacks.count, callbacks.count)
+            XCTAssertEqual(delegate.callbacks, callbacks, "Callbacks for \(#function)")
         }
 
-        await fulfillment(of: [delegate.expectation], timeout: 50)
-        
-        do {
-            _ = try await task.receive()
-            XCTFail("Expected to throw when receiving on closed task")
-        } catch {
-            let urlError = try XCTUnwrap(error as? URLError)
-            XCTAssertEqual(urlError._nsError.code, NSURLErrorNetworkConnectionLost)
-        }
-        
-        let callbacks = [ "urlSession(_:webSocketTask:didOpenWithProtocol:)",
-                          "urlSession(_:webSocketTask:didCloseWith:reason:)",
-                          "urlSession(_:task:didCompleteWithError:)" ]
-        XCTAssertEqual(delegate.callbacks.count, callbacks.count)
-        XCTAssertEqual(delegate.callbacks, callbacks, "Callbacks for \(#function)")
+        try await testWebSocket(withURL: "ws://127.0.0.1:\(TestURLSession.serverPort)/web-socket")
+        try await testWebSocket(withURL: "ws://127.0.0.1:\(TestURLSession.serverPort)/web-socket/buffered-sending")
+        try await testWebSocket(withURL: "ws://127.0.0.1:\(TestURLSession.serverPort)/web-socket/fragmented")
     }
 
     func test_webSocketShared() async throws {


### PR DESCRIPTION
This PR fixes a bug in Foundation.URLSessionWebSocketTask where incoming WebSocket frames were incorrectly assumed to arrive in a single TCP read. Since TCP can arbitrarily split data, this led to dropped or malformed messages.

Fixes:
* Accumulates socket data until the entire WebSocket frame is received
* Adds support for fragmented WebSocket messages (multiple frames using opcode 0x0)

The WebSocket unit tests were extended to cover:
* Buffered sending – simulates server-side buffering by sending a message in small TCP chunks
* Fragmented message – splits a single message across multiple WebSocket frames