### PR TITLE
Fix memory leak in NSAttributedString

### DIFF
--- a/Sources/CoreFoundation/CFRunArray.c
+++ b/Sources/CoreFoundation/CFRunArray.c
@@ -200,6 +200,14 @@ CFRunArrayRef CFRunArrayCreate(CFAllocatorRef allocator) {
     return array;
 }
 
+CFRunArrayRef CFRunArrayRetain(CFRunArrayRef array) {
+    return COPY(array);
+}
+
+void CFRunArrayRelease(CFRunArrayRef array) {
+    FREE(array);
+}
+
 CFIndex CFRunArrayGetCount(CFRunArrayRef array) {
     return array->guts->length;
 }

--- a/Sources/CoreFoundation/include/CFRunArray.h
+++ b/Sources/CoreFoundation/include/CFRunArray.h
@@ -34,6 +34,8 @@ Returns the type identifier of all CFAttributedString instances.
 CF_EXPORT CFTypeID CFRunArrayGetTypeID(void);
 
 CF_EXPORT CFRunArrayRef CFRunArrayCreate(CFAllocatorRef allocator);
+CF_EXPORT CFRunArrayRef CFRunArrayRetain(CFRunArrayRef array);
+CF_EXPORT void CFRunArrayRelease(CFRunArrayRef array);
 
 CF_EXPORT CFIndex CFRunArrayGetCount(CFRunArrayRef array);
 CF_EXPORT CFTypeRef CFRunArrayGetValueAtIndex(CFRunArrayRef array, CFIndex loc, CFRange *effectiveRange, CFIndex *runArrayIndexPtr);

--- a/Sources/Foundation/NSAttributedString.swift
+++ b/Sources/Foundation/NSAttributedString.swift
@@ -63,7 +63,7 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         
         // use the resulting _string and _attributeArray to initialize a new instance, just like init
         _string = mutableAttributedString._string
-        _attributeArray = mutableAttributedString._attributeArray
+        _attributeArray = CFRunArrayRetain(mutableAttributedString._attributeArray)
     }
     
     open func encode(with aCoder: NSCoder) {
@@ -223,7 +223,12 @@ open class NSAttributedString: NSObject, NSCopying, NSMutableCopying, NSSecureCo
         
         // use the resulting _string and _attributeArray to initialize a new instance
         _string = mutableAttributedString._string
-        _attributeArray = mutableAttributedString._attributeArray
+        _attributeArray = CFRunArrayRetain(mutableAttributedString._attributeArray)
+    }
+
+    deinit {
+        // Release the CFRunArray created in init methods
+        CFRunArrayRelease(_attributeArray)
     }
 
     /// Executes the block for each attribute in the range.


### PR DESCRIPTION
Currently, all attributes are leaking in `NSAttributedString`
This PR adds proper retain/release handling for `CFRunArray` in the appropriate places.

A test was added to validate that attribute values in `NSAttributedString` are no longer leaking.