### PR TITLE
bugfix: added include for alloca

### DIFF
--- a/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
@@ -45,10 +45,6 @@
 #include <unistd.h>
 #endif
 
-#if __has_include(<alloca.h>)
-#include <alloca.h>
-#endif
-
 #if _POSIX_THREADS
 #include <pthread.h>
 #endif
@@ -65,6 +61,8 @@
 #endif
 
 #if TARGET_OS_LINUX
+#include <alloca.h>
+#include <unistd.h>
 #include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <sys/stat.h>


### PR DESCRIPTION
I got an error while using CoreFoundation on Linux, clang complains that alloca cannot be found. It is not included, I added it. (Not a compiler built-in: https://godbolt.org/z/M98fhzeqE)

My error is:
```
backend> clang: warning: argument unused during compilation: '-L./home/GNUstep/Library/Libraries' [-Wunused-command-line-argument]
backend> clang: warning: argument unused during compilation: '-L/nix/store/xhq6ib29fzq58f91s7c6gx2ifzpm85s7-gnustep-make-2.9.3/local/lib' [-Wunused-command-line-argument]
backend> clang: warning: argument unused during compilation: '-L/nix/store/xhq6ib29fzq58f91s7c6gx2ifzpm85s7-gnustep-make-2.9.3/lib' [-Wunused-command-line-argument]
backend> In file included from /build/gjsyk3r46lndikc2zfq0wbzg265j5b3s-source/Sources/Test/test.m:3:
backend> In file included from /nix/store/j1m50jvhh8jy0fir8c5lg98vic6aj797-gnustep-base-1.29.0-dev/include/Foundation/Foundation.h:197:
backend> In file included from /nix/store/b8n4zm1ry8amvdn475arml8byqziczsy-swift-corelibs-foundation-5.8-dev/include/CoreFoundation/CoreFoundation.h:103:
backend> /nix/store/b8n4zm1ry8amvdn475arml8byqziczsy-swift-corelibs-foundation-5.8-dev/include/CoreFoundation/ForSwiftFoundationOnly.h:531:38: error: use of undeclared identifier 'alloca'
backend>   531 |     buffer.memory = buffer.onStack ? alloca(buffer.capacity) : malloc(buffer.capacity);
backend>       |                                      ^
backend> /nix/store/b8n4zm1ry8amvdn475arml8byqziczsy-swift-corelibs-foundation-5.8-dev/include/CoreFoundation/ForSwiftFoundationOnly.h:642:12: error: use of undeclared identifier 'lstat'
backend>   642 |     return lstat(filename, buffer) == 0 ? 0 : errno;
backend>       |            ^
backend> 2 errors generated.
backend> ninja: build stopped: subcommand failed.
```

lstat is included in unistd.h, which was already added to the swift header, but that is already the case in the upstream version.