### PR TITLE
Add Android certificate paths to CURL_CA_PATH

### DIFF
--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -232,7 +232,7 @@ extension _EasyHandle {
                 var isDirectory: ObjCBool = false
                 if FileManager.default.fileExists(atPath: path,
                                                   isDirectory: &isDirectory)
-                    && isDirectory.boolValue {
+                        && isDirectory.boolValue {
                     path.withCString { pathPtr in
                         try! CFURLSession_easy_setopt_ptr(rawHandle, CFURLSessionOptionCAPATH, UnsafeMutablePointer(mutating: pathPtr)).asError()
                     }


### PR DESCRIPTION
On Android devices, there is not single aggregate `.cer` file we can set with `CFURLSessionInfoCAINFO`, but rather a system managed folder that needs to be specified with `CFURLSessionOptionCAPATH`. This is similar to how swift-nio handles it (https://github.com/apple/swift-nio-ssl/pull/453).

This is a better solution than https://github.com/swiftlang/swift-corelibs-foundation/pull/5163, so I'll close that in favor of this.

It only affects Android codepaths, so this change should be low-risk.