### PR TITLE
fixed #5285 fatalError when connection was lost immediately after sending r…

### DIFF
--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -239,7 +239,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         guard let response = ts.response else {
             internalState = .transferFailed
             let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost,
-                                userInfo: [NSLocalizedDescriptionKey: "The network connection was lost."])
+                                userInfo: [NSLocalizedDescriptionKey: "Transfer completed, but there's no response."])
             failWith(error: error, request: request)
             return
         }


### PR DESCRIPTION
fixes https://github.com/swiftlang/swift-corelibs-foundation/issues/5285
I tried to write a test case, but it's a hard to reproduce error as it will not happen when just closing the connection from the server side. But as it happens in the wild and crashes it should behave correctly with this fix.