### PR TITLE
Ensure strsep operates on a copy of PATH.

### DIFF
--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -266,10 +266,12 @@ const char *_CFProcessPath(void) {
     }
 
     // Search PATH.
-    if (argv0) {
-        char *paths = getenv("PATH");
+    char *path = getenv("PATH");
+    if (argv0 && path) {
+        char *paths = strdup(path);
+        char *remaining = paths;
         char *p = NULL;
-        while ((p = strsep(&paths, ":")) != NULL) {
+        while ((p = strsep(&remaining, ":")) != NULL) {
             char pp[PATH_MAX];
             int l = snprintf(pp, PATH_MAX, "%s/%s", p, argv0);
             if (l >= PATH_MAX) {
@@ -283,11 +285,13 @@ const char *_CFProcessPath(void) {
                 _CFSetProgramNameFromPath(res);
                 free(argv0);
                 free(res);
+                free(paths);
                 return __CFProcessPath;
             }
             free(res);
         }
         free(argv0);
+        free(paths);
     }
 
     // See if the shell will help.


### PR DESCRIPTION
strsep modifies its first argument, which means that if we don't make a copy, any PATH processing that may occur after _CFProcessPath executes breaks because strsep will effectively change PATH to be only the first list item. For example, swiftpm's tool finding fails because it searches PATH, and if the tool in question doesn't reside in the first PATH item, things break.

This only occurs on BSD and only when the program name, i.e., argv[0], is not an absolute path.

(As a heads up: this should be picked onto release branches.)