### PR TITLE
Fix various typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ include(CheckSymbolExists)
 check_linker_flag(C "LINKER:--build-id=sha1" LINKER_SUPPORTS_BUILD_ID)
 
 # Detect if the system libc defines symbols for these functions.
-# If it is not availble, swift-corelibs-foundation has its own implementations
+# If it is not available, swift-corelibs-foundation has its own implementations
 # that will be used. If it is available, it should not redefine them.
 # Note: SwiftPM does not have the ability to introspect the contents of the SDK
 #       and therefore will always include these functions in the build and will

--- a/Sources/CoreFoundation/BlockRuntime/runtime.c
+++ b/Sources/CoreFoundation/BlockRuntime/runtime.c
@@ -374,7 +374,7 @@ static void *_Block_copy_internal(const void *arg, const bool wantsOne) {
         return aBlock;
     }
 
-    // Its a stack block.  Make a copy.
+    // It's a stack block.  Make a copy.
     if (!isGC) {
         struct Block_layout *result = malloc(aBlock->descriptor->size);
         if (!result) return NULL;
@@ -433,7 +433,7 @@ static void _Block_byref_assign_copy(void *dest, const void *arg, const int flag
     else if ((src->forwarding->flags & BLOCK_REFCOUNT_MASK) == 0) {
         // src points to stack
         bool isWeak = ((flags & (BLOCK_FIELD_IS_BYREF|BLOCK_FIELD_IS_WEAK)) == (BLOCK_FIELD_IS_BYREF|BLOCK_FIELD_IS_WEAK));
-        // if its weak ask for an object (only matters under GC)
+        // if it's weak ask for an object (only matters under GC)
         struct Block_byref *copy = (struct Block_byref *)_Block_allocator(src->size, false, isWeak);
         copy->flags = src->flags | _Byref_flag_initial_value; // non-GC one for caller, one for stack
         copy->forwarding = copy; // patch heap copy to point to itself (skip write-barrier)

--- a/Sources/CoreFoundation/CFBase.c
+++ b/Sources/CoreFoundation/CFBase.c
@@ -470,7 +470,7 @@ CFAllocatorRef CFAllocatorGetDefault(void) {
 
 void CFAllocatorSetDefault(CFAllocatorRef allocator) {
 #ifndef __clang_analyzer__
-    // clang doesn't like complexity of staticly laid out instances like the black magic we do here and  __CFGetDefaultAllocator
+    // clang doesn't like complexity of statically laid out instances like the black magic we do here and __CFGetDefaultAllocator
     CFAllocatorRef current = __CFGetDefaultAllocator();
 #if defined(DEBUG) 
     if (NULL != allocator) {

--- a/Sources/CoreFoundation/CFBundle_Binary.c
+++ b/Sources/CoreFoundation/CFBundle_Binary.c
@@ -123,7 +123,7 @@ static char *_cleanedPathForPath(const char *curName) {
 }
 
 CF_PRIVATE CFArrayRef _CFBundleDYLDCopyLoadedImagePathsIfChanged(void) {
-    // This returns an array of the paths of all the dyld images in the process.  These paths may not be absolute, they may point at things that are not bundles, they may be staticly linked bundles or dynamically loaded bundles, they may be NULL.
+    // This returns an array of the paths of all the dyld images in the process.  These paths may not be absolute, they may point at things that are not bundles, they may be statically linked bundles or dynamically loaded bundles, they may be NULL.
     uint32_t i, numImages = _dyld_image_count();
     CFMutableArrayRef result = NULL;
     static uint32_t _cachedDYLDImageCount = -1;
@@ -442,7 +442,7 @@ static void *_CFBundleDYLDGetSymbolByNameWithSearch(CFBundleRef bundle, CFString
                 if (!CFStringGetCString(executableName, hintBuff, 1024, kCFStringEncodingUTF8)) hintBuff[0] = '\0';
                 CFRelease(executableName);
             }
-            // Nowdays, NSIsSymbolNameDefinedWithHint() and NSLookupAndBindSymbolWithHint()
+            // Nowadays, NSIsSymbolNameDefinedWithHint() and NSLookupAndBindSymbolWithHint()
             // are identical, except the first just returns a bool, so checking with the
             // Is function first just causes a redundant lookup.
             // This returns NULL on failure.

--- a/Sources/CoreFoundation/CFCalendar.c
+++ b/Sources/CoreFoundation/CFCalendar.c
@@ -156,7 +156,7 @@ static void __CFCalendarSetToFirstInstant(CFCalendarRef calendar, CFCalendarUnit
             __cficu_ucal_set(calendar->_cal, UCAL_YEAR, __cficu_ucal_getLimit(calendar->_cal, UCAL_YEAR, UCAL_ACTUAL_MINIMUM, &status));
         case kCFCalendarUnitYear:
             __cficu_ucal_set(calendar->_cal, UCAL_MONTH, __cficu_ucal_getLimit(calendar->_cal, UCAL_MONTH, UCAL_ACTUAL_MINIMUM, &status));
-            // #warning if there is a lunar leap month of the same number *preceeding* month N,
+            // #warning if there is a lunar leap month of the same number *preceding* month N,
             // then we should set the calendar to the leap month, not the regular month.
             __cficu_ucal_set(calendar->_cal, UCAL_IS_LEAP_MONTH, 0);
         case kCFCalendarUnitMonth:

--- a/Sources/CoreFoundation/CFCharacterSet.c
+++ b/Sources/CoreFoundation/CFCharacterSet.c
@@ -1360,13 +1360,13 @@ const CFRuntimeClass __CFCharacterSetClass = {
     __CFCharacterSetCopyDescription
 };
 
-static bool __CFCheckForExapendedSet = false;
+static bool __CFDebugExpandedSet = false;
 
 CF_PRIVATE void __CFCharacterSetInitialize(void) {
     static dispatch_once_t initOnce;
     dispatch_once(&initOnce, ^{
         const char *checkForExpandedSet = getenv("__CF_DEBUG_EXPANDED_SET");
-        if (checkForExpandedSet && (*checkForExpandedSet == 'Y')) __CFCheckForExapendedSet = true;
+        if (checkForExpandedSet && (*checkForExpandedSet == 'Y')) __CFDebugExpandedSet = true;
     });
 }
 
@@ -1378,7 +1378,7 @@ CFTypeID CFCharacterSetGetTypeID(void) {
 }
 
 /*** CharacterSet creation ***/
-/* Functions to create basic immutable characterset.
+/* Functions to create basic immutable character set.
 */
 CFCharacterSetRef CFCharacterSetGetPredefined(CFCharacterSetPredefinedSet theSetIdentifier) {
     CFCharacterSetRef cset;
@@ -2362,7 +2362,7 @@ void CFCharacterSetAddCharactersInRange(CFMutableCharacterSetRef theSet, CFRange
     }
     __CFCSetPutHasHashValue(theSet, false);
 
-    if (__CFCheckForExapendedSet) __CFCheckForExpandedSet(theSet);
+    if (__CFDebugExpandedSet) __CFCheckForExpandedSet(theSet);
 }
 
 void CFCharacterSetRemoveCharactersInRange(CFMutableCharacterSetRef theSet, CFRange theRange) {
@@ -2436,7 +2436,7 @@ void CFCharacterSetRemoveCharactersInRange(CFMutableCharacterSetRef theSet, CFRa
     }
 
     __CFCSetPutHasHashValue(theSet, false);
-    if (__CFCheckForExapendedSet) __CFCheckForExpandedSet(theSet);
+    if (__CFDebugExpandedSet) __CFCheckForExpandedSet(theSet);
 }
 
 void CFCharacterSetAddCharactersInString(CFMutableCharacterSetRef theSet,  CFStringRef theString) {
@@ -2527,7 +2527,7 @@ void CFCharacterSetAddCharactersInString(CFMutableCharacterSetRef theSet,  CFStr
 
     __CFCSetPutHasHashValue(theSet, false);
 
-    if (__CFCheckForExapendedSet) __CFCheckForExpandedSet(theSet);
+    if (__CFDebugExpandedSet) __CFCheckForExpandedSet(theSet);
 
     if (hasSurrogate) __CFApplySurrogatesInString(theSet, theString, &CFCharacterSetAddCharactersInRange);
 }
@@ -2614,7 +2614,7 @@ void CFCharacterSetRemoveCharactersInString(CFMutableCharacterSetRef theSet, CFS
     }
     
     __CFCSetPutHasHashValue(theSet, false);
-    if (__CFCheckForExapendedSet) __CFCheckForExpandedSet(theSet);
+    if (__CFDebugExpandedSet) __CFCheckForExpandedSet(theSet);
 
     if (hasSurrogate) __CFApplySurrogatesInString(theSet, theString, &CFCharacterSetRemoveCharactersInRange);
 }
@@ -2740,7 +2740,7 @@ void CFCharacterSetUnion(CFMutableCharacterSetRef theSet, CFCharacterSetRef theO
                 }
             }
         }
-        if (__CFCheckForExapendedSet) __CFCheckForExpandedSet(theSet);
+        if (__CFDebugExpandedSet) __CFCheckForExpandedSet(theSet);
     } else { // It's NSCharacterSet
         CFDataRef bitmapRep = CFCharacterSetCreateBitmapRepresentation(kCFAllocatorSystemDefault, theOtherSet);
         const UInt32 *bitmap2 = (bitmapRep && CFDataGetLength(bitmapRep) ? (const UInt32 *)CFDataGetBytePtr(bitmapRep) : NULL);
@@ -2984,7 +2984,7 @@ void CFCharacterSetIntersect(CFMutableCharacterSetRef theSet, CFCharacterSetRef 
                 __CFCSetDeallocateAnnexPlane(theSet);
             }
         }
-        if (__CFCheckForExapendedSet) __CFCheckForExpandedSet(theSet);
+        if (__CFDebugExpandedSet) __CFCheckForExpandedSet(theSet);
     } else { // It's NSCharacterSet
         CFDataRef bitmapRep = CFCharacterSetCreateBitmapRepresentation(kCFAllocatorSystemDefault, theOtherSet);
         const UInt32 *bitmap2 = (bitmapRep && CFDataGetLength(bitmapRep) ? (const UInt32 *)CFDataGetBytePtr(bitmapRep) : NULL);

--- a/Sources/CoreFoundation/CFDateFormatter.c
+++ b/Sources/CoreFoundation/CFDateFormatter.c
@@ -955,7 +955,7 @@ static CFMutableStringRef __createISO8601FormatString(CFISO8601DateFormatOptions
                     } else {
                         CFStringAppendCString(resultStr, "HH:mm:ss", kCFStringEncodingUTF8);
                     }
-                    // Add support for fracional seconds
+                    // Add support for fractional seconds
                     if (includeFractionalSecs) {
                         CFStringAppendCString(resultStr, ".SSS", kCFStringEncodingUTF8);
                     }

--- a/Sources/CoreFoundation/CFICUConverters.c
+++ b/Sources/CoreFoundation/CFICUConverters.c
@@ -263,7 +263,7 @@ CF_PRIVATE CFIndex __CFStringEncodingICUToBytes(const char *icuName, uint32_t fl
         ucnv_fromUnicode(converter, &destination, destinationLimit, (const UChar **)&source, (const UChar *)sourceLimit, NULL, flush, &errorCode);
 
 #if HAS_ICU_BUG_6024743
-/* Another critical ICU design issue. Similar to conversion error, source pointer returned from U_BUFFER_OVERFLOW_ERROR is already beyond the last valid character position. It renders the returned value from source entirely unusable. We have to manually back up until succeeding <rdar://problem/7183045> Interestingly, this issue doesn't apply to ucnv_toUnicode. The asynmmetric nature makes this more dangerous */
+/* Another critical ICU design issue. Similar to conversion error, source pointer returned from U_BUFFER_OVERFLOW_ERROR is already beyond the last valid character position. It renders the returned value from source entirely unusable. We have to manually back up until succeeding <rdar://problem/7183045> Interestingly, this issue doesn't apply to ucnv_toUnicode. The asymmetric nature makes this more dangerous */
         if (U_BUFFER_OVERFLOW_ERROR == errorCode) {
             const uint8_t *bitmap = CFUniCharGetBitmapPtrForPlane(kCFUniCharNonBaseCharacterSet, 0);
             const uint8_t *nonBase;

--- a/Sources/CoreFoundation/CFLocaleIdentifier.c
+++ b/Sources/CoreFoundation/CFLocaleIdentifier.c
@@ -2195,9 +2195,9 @@ CFStringRef CFLocaleCreateLocaleIdentifierFromComponents(CFAllocatorRef allocato
                 CFCalendarRef cal = (CFCalendarRef)values[idx];
                 CFStringRef ident = CFCalendarGetIdentifier(cal);
                 value = __CStringFromString(ident);
-                char *oldkey = key;
+                char *oldKey = key;
                 key = strdup("calendar");
-                free(oldkey);
+                free(oldKey);
             } else {
                 value = __CStringFromString(values[idx]);
             }

--- a/Sources/CoreFoundation/CFOldStylePList.c
+++ b/Sources/CoreFoundation/CFOldStylePList.c
@@ -86,7 +86,7 @@ static Boolean advanceToNonSpace(_CFStringsFileParseInfo *pInfo) {
         if (ch2 == ' ' || ch2 == 0x2028 || ch2 == 0x2029) continue;	// space and Unicode line sep, para sep
         if (ch2 == '/') {
             if (pInfo->curr >= pInfo->end) {
-                // TODO: this could possibly be made more robust (imagine if pInfo->curr is stomped; pInfo->end - 1 might be safer.  Unless its smashed too :-/
+                // TODO: this could possibly be made more robust (imagine if pInfo->curr is stomped; pInfo->end - 1 might be safer.  Unless it's smashed too :-/
                 // whoops; back up and return
                 pInfo->curr --;
                 return true;

--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -925,7 +925,7 @@ static void __CFTSDFinalize(void *arg) {
     __CFMainThreadHasExited = true;
 #else
     if (_CFIsMainThread()) {
-        // Important: we need to be sure that the only time we set this flag to true is when we actually can guarentee we ARE the main thread. 
+        // Important: we need to be sure that the only time we set this flag to true is when we actually can guarantee we ARE the main thread.
         __CFMainThreadHasExited = true;
     }
 #endif
@@ -960,7 +960,7 @@ static void __CFTSDFinalize(void *arg) {
         free(table);
 
         // FreeBSD libthr emits debug message to stderr if there are leftover nonnull TSD after PTHREAD_DESTRUCTOR_ITERATIONS
-        // On this platform, the destructor will never be called again, therefore it is unneccessary to set the TSD to CF_TSD_BAD_PTR
+        // On this platform, the destructor will never be called again, therefore it is unnecessary to set the TSD to CF_TSD_BAD_PTR
         #if defined(__FreeBSD__)
         __CFTSDSetSpecific(NULL);
         #else

--- a/Sources/CoreFoundation/CFPropertyList.c
+++ b/Sources/CoreFoundation/CFPropertyList.c
@@ -481,7 +481,7 @@ static void _appendEscapedString(CFStringRef origStr, CFMutableDataRef mStr) {
 /* Base-64 encoding/decoding */
 
 /* The base-64 encoding packs three 8-bit bytes into four 7-bit ASCII
- * characters.  If the number of bytes in the original data isn't divisable
+ * characters.  If the number of bytes in the original data isn't divisible
  * by three, "=" characters are used to pad the encoded data.  The complete
  * set of characters used in base-64 are:
  *

--- a/Sources/CoreFoundation/CFStorage.c
+++ b/Sources/CoreFoundation/CFStorage.c
@@ -449,7 +449,7 @@ static void __CFStorageDeallocateNode(CFStorageRef storage, CFStorageNode *node)
  
  The only acceptable time to directly call the Unfrozen variant is for the root node of a CFStorage, because root nodes may never be frozen.  The isRootNode parameter determines whether we are in this case.
  
- The Insertion functions return two nodes.  As an awful performance hack, if the first node returned from __CFStorageInsert* is the same as the node passed in, that node is *not* retained, so should not be relased.  If it is a different node, it is retained.
+ The Insertion functions return two nodes.  As an awful performance hack, if the first node returned from __CFStorageInsert* is the same as the node passed in, that node is *not* retained, so should not be released.  If it is a different node, it is retained.
  */
 static CFStorageDoubleNodeReturn __CFStorageInsert(CFAllocatorRef allocator, CFStorageRef storage, CFStorageNode * _Nonnull node, CFIndex byteNum, CFIndex size, CFIndex absoluteByteNum);
 static CFStorageNode *__CFStorageDelete(CFAllocatorRef allocator, CFStorageRef storage, CFStorageNode * _Nonnull node, CFRange range, bool compact);
@@ -1253,7 +1253,7 @@ void CFStorageDeleteValues(CFStorageRef storage, CFRange range) {
     CFRange byteRange = __CFStorageConvertValuesToByteRange(storage, range.location, range.length);
     const CFIndex expectedByteCount = storage->rootNode.numBytes - byteRange.length;
     
-    /* We don't try to mantain the cache across deletion */
+    /* We don't try to maintain the cache across deletion */
     __CFStorageSetCache(storage, NULL, 0);
     
     /* The root node can never be frozen, so it's always OK to modify it */

--- a/Sources/CoreFoundation/CFString.c
+++ b/Sources/CoreFoundation/CFString.c
@@ -1375,7 +1375,7 @@ CF_PRIVATE CFStringRef __CFStringCreateImmutableFunnel3(
             numBytes = vBuf.isASCII ? vBuf.numChars : (vBuf.numChars * sizeof(UniChar));
             hasLengthByte = hasNullByte = false;
 
-            // Get rid of the original buffer if its not being used
+            // Get rid of the original buffer if it's not being used
             if (noCopy && (contentsDeallocator != kCFAllocatorNull)) {
                 CFAllocatorDeallocate(contentsDeallocator, (void *)bytes);
             }
@@ -2363,7 +2363,7 @@ extern void __CFLocaleSetDoesNotRequireSpecialCaseHandling(struct __CFLocale *lo
 // - "tr": Turkish
 // - "nl": Dutch
 // - "el": Greek
-// For all other locales such as en_US, this function returs NULL.
+// For all other locales such as en_US, this function returns NULL.
 // See `CFUniCharMapCaseTo`
 // See https://www.unicode.org/Public/UNIDATA/SpecialCasing.txt
 static const char *_CFStrGetSpecialCaseHandlingLanguageIdentifierForLocale(CFLocaleRef locale, bool collatorOnly) {
@@ -2451,7 +2451,7 @@ static CFIndex __CFStringFoldCharacterClusterAtIndex(UTF32Char character, CFStri
     if (0 != character) {
         UTF16Char lowSurrogate;
         CFIndex planeNo = (character >> 16);
-        bool isTurkikCapitalI = false;
+        bool isTurkicCapitalI = false;
         static const uint8_t *decompBMP = NULL;
         static const uint8_t *graphemeBMP = NULL;
 
@@ -2514,21 +2514,21 @@ static CFIndex __CFStringFoldCharacterClusterAtIndex(UTF32Char character, CFStri
                     caseFoldBMP = CFUniCharGetBitmapPtrForPlane(kCFUniCharHasNonSelfCaseFoldingCharacterSet, 0);
                 }
 
-                if ((NULL != langCode) && ('I' == character) && ((0 == strcmp((const char *)langCode, "tr")) || (0 == strcmp((const char *)langCode, "az")))) { // do Turkik special-casing
+                if ((NULL != langCode) && ('I' == character) && ((0 == strcmp((const char *)langCode, "tr")) || (0 == strcmp((const char *)langCode, "az")))) { // do Turkic special-casing
                     if (filledLength > 1) {
                         if (0x0307 == outCharacters[1]) {
                             if (--filledLength > 1) memmove((outCharacters + 1), (outCharacters + 2), sizeof(UTF32Char) * (filledLength - 1));
                             character = *outCharacters = 'i';
-                            isTurkikCapitalI = true;
+                            isTurkicCapitalI = true;
                         }
                     } else if (0x0307 == CFStringGetCharacterFromInlineBuffer(buffer, currentIndex)) {
                         character = *outCharacters = 'i';
                         filledLength = 1;
                         ++currentIndex;
-                        isTurkikCapitalI = true;
+                        isTurkicCapitalI = true;
                     }
                 }
-                if (!isTurkikCapitalI && (CFUniCharIsMemberOfBitmap(character, ((0 == planeNo) ? lowerBMP : CFUniCharGetBitmapPtrForPlane(kCFUniCharHasNonSelfLowercaseCharacterSet, planeNo))) || CFUniCharIsMemberOfBitmap(character, ((0 == planeNo) ? caseFoldBMP : CFUniCharGetBitmapPtrForPlane(kCFUniCharHasNonSelfCaseFoldingCharacterSet, planeNo))))) {
+                if (!isTurkicCapitalI && (CFUniCharIsMemberOfBitmap(character, ((0 == planeNo) ? lowerBMP : CFUniCharGetBitmapPtrForPlane(kCFUniCharHasNonSelfLowercaseCharacterSet, planeNo))) || CFUniCharIsMemberOfBitmap(character, ((0 == planeNo) ? caseFoldBMP : CFUniCharGetBitmapPtrForPlane(kCFUniCharHasNonSelfCaseFoldingCharacterSet, planeNo))))) {
                     UTF16Char caseFoldBuffer[MAX_CASE_MAPPING_BUF];
                     const UTF16Char *bufferP = caseFoldBuffer, *bufferLimit;
                     UTF32Char *outCharactersP = outCharacters;
@@ -2623,8 +2623,8 @@ static CFIndex __CFStringFoldCharacterClusterAtIndex(UTF32Char character, CFStri
                     nonBaseBitmap = graphemeBMP;
                     decompBitmap = decompBMP;
                 }
-                if (isTurkikCapitalI) {
-                    isTurkikCapitalI = false;
+                if (isTurkicCapitalI) {
+                    isTurkicCapitalI = false;
                 } else if (CFUniCharIsMemberOfBitmap(character, nonBaseBitmap)) {
                     if (doFill) {
                         if (CFUniCharIsMemberOfBitmap(character, decompBitmap)) {
@@ -4776,7 +4776,7 @@ CFStringRef CFStringCreateByCombiningStrings(CFAllocatorRef alloc, CFArrayRef ar
     CFIndex separatorNumByte;
     CFIndex stringCount = CFArrayGetCount(array);
     Boolean isSepCFString = !CF_IS_OBJC(_kCFRuntimeIDCFString, separatorString) && !CF_IS_SWIFT(_kCFRuntimeIDCFString, separatorString);
-    Boolean canBeEightbit = isSepCFString && __CFStrIsEightBit(separatorString);
+    Boolean canBeEightBit = isSepCFString && __CFStrIsEightBit(separatorString);
     CFIndex idx;
     CFStringRef otherString;
     void *buffer;
@@ -4795,11 +4795,11 @@ CFStringRef CFStringCreateByCombiningStrings(CFAllocatorRef alloc, CFArrayRef ar
     for (idx = 0; idx < stringCount; idx++) {
         otherString = (CFStringRef)CFArrayGetValueAtIndex(array, idx);
         numChars += CFStringGetLength(otherString);
-	// canBeEightbit is already false if the separator is an NSString...
-        if (CF_IS_OBJC(_kCFRuntimeIDCFString, otherString) || CF_IS_SWIFT(_kCFRuntimeIDCFString, otherString) || ! __CFStrIsEightBit(otherString)) canBeEightbit = false;
+	// canBeEightBit is already false if the separator is an NSString...
+        if (CF_IS_OBJC(_kCFRuntimeIDCFString, otherString) || CF_IS_SWIFT(_kCFRuntimeIDCFString, otherString) || ! __CFStrIsEightBit(otherString)) canBeEightBit = false;
     }
 
-    buffer = (uint8_t *)CFAllocatorAllocate(alloc, canBeEightbit ? ((numChars + 1) * sizeof(uint8_t)) : (numChars * sizeof(UniChar)), 0);
+    buffer = (uint8_t *)CFAllocatorAllocate(alloc, canBeEightBit ? ((numChars + 1) * sizeof(uint8_t)) : (numChars * sizeof(UniChar)), 0);
 	bufPtr = (uint8_t *)buffer;
 
     // check that bufPtr actually got allocated
@@ -4808,7 +4808,7 @@ CFStringRef CFStringCreateByCombiningStrings(CFAllocatorRef alloc, CFArrayRef ar
     }
     
     if (__CFOASafe) __CFSetLastAllocationEventName(buffer, "CFString (store)");
-    separatorNumByte = CFStringGetLength(separatorString) * (canBeEightbit ? sizeof(uint8_t) : sizeof(UniChar));
+    separatorNumByte = CFStringGetLength(separatorString) * (canBeEightBit ? sizeof(uint8_t) : sizeof(UniChar));
 
     for (idx = 0; idx < stringCount; idx++) {
         if (idx) { // add separator here unless first string
@@ -4817,7 +4817,7 @@ CFStringRef CFStringCreateByCombiningStrings(CFAllocatorRef alloc, CFArrayRef ar
             } else {
                 if (!isSepCFString) { // NSString
                     CFStringGetCharacters(separatorString, CFRangeMake(0, CFStringGetLength(separatorString)), (UniChar *)bufPtr);
-                } else if (canBeEightbit || __CFStrIsUnicode(separatorString)) {
+                } else if (canBeEightBit || __CFStrIsUnicode(separatorString)) {
                     memmove(bufPtr, (const uint8_t *)__CFStrContents(separatorString) + __CFStrSkipAnyLengthByte(separatorString), separatorNumByte);
                 } else {	
                     __CFStrConvertBytesToUnicode((uint8_t *)__CFStrContents(separatorString) + __CFStrSkipAnyLengthByte(separatorString), (UniChar *)bufPtr, __CFStrLength(separatorString));
@@ -4834,9 +4834,9 @@ CFStringRef CFStringCreateByCombiningStrings(CFAllocatorRef alloc, CFArrayRef ar
             bufPtr += otherLength * sizeof(UniChar);
         } else {
             const uint8_t * otherContents = (const uint8_t *)__CFStrContents(otherString);
-            CFIndex otherNumByte = __CFStrLength2(otherString, otherContents) * (canBeEightbit ? sizeof(uint8_t) : sizeof(UniChar));
+            CFIndex otherNumByte = __CFStrLength2(otherString, otherContents) * (canBeEightBit ? sizeof(uint8_t) : sizeof(UniChar));
 
-            if (canBeEightbit || __CFStrIsUnicode(otherString)) {
+            if (canBeEightBit || __CFStrIsUnicode(otherString)) {
                 memmove(bufPtr, otherContents + __CFStrSkipAnyLengthByte(otherString), otherNumByte);
             } else {
                 __CFStrConvertBytesToUnicode(otherContents + __CFStrSkipAnyLengthByte(otherString), (UniChar *)bufPtr, __CFStrLength2(otherString, otherContents));
@@ -4844,9 +4844,9 @@ CFStringRef CFStringCreateByCombiningStrings(CFAllocatorRef alloc, CFArrayRef ar
             bufPtr += otherNumByte;
         }
     }
-    if (canBeEightbit) *bufPtr = 0; // NULL byte;
+    if (canBeEightBit) *bufPtr = 0; // NULL byte;
 
-    return canBeEightbit ? 
+    return canBeEightBit ?
 		CFStringCreateWithCStringNoCopy(alloc, (const char*)buffer, __CFStringGetEightBitStringEncoding(), alloc) : 
 		CFStringCreateWithCharactersNoCopy(alloc, (UniChar *)buffer, numChars, alloc);
 }
@@ -7160,7 +7160,7 @@ static CFIndex __CFStringValidateFormat(CFStringRef expected, CFStringRef untrus
  originalValuesSize: Only used for recursive calls when doing stringsDict formatting. Otherwise 0. <<!!! Confirm>>
  args: The arguments to be formatted.
  outReplacementMetadata: On return, contains information on the replacements applied for the specifiers. If NULL, no metadata is generated.
- errorPtr: Only used when validating the formatString against valid format specfiers. Nil unless the validation fails. If error is set, return value is false.
+ errorPtr: Only used when validating the formatString against valid format specifiers. Nil unless the validation fails. If error is set, return value is false.
  
  ??? %s depends on handling of encodings by __CFStringAppendBytes
 */
@@ -7284,7 +7284,7 @@ static Boolean __CFStringAppendFormatCore(CFMutableStringRef outputString, CFStr
         }
     }
     
-    /* The code following this point makes multiple integer calcuations based off sizeSpecs, which is an upper-bound of the number of tokens in the string based on the number of '%' characters found. In order to avoid integer overflow at multiple points throughout this function, we will cap sizeSpec to an amount that won't overflow, but is still plenty large enough to support any reasonable format strings */
+    /* The code following this point makes multiple integer calculations based off sizeSpecs, which is an upper-bound of the number of tokens in the string based on the number of '%' characters found. In order to avoid integer overflow at multiple points throughout this function, we will cap sizeSpec to an amount that won't overflow, but is still plenty large enough to support any reasonable format strings */
 #define MAX_SIZE_SPECS (0xfffff) /* Won't overflow a 32-bit integer up to and including a multiplicative factor of 256 */
     if (sizeSpecs > MAX_SIZE_SPECS) {
         if (errorPtr) *errorPtr = __CFCreateOverflowError();

--- a/Sources/CoreFoundation/CFStringEncodingConverter.c
+++ b/Sources/CoreFoundation/CFStringEncodingConverter.c
@@ -600,7 +600,7 @@ static const _CFEncodingConverter *__CFGetConverter(uint32_t encoding) {
     switch (encoding) {
 	case kCFStringEncodingUTF8: commonConverterSlot = (const _CFEncodingConverter **)&(commonConverters[0]); break;
 
-	    /* the swith here should avoid possible bootstrap issues in the default: case below when invoked from CFStringGetSystemEncoding() */
+	    /* the switch here should avoid possible bootstrap issues in the default: case below when invoked from CFStringGetSystemEncoding() */
 #if TARGET_OS_MAC || TARGET_OS_LINUX
 	case kCFStringEncodingMacRoman: commonConverterSlot = (const _CFEncodingConverter **)&(commonConverters[1]); break;
 #elif TARGET_OS_WIN32
@@ -997,7 +997,7 @@ static CFComparisonResult __CFStringEncodingComparator(const void *v1, const voi
     return ((val1 == val2) ? ((CFComparisonResult)(*(const CFStringEncoding *)v1) - (CFComparisonResult)(*(const CFStringEncoding *)v2)) : val1 - val2);
 }
 
-static void __CFStringEncodingFliterDupes(CFStringEncoding *encodings, CFIndex numSlots) {
+static void __CFStringEncodingFilterDupes(CFStringEncoding *encodings, CFIndex numSlots) {
     CFStringEncoding last = kCFStringEncodingInvalidId;
     const CFStringEncoding *limitEncodings = encodings + numSlots;
 
@@ -1042,7 +1042,7 @@ CF_PRIVATE const CFStringEncoding *CFStringEncodingListOfAvailableEncodings(void
             }
 
             CFQSortArray(list, numSlots, sizeof(CFStringEncoding), (CFComparatorFunction)__CFStringEncodingComparator, NULL);
-            __CFStringEncodingFliterDupes(list, numSlots);
+            __CFStringEncodingFilterDupes(list, numSlots);
         }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated"

--- a/Sources/CoreFoundation/CFStringUtilities.c
+++ b/Sources/CoreFoundation/CFStringUtilities.c
@@ -596,7 +596,7 @@ CF_PRIVATE CFComparisonResult _CFCompareStringsWithLocale(CFStringInlineBuffer *
 	controlBMP = CFUniCharGetBitmapPtrForPlane(kCFUniCharControlAndFormatterCharacterSet, 0);
     }
     
-    // Determine the range of characters surrodiing the current index significant for localized comparison. The range is extended backward and forward as long as they are contextual. Contextual characters include all letters and punctuations. Since most control/format characters are ignorable in localized comparison, we also include them extending forward.
+    // Determine the range of characters surrounding the current index significant for localized comparison. The range is extended backward and forward as long as they are contextual. Contextual characters include all letters and punctuations. Since most control/format characters are ignorable in localized comparison, we also include them extending forward.
     
     range1.location = str1Range.location;
     range2.location = str2Range.location;

--- a/Sources/CoreFoundation/CFTimeZone.c
+++ b/Sources/CoreFoundation/CFTimeZone.c
@@ -189,7 +189,7 @@ static void __CFTimeZoneGetOffset(CFStringRef timezone, int32_t *offset) {
  * structure, and the files with the same name as the time zone.
  * Instead all the information is in one file, where all the time zone
  * information for all the zones is held. Also, to allow upgrades to the time
- * zone database without an update to the system, the database can be overriden
+ * zone database without an update to the system, the database can be overridden
  * by a secondary location.
  * - /data/misc/zoneinfo/current/tzdata overrides for the time zone information
  *   from the system.

--- a/Sources/CoreFoundation/CFUtilities.c
+++ b/Sources/CoreFoundation/CFUtilities.c
@@ -849,7 +849,7 @@ static bool also_do_stderr(const _cf_logging_style style) {
         //
         // Otherwise, we check for the force flag as we always have.
         //
-        // That failing, we'll stat STDERR and see if its sxomething we like.
+        // That failing, we'll stat STDERR and see if it's something we like.
         //
         // NOTE: As nice as it would be to dispatch_once this, all of these things
         // can and do change at runtime under certain circumstances, so we need to

--- a/Sources/CoreFoundation/CFWindowsUtilities.c
+++ b/Sources/CoreFoundation/CFWindowsUtilities.c
@@ -80,7 +80,7 @@ CF_EXPORT int64_t OSAtomicAdd64( int64_t __theAmount, volatile int64_t *__theVal
 }
 
 CF_EXPORT int64_t OSAtomicAdd64Barrier( int64_t __theAmount, volatile int64_t *__theValue ) {
-    retun (InterlockedExchangeAdd64((volatile LONGLONG *)__theValue, __theAmount) + __theAmount);
+    return (InterlockedExchangeAdd64((volatile LONGLONG *)__theValue, __theAmount) + __theAmount);
 }
  */
 

--- a/Sources/CoreFoundation/include/CFBase.h
+++ b/Sources/CoreFoundation/include/CFBase.h
@@ -34,7 +34,7 @@
 #endif
 
 #if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
-#error Do not know the endianess of this architecture
+#error Do not know the endianness of this architecture
 #endif
 
 #if !__BIG_ENDIAN__ && !__LITTLE_ENDIAN__

--- a/Sources/CoreFoundation/include/CFCharacterSet.h
+++ b/Sources/CoreFoundation/include/CFCharacterSet.h
@@ -303,7 +303,7 @@ void CFCharacterSetAddCharactersInRange(CFMutableCharacterSetRef theSet, CFRange
 
 /*!
 	@function CFCharacterSetRemoveCharactersInRange
-	Removes the given range from the charaacter set.
+	Removes the given range from the character set.
 	@param theSet The character set from which the range is to be
                 removed.  If this parameter is not a valid mutable
                 CFCharacterSet, the behavior is undefined.

--- a/Sources/CoreFoundation/include/CFPriv.h
+++ b/Sources/CoreFoundation/include/CFPriv.h
@@ -221,7 +221,7 @@ typedef CF_ENUM(CFIndex, CFSearchPathDirectory) {
 typedef CF_OPTIONS(CFOptionFlags, CFSearchPathDomainMask) {
     kCFUserDomainMask = 1,	/* user's home directory --- place to install user's personal items (~) */
     kCFLocalDomainMask = 2,	/* local to the current machine --- place to install items available to everyone on this machine (/Local) */
-    kCFNetworkDomainMask = 4, 	/* publically available location in the local area network --- place to install items available on the network (/Network) */
+    kCFNetworkDomainMask = 4, 	/* publicly available location in the local area network --- place to install items available on the network (/Network) */
     kCFSystemDomainMask = 8,	/* provided by Apple, unmodifiable (/System) */
     kCFAllDomainsMask = 0x0ffff	/* all domains: all of the above and more, future items */
 };

--- a/Sources/CoreFoundation/include/CFRuntime.h
+++ b/Sources/CoreFoundation/include/CFRuntime.h
@@ -262,7 +262,7 @@ CF_EXPORT void _CFRuntimeSetInstanceTypeID(CFTypeRef cf, CFTypeID typeID);
 #else
 CF_EXPORT void _CFRuntimeInitStaticInstance(void *memory, CFTypeID typeID);
 	/* This function initializes a memory block to be a constant
-	 * (unreleaseable) CF object of the given typeID.
+	 * (unreleasable) CF object of the given typeID.
 	 * If the specified CFTypeID is unknown to the CF runtime,
 	 * this function does nothing.  The memory block should
 	 * be a chunk of in-binary writeable static memory, and at

--- a/Sources/CoreFoundation/include/CFStream.h
+++ b/Sources/CoreFoundation/include/CFStream.h
@@ -197,7 +197,7 @@ CF_EXPORT const CFStringRef _Nonnull kCFStreamSocketSOCKSVersion4 CF_AVAILABLE(1
  *  kCFStreamSocketSOCKSVersion5
  *
  *  Discussion:
- *    CFDictionary value for SOCKS proxy information.  Indcates that
+ *    CFDictionary value for SOCKS proxy information.  Indicates that
  *    SOCKS will or is using version 5 of the SOCKS protocol.
  *
  */
@@ -246,7 +246,7 @@ CF_EXPORT const int kCFStreamErrorDomainSSL CF_AVAILABLE(10_2, 2_0);
  *  Discussion:
  *    Stream property key, for both set and copy operations. To set a
  *    stream to be secure, call CFReadStreamSetProperty or
- *    CFWriteStreamSetPropertywith the property name set to
+ *    CFWriteStreamSetProperty with the property name set to
  *    kCFStreamPropertySocketSecurityLevel and the value being one of
  *    the following values.  Streams may set a security level after
  *    open in order to allow on-the-fly securing of a stream.

--- a/Sources/CoreFoundation/include/CFString.h
+++ b/Sources/CoreFoundation/include/CFString.h
@@ -793,7 +793,7 @@ UInt32 CFStringConvertEncodingToWindowsCodepage(CFStringEncoding encoding);
 CF_EXPORT
 CFStringEncoding CFStringConvertWindowsCodepageToEncoding(UInt32 codepage);
 
-/* ID mapping functions from/to IANA registery charset names.  Returns kCFStringEncodingInvalidId if no mapping exists.
+/* ID mapping functions from/to IANA registry charset names.  Returns kCFStringEncodingInvalidId if no mapping exists.
 */
 CF_EXPORT
 CFStringEncoding CFStringConvertIANACharSetNameToEncoding(CFStringRef theString);

--- a/Sources/CoreFoundation/include/CFTree.h
+++ b/Sources/CoreFoundation/include/CFTree.h
@@ -59,7 +59,7 @@ typedef CFStringRef	(*CFTreeCopyDescriptionCallBack)(const void *info);
         @field retain The callback used to add a retain for the info field.
                 If this parameter is not a pointer to a function of the correct
                 prototype, the behavior is undefined.  The value may be NULL.
-        @field release The calllback used to remove a retain previously added
+        @field release The callback used to remove a retain previously added
                 for the info field.  If this parameter is not a pointer to a 
                 function of the correct prototype, the behavior is undefined.
                 The value may be NULL.

--- a/Sources/CoreFoundation/include/CFURLPriv.h
+++ b/Sources/CoreFoundation/include/CFURLPriv.h
@@ -204,7 +204,7 @@ CF_EXPORT const CFStringRef _kCFURLLocalizedNameDictionaryKey API_AVAILABLE(maco
     /* For items with localized display names, the dictionary of all available localizations. The keys are the canonical locale strings for the available localizations. (CFDictionary) */
 
 CF_EXPORT const CFStringRef _kCFURLLocalizedNameWithExtensionsHiddenDictionaryKey API_AVAILABLE(macosx(10.13), ios(11.0), watchos(4.0), tvos(11.0));
-    /* For items with localized display names, the dictionary of all available localizations with extensions hidden if safe. The keys are the cannonical locale strings for the available localizations. (CFDictionary) */
+    /* For items with localized display names, the dictionary of all available localizations with extensions hidden if safe. The keys are the canonical locale strings for the available localizations. (CFDictionary) */
 
 CF_EXPORT const CFStringRef _kCFURLLocalizedTypeDescriptionDictionaryKey API_AVAILABLE(macos(10.7), ios(9.0), watchos(2.0), tvos(9.0));
     /* The dictionary of all available localizations of the item kind string. The keys are the canonical locale strings for the available localizations. (CFDictionary) */

--- a/Sources/CoreFoundation/include/CFUniChar.h
+++ b/Sources/CoreFoundation/include/CFUniChar.h
@@ -169,7 +169,7 @@ CF_EXPORT bool CFUniCharFillDestinationBuffer(const UTF32Char *src, CFIndex srcL
 
 // UTF32 support
 
-CF_INLINE bool CFUniCharToUTF32(const UTF16Char *src, CFIndex length, UTF32Char *dst, bool allowLossy, bool isBigEndien) {
+CF_INLINE bool CFUniCharToUTF32(const UTF16Char *src, CFIndex length, UTF32Char *dst, bool allowLossy, bool isBigEndian) {
     const UTF16Char *limit = src + length;
     UTF32Char character;
 
@@ -188,18 +188,18 @@ CF_INLINE bool CFUniCharToUTF32(const UTF16Char *src, CFIndex length, UTF32Char 
             character = 0xFFFD; // replacement character
         }
 
-        *(dst++) = (isBigEndien ? CFSwapInt32HostToBig(character) : CFSwapInt32HostToLittle(character));
+        *(dst++) = (isBigEndian ? CFSwapInt32HostToBig(character) : CFSwapInt32HostToLittle(character));
     }
 
     return true;
 }
 
-CF_INLINE bool CFUniCharFromUTF32(const UTF32Char *src, CFIndex length, UTF16Char *dst, bool allowLossy, bool isBigEndien) {
+CF_INLINE bool CFUniCharFromUTF32(const UTF32Char *src, CFIndex length, UTF16Char *dst, bool allowLossy, bool isBigEndian) {
     const UTF32Char *limit = src + length;
     UTF32Char character;
 
     while (src < limit) {
-        character = (isBigEndien ? CFSwapInt32BigToHost(*(src++)) : CFSwapInt32LittleToHost(*(src++)));
+        character = (isBigEndian ? CFSwapInt32BigToHost(*(src++)) : CFSwapInt32LittleToHost(*(src++)));
 
         if (character < 0x10000) { // BMP
             if (allowLossy) {
@@ -207,7 +207,7 @@ CF_INLINE bool CFUniCharFromUTF32(const UTF32Char *src, CFIndex length, UTF16Cha
                     UTF32Char otherCharacter = 0xFFFD; // replacement character
 
                     if (src < limit) {
-                        otherCharacter = (isBigEndien ? CFSwapInt32BigToHost(*src) : CFSwapInt32LittleToHost(*src));
+                        otherCharacter = (isBigEndian ? CFSwapInt32BigToHost(*src) : CFSwapInt32LittleToHost(*src));
 
                         
                         if ((otherCharacter < 0x10000) && CFUniCharIsSurrogateLowCharacter(otherCharacter)) {

--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -615,7 +615,7 @@ open class FileHandle : NSObject, @unchecked Sendable {
             // console output is not buffered.
             if dwError == ERROR_INVALID_HANDLE &&
                     GetFileType(self._handle) == FILE_TYPE_CHAR {
-                // Simlar to the Linux, macOS, BSD cases below, ignore the error
+                // Similar to the Linux, macOS, BSD cases below, ignore the error
                 // on the special file type.
                 return
             }

--- a/Sources/Foundation/JSONSerialization+Parser.swift
+++ b/Sources/Foundation/JSONSerialization+Parser.swift
@@ -150,7 +150,7 @@ internal struct JSONParser {
         self.depth += 1
         defer { depth -= 1 }
 
-        // parse first value or end immediatly
+        // parse first value or end immediately
         switch try reader.consumeWhitespace() {
         case ._space, ._return, ._newline, ._tab:
             preconditionFailure("Expected that all white space is consumed")

--- a/Sources/Foundation/NSCoder.swift
+++ b/Sources/Foundation/NSCoder.swift
@@ -10,9 +10,9 @@
 extension NSCoder {
 
     /// Describes the action an `NSCoder` should take when it encounters decode
-    /// failures (e.g. corrupt data) for non-TopLevel decodes. Darwin platfrom
+    /// failures (e.g. corrupt data) for non-TopLevel decodes. Darwin platform
     /// supports exceptions here, and there may be other approaches supported
-    /// in the future, so its included for completeness.
+    /// in the future, so it's included for completeness.
     public enum DecodingFailurePolicy : Int, Sendable {
         case raiseException
         case setErrorAndReturn

--- a/Sources/Foundation/NSData.swift
+++ b/Sources/Foundation/NSData.swift
@@ -252,7 +252,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
     open var bytes: UnsafeRawPointer {
         requireFunnelOverridden()
         guard let bytePtr = CFDataGetBytePtr(_cfObject) else {
-            //This could occure on empty data being encoded.
+            //This could occur on empty data being encoded.
             //TODO: switch with nil when signature is fixed
             return UnsafeRawPointer(bitPattern: 0x7f00dead)! //would not result in 'nil unwrapped optional'
         }
@@ -463,7 +463,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
             }
 
             // NOTE: Each flag such as `S_IRUSR` may be literal depends on the system.
-            // Without explicity type them as `Int`, type inference will not complete in reasonable time
+            // Without explicitly type them as `Int`, type inference will not complete in reasonable time
             // and the compiler will throw an error.
 #if os(Windows)
             let createMode = Int(ucrt.S_IREAD) | Int(ucrt.S_IWRITE)
@@ -888,7 +888,7 @@ open class NSData : NSObject, NSCopying, NSMutableCopying, NSSecureCoding {
                 inputIndex += 3
             } else {
                 // This runs once at the end of there were 1 or 2 bytes left, byte1 having already been read.
-                // Read byte2 or 0 if there isnt another byte
+                // Read byte2 or 0 if there isn't another byte
                 let byte2 = bytesLeft == 1 ? 0 : dataBuffer[inputIndex + 1]
                 var value = UInt16(byte1 & 0x3) << 8
                 value |= UInt16(byte2)

--- a/Sources/Foundation/NSDate.swift
+++ b/Sources/Foundation/NSDate.swift
@@ -390,8 +390,8 @@ open class NSDateInterval : NSObject, NSCopying, NSSecureCoding, @unchecked Send
     open func contains(_ date: Date) -> Bool {
         let timeIntervalForGivenDate = date.timeIntervalSinceReferenceDate
         let timeIntervalForSelfStart = startDate.timeIntervalSinceReferenceDate
-        let timeIntervalforSelfEnd = endDate.timeIntervalSinceReferenceDate
-        if (timeIntervalForGivenDate >= timeIntervalForSelfStart) && (timeIntervalForGivenDate <= timeIntervalforSelfEnd) {
+        let timeIntervalForSelfEnd = endDate.timeIntervalSinceReferenceDate
+        if (timeIntervalForGivenDate >= timeIntervalForSelfStart) && (timeIntervalForGivenDate <= timeIntervalForSelfEnd) {
             return true
         }
         return false

--- a/Sources/Foundation/NSExpression.swift
+++ b/Sources/Foundation/NSExpression.swift
@@ -117,7 +117,7 @@ open class NSExpression : NSObject, NSCopying {
     public convenience init(forMinusSet left: NSExpression, with right: NSExpression) { NSUnsupported() } // return an expression that will return the disjunction of the collections expressed by left and right
 
     @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
-    public convenience init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: Any) { NSUnsupported() } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifer returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
+    public convenience init(forSubquery expression: NSExpression, usingIteratorVariable variable: String, predicate: Any) { NSUnsupported() } // Expression that filters a collection by storing elements in the collection in the variable variable and keeping the elements for which qualifier returns true; variable is used as a local variable, and will shadow any instances of variable in the bindings dictionary, the variable is removed or the old value replaced once evaluation completes
 
     @available(*, unavailable, message: "NSExpression is not available in swift-corelibs-foundation")
     public convenience init(forFunction target: NSExpression, selectorName name: String, arguments parameters: [Any]?) { NSUnsupported() } // Expression that invokes the selector on target with parameters. Will throw at runtime if target does not implement selector or if parameters are wrong.

--- a/Sources/Foundation/NSObjCRuntime.swift
+++ b/Sources/Foundation/NSObjCRuntime.swift
@@ -185,7 +185,7 @@ public typealias Comparator = (Any, Any) -> ComparisonResult
 public let NSNotFound: Int = Int.max
 
 internal func NSRequiresConcreteImplementation(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {
-    fatalError("\(fn) must be overriden in subclass implementations", file: file, line: line)
+    fatalError("\(fn) must be overridden in subclass implementations", file: file, line: line)
 }
 
 internal func NSUnimplemented(_ fn: String = #function, file: StaticString = #file, line: UInt = #line) -> Never {

--- a/Sources/Foundation/NSPersonNameComponents.swift
+++ b/Sources/Foundation/NSPersonNameComponents.swift
@@ -77,7 +77,7 @@ open class NSPersonNameComponents : NSObject, NSCopying, NSSecureCoding {
         _pnc == other._pnc
     }
     
-    // Internal for ObjectiveCBridgable access
+    // Internal for ObjectiveCBridgeable access
     internal var _pnc = PersonNameComponents()
     
     /// Assuming the full name is: Dr. Johnathan Maple Appleseed Esq., nickname "Johnny", pre-nominal letters denoting title, salutation, or honorific, e.g. Dr., Mr.

--- a/Sources/Foundation/NSURL.swift
+++ b/Sources/Foundation/NSURL.swift
@@ -897,7 +897,7 @@ extension NSURL {
     /* The following methods work only on `file:` scheme URLs; for non-`file:` scheme URLs, these methods return the URL unchanged.
     */
     public var standardizingPath: URL? {
-        // Documentation says it should expand initial tilde, but it does't do this on OS X.
+        // Documentation says it should expand initial tilde, but it doesn't do this on OS X.
         // In remaining cases it works just like URLByResolvingSymlinksInPath.
         return _resolveSymlinksInPath(excludeSystemDirs: true, preserveDirectoryFlag: true)
     }

--- a/Sources/Foundation/Operation.swift
+++ b/Sources/Foundation/Operation.swift
@@ -343,8 +343,7 @@ open class Operation : NSObject, @unchecked Sendable {
             fatalError("\(self): receiver is not yet ready to execute")
         }
         
-        let isCanc = _isCancelled
-        if !isCanc {
+        if !_isCancelled {
             _state = .executing
             Operation.observeValue(forKeyPath: _NSOperationIsExecuting, ofObject: self)
             
@@ -438,27 +437,27 @@ open class Operation : NSObject, @unchecked Sendable {
     open func removeDependency(_ op: Operation) {
         withExtendedLifetime(self) {
             withExtendedLifetime(op) {
-                var up_canidate: Operation?
+                var up_candidate: Operation?
                 _lock()
-                let idxCanidate = __dependencies.firstIndex { $0 === op }
-                if idxCanidate != nil {
-                    up_canidate = op
+                let idxCandidate = __dependencies.firstIndex { $0 === op }
+                if idxCandidate != nil {
+                    up_candidate = op
                 }
                 _unlock()
                 
-                if let canidate = up_canidate {
-                    canidate._lock()
+                if let candidate = up_candidate {
+                    candidate._lock()
                     _lock()
                     if let idx = __dependencies.firstIndex(where: { $0 === op }) {
-                        if canidate._state == .finished && _isCancelled {
+                        if candidate._state == .finished && _isCancelled {
                             _decrementUnfinishedDependencyCount()
                         }
-                        canidate._removeParent(self)
+                        candidate._removeParent(self)
                         __dependencies.remove(at: idx)
                     }
                     
                     _unlock()
-                    canidate._unlock()
+                    candidate._unlock()
                 }
                 Operation.observeValue(forKeyPath: _NSOperationIsReady, ofObject: self)
             }

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -492,7 +492,7 @@ open class Process: NSObject, @unchecked Sendable {
         // Dispatch the manager thread if it isn't already running
         Process.setup()
 
-        // Check that the process isnt run more than once
+        // Check that the process isn't run more than once
         guard hasStarted == false && hasFinished == false else {
             throw NSError(domain: NSCocoaErrorDomain, code: NSExecutableLoadError)
         }

--- a/Sources/FoundationNetworking/DataURLProtocol.swift
+++ b/Sources/FoundationNetworking/DataURLProtocol.swift
@@ -114,7 +114,7 @@ internal class _DataURLProtocol: URLProtocol {
         var charSet: String?
         var base64 = false
 
-        // Simple validation that the mime type has only one '/' and its not at the start or end.
+        // Simple validation that the mime type has only one '/' and it's not at the start or end.
         func validate(mimeType: String) -> Bool {
             if mimeType.hasPrefix("/") { return false }
             var count = 0

--- a/Sources/FoundationNetworking/URLSession/BodySource.swift
+++ b/Sources/FoundationNetworking/URLSession/BodySource.swift
@@ -45,7 +45,7 @@ internal func splitData(dispatchData data: DispatchData, atPosition position: In
 
 /// A (non-blocking) source for body data.
 internal protocol _BodySource: AnyObject {
-    /// Get the next chunck of data.
+    /// Get the next chunk of data.
     ///
     /// - Returns: `.data` until the source is exhausted, at which point it will
     /// return `.done`. Since this is non-blocking, it will return `.retryLater`

--- a/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/NativeProtocol.swift
@@ -297,7 +297,7 @@ internal class _NativeProtocol: URLProtocol, _EasyHandleDelegate {
         // We will reset the body source and seek forward.
         guard let session = task?.session as? URLSession else { fatalError() }
         
-        // TODO: InputStream is not Sendable, but it seems safe here beacuse of the wait on the dispatch group. It would be nice to prove this to the compiler.
+        // TODO: InputStream is not Sendable, but it seems safe here because of the wait on the dispatch group. It would be nice to prove this to the compiler.
         nonisolated(unsafe) var currentInputStream: InputStream?
         
         if let delegate = task?.delegate {

--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -436,7 +436,7 @@ open class URLSessionTask : NSObject, NSCopying, @unchecked Sendable {
     /// nestable.
     open func suspend() {
         // suspend / resume is implemented simply by adding / removing the task's
-        // easy handle fromt he session's multi-handle.
+        // easy handle from the session's multi-handle.
         //
         // This might result in slightly different behaviour than the Darwin Foundation
         // implementation, but it'll be difficult to get complete parity anyhow.
@@ -975,7 +975,7 @@ extension URLSessionWebSocketDelegate {
  * -URLSession:dataTask:didReceiveResponse: delegate message.
  *
  * URLSessionStreamTask can be used to perform asynchronous reads
- * and writes.  Reads and writes are enquened and executed serially,
+ * and writes.  Reads and writes are enqueued and executed serially,
  * with the completion handler being invoked on the sessions delegate
  * queuee.  If an error occurs, or the task is canceled, all
  * outstanding read and write calls will have their completion
@@ -983,7 +983,7 @@ extension URLSessionWebSocketDelegate {
  *
  * It is also possible to create InputStream and OutputStream
  * instances from an URLSessionTask by sending
- * -captureStreams to the task.  All outstanding read and writess are
+ * -captureStreams to the task.  All outstanding reads and writes are
  * completed before the streams are created.  Once the streams are
  * delivered to the session delegate, the task is considered complete
  * and will receive no more messages.  These streams are

--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -135,7 +135,7 @@ internal protocol _EasyHandleDelegate: AnyObject {
     /// Seek the input stream to the given position
     func seekInputStream(to position: UInt64) throws
     /// Gets called during the transfer to update progress.
-    func updateProgressMeter(with propgress: _EasyHandle._Progress)
+    func updateProgressMeter(with progress: _EasyHandle._Progress)
 }
 extension _EasyHandle {
     func set(verboseModeOn flag: Bool) {
@@ -745,8 +745,8 @@ fileprivate extension _EasyHandle {
         //     <https://en.wikipedia.org/wiki/Type_of_service>
         //     <https://en.wikipedia.org/wiki/Quality_of_service>
     }
-    func updateProgressMeter(with propgress: _Progress) {
-        delegate?.updateProgressMeter(with: propgress)
+    func updateProgressMeter(with progress: _Progress) {
+        delegate?.updateProgressMeter(with: progress)
     }
     
     func seekInputStream(offset: Int64, origin: CInt) -> CInt {

--- a/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
@@ -552,7 +552,7 @@ fileprivate class _SocketSources {
         handle.cancelWorkItem(for: socket) // There could be pending register action which needs to be cancelled
         
         guard readSource != nil || writeSource != nil else {
-            // This means that we have posponed (and already abandoned)
+            // This means that we have postponed (and already abandoned)
             // sources creation.
             return
         }

--- a/Sources/FoundationXML/XMLNode.swift
+++ b/Sources/FoundationXML/XMLNode.swift
@@ -411,7 +411,7 @@ open class XMLNode: NSObject, NSCopying {
                 return returned == nil ? nil : unsafeBitCast(returned!, to: NSString.self) as String
                 
             case .element:
-                // As with Darwin, children's string values are just concanated without spaces.
+                // As with Darwin, children's string values are just concatenated without spaces.
                 return children?.compactMap({ $0.stringValue }).joined() ?? ""
                 
             default:

--- a/Sources/FoundationXML/XMLParser.swift
+++ b/Sources/FoundationXML/XMLParser.swift
@@ -403,7 +403,7 @@ open class XMLParser : NSObject {
 
     internal var _chunkSize = Int(4096 * 32) // a suitably large number for a decent chunk size
     // This chunk of data stores the head of the stream. We know we have enough information for encoding
-    // when there are atleast 4 bytes in here.
+    // when there are at least 4 bytes in here.
     internal var _bomChunk: Data?
     fileprivate var _parserContext: _CFXMLInterfaceParserContext?
     internal var _delegateAborted = false

--- a/Sources/XCTest/Private/TestListing.swift
+++ b/Sources/XCTest/Private/TestListing.swift
@@ -31,7 +31,7 @@ internal struct TestListing {
         }
     }
 
-    /// Prints a JSON representation of the tests in the suite, mirring the internal
+    /// Prints a JSON representation of the tests in the suite, mirroring the internal
     /// tree representation of test suites and test cases. This output is intended
     /// to be consumed by other tools.
     func printTestJSON() {

--- a/Sources/plutil/PLULiteralOutput.swift
+++ b/Sources/plutil/PLULiteralOutput.swift
@@ -27,7 +27,7 @@ internal func objcLiteralDataWithPropertyList(_ plist: Any, originalFileName: St
 }
 
 internal func objcLiteralHeaderDataWithPropertyList(_ plist: Any, originalFileName: String, newFileName: String) throws -> Data {
-    let result = try _objCLiteralVaribleWithPropertyList(plist, forHeader: true, originalFilename: originalFileName, outputFilename: newFileName)
+    let result = try _objCLiteralVariableWithPropertyList(plist, forHeader: true, originalFilename: originalFileName, outputFilename: newFileName)
     
     // Add final semi-colon
     let withNewline = result.appending(";\n")
@@ -110,7 +110,7 @@ extension String {
 private func _objcLiteralDataWithPropertyList(_ plist: Any, depth: Int, indent: Bool, originalFilename: String, outputFilename: String) throws -> String {
     var result = ""
     if depth == 0 {
-        result.append(try _objCLiteralVaribleWithPropertyList(plist, forHeader: false, originalFilename: originalFilename, outputFilename: outputFilename))
+        result.append(try _objCLiteralVariableWithPropertyList(plist, forHeader: false, originalFilename: originalFilename, outputFilename: outputFilename))
     }
     
     if indent {
@@ -148,7 +148,7 @@ private func _objcLiteralDataWithPropertyList(_ plist: Any, depth: Int, indent: 
     return result
 }
 
-private func _objCLiteralVaribleWithPropertyList(_ plist: Any, forHeader: Bool, originalFilename: String, outputFilename: String) throws -> String {
+private func _objCLiteralVariableWithPropertyList(_ plist: Any, forHeader: Bool, originalFilename: String, outputFilename: String) throws -> String {
     let objCName: String
     if let _ = plist as? NSNumber {
         objCName = "NSNumber"

--- a/Sources/xdgTestHelper/main.swift
+++ b/Sources/xdgTestHelper/main.swift
@@ -76,7 +76,7 @@ func signalTest() {
     sigaddset(&signalSet, SIGINT)
     sigaddset(&signalSet, SIGALRM)
     guard sigprocmask(SIG_BLOCK, &signalSet, nil) == 0 else {
-        fatalError("Cant block signals")
+        fatalError("Can't block signals")
     }
     // Timeout
     alarm(3)

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -1070,7 +1070,7 @@ public class TestURLSessionServer: CustomStringConvertible {
     
     private func statusCodeResponse(forRequest request: _HTTPRequest, statusCode: Int) throws -> _HTTPResponse {
         guard let bodyData = try? request.headersAsJSON() else {
-            return try _HTTPResponse(response: .SERVER_ERROR, body: "Cant convert headers to JSON object")
+            return try _HTTPResponse(response: .SERVER_ERROR, body: "Cannot convert headers to JSON object")
         }
 
         var response: _HTTPResponse

--- a/Tests/Foundation/TestBundle.swift
+++ b/Tests/Foundation/TestBundle.swift
@@ -22,7 +22,7 @@ internal func testBundle(executable: Bool = false) -> Bundle {
             return bundle
         }
     }
-    fatalError("Cant find test bundle")
+    fatalError("Can't find test bundle")
     #else
     return executable ? Bundle.main : Bundle.module
     #endif

--- a/Tests/Foundation/TestDataURLProtocol.swift
+++ b/Tests/Foundation/TestDataURLProtocol.swift
@@ -123,7 +123,7 @@ class TestDataURLProtocol: XCTestCase {
                 if let data = delegate.data, let string = String(data: data, encoding: encoding) {
                     XCTAssertEqual(body, string, "\(urlString) has wrong body string")
                 } else {
-                    XCTFail("Cant convert data to string for \(urlString)")
+                    XCTFail("Can't convert data to string for \(urlString)")
                 }
 
             } else {

--- a/Tests/Foundation/TestFileHandle.swift
+++ b/Tests/Foundation/TestFileHandle.swift
@@ -617,7 +617,7 @@ class TestFileHandle : XCTestCase {
 #endif
 
     func testSynchronizeOnSpecialFile() throws {
-        // .synchronize() on a special file shouldnt fail
+        // .synchronize() on a special file shouldn't fail
 #if os(Windows)
         let fh = try XCTUnwrap(FileHandle(forWritingAtPath: "CON"))
 #else

--- a/Tests/Foundation/TestFileManager.swift
+++ b/Tests/Foundation/TestFileManager.swift
@@ -86,9 +86,9 @@ class TestFileManager : XCTestCase {
         let attributes = [FileAttributeKey.posixPermissions: permissions]
         XCTAssertTrue(fm.createFile(atPath: path, contents: Data(),
                                     attributes: attributes))
-        let retrievedAtributes = try fm.attributesOfItem(atPath: path)
+        let retrievedAttributes = try fm.attributesOfItem(atPath: path)
 
-        let retrievedPermissions = try XCTUnwrap(retrievedAtributes[.posixPermissions] as? NSNumber)
+        let retrievedPermissions = try XCTUnwrap(retrievedAttributes[.posixPermissions] as? NSNumber)
         XCTAssertEqual(retrievedPermissions, permissions)
 
         try fm.removeItem(atPath: path)
@@ -386,14 +386,14 @@ class TestFileManager : XCTestCase {
         if let size = item1FileAttributes[.size] as? NSNumber {
             XCTAssertEqual(size.int64Value, 123)
         } else {
-            XCTFail("Cant get file size for 'item'")
+            XCTFail("Can't get file size for 'item'")
         }
 
         XCTAssertNotNil(item2FileAttributes)
         if let size = item2FileAttributes[.size] as? NSNumber {
             XCTAssertEqual(size.int64Value, 456)
         } else {
-            XCTFail("Cant get file size for 'path2/item'")
+            XCTFail("Can't get file size for 'path2/item'")
         }
 
         if let e2 = FileManager.default.enumerator(atPath: basePath) {
@@ -481,13 +481,13 @@ class TestFileManager : XCTestCase {
         XCTAssertNotNil(try? fm.createDirectory(atPath: subDirs1, withIntermediateDirectories: true, attributes: nil))
         XCTAssertNotNil(try? fm.createDirectory(atPath: subDirs2, withIntermediateDirectories: true, attributes: nil))
         for filename in [itemPath1, itemPath2, itemPath3] {
-            XCTAssertTrue(fm.createFile(atPath: filename, contents: Data(), attributes: nil), "Cant create file '\(filename)'")
+            XCTAssertTrue(fm.createFile(atPath: filename, contents: Data(), attributes: nil), "Can't create file '\(filename)'")
         }
 
         var resourceValues = URLResourceValues()
         resourceValues.isHidden = true
         for filename in [ hiddenItem1, hiddenItem2, hiddenItem3, hiddenItem4] {
-            XCTAssertTrue(fm.createFile(atPath: filename, contents: Data(), attributes: nil), "Cant create file '\(filename)'")
+            XCTAssertTrue(fm.createFile(atPath: filename, contents: Data(), attributes: nil), "Can't create file '\(filename)'")
 #if os(Windows)
             do {
                 var url = URL(fileURLWithPath: filename)
@@ -515,25 +515,25 @@ class TestFileManager : XCTestCase {
                 XCTAssertEqual(fileLevels[name], level, "File level for \(name) is wrong")
             }
         } else {
-            XCTFail("Cant enumerate directory at \(basePath) with options: []")
+            XCTFail("Can't enumerate directory at \(basePath) with options: []")
         }
 
         if let foundItems = directoryItems(options: [.skipsHiddenFiles]) {
             XCTAssertEqual(foundItems.count, 5)
         } else {
-            XCTFail("Cant enumerate directory at \(basePath) with options: [.skipsHiddenFiles]")
+            XCTFail("Can't enumerate directory at \(basePath) with options: [.skipsHiddenFiles]")
         }
 
         if let foundItems = directoryItems(options: [.skipsSubdirectoryDescendants]) {
             XCTAssertEqual(foundItems.count, 3)
         } else {
-            XCTFail("Cant enumerate directory at \(basePath) with options: [.skipsSubdirectoryDescendants]")
+            XCTFail("Can't enumerate directory at \(basePath) with options: [.skipsSubdirectoryDescendants]")
         }
 
         if let foundItems = directoryItems(options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]) {
             XCTAssertEqual(foundItems.count, 2)
         } else {
-            XCTFail("Cant enumerate directory at \(basePath) with options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]")
+            XCTFail("Can't enumerate directory at \(basePath) with options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]")
         }
 
         if let foundItems = directoryItems(options: [.skipsPackageDescendants]) {
@@ -543,7 +543,7 @@ class TestFileManager : XCTestCase {
             XCTAssertEqual(foundItems.count, 15)
 #endif
         } else {
-            XCTFail("Cant enumerate directory at \(basePath) with options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]")
+            XCTFail("Can't enumerate directory at \(basePath) with options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]")
         }
 
         var didGetError = false
@@ -786,7 +786,7 @@ class TestFileManager : XCTestCase {
 
         func getFileInfo(atPath path: String, _ body: (String, Bool, UInt64, UInt64) -> ()) {
             guard let enumerator = fm.enumerator(atPath: path) else {
-                XCTFail("Cant enumerate \(path)")
+                XCTFail("Can't enumerate \(path)")
                 return
             }
             while let item = enumerator.nextObject() as? String {
@@ -827,7 +827,7 @@ class TestFileManager : XCTestCase {
 
         getFileInfo(atPath: destPath, { name, isDir, inode, linkCount in
             guard let srcFileInfo = fileInfos.removeValue(forKey: name) else {
-                XCTFail("Cant find \(name) in \(destPath)")
+                XCTFail("Can't find \(name) in \(destPath)")
                 return
             }
             let (srcIsDir, srcInode, srcLinkCount) = srcFileInfo
@@ -914,7 +914,7 @@ class TestFileManager : XCTestCase {
             try FileManager.default.removeItem(at: baseURL)
 
             #if !os(Windows)
-            // D) Check infinite recursion loops are stopped and the function returns the intial symlink
+            // D) Check infinite recursion loops are stopped and the function returns the initial symlink
             //
             // Note: This cannot be tested on platforms which only support creating symlinks pointing to existing targets.
             try FileManager.default.createDirectory(at: baseURL, withIntermediateDirectories: true)
@@ -928,27 +928,27 @@ class TestFileManager : XCTestCase {
     }
 
     func test_homedirectoryForUser() {
-        let filemanger = FileManager.default
-        XCTAssertNil(filemanger.homeDirectory(forUser: "someuser"))
-        XCTAssertNil(filemanger.homeDirectory(forUser: ""))
-        XCTAssertNotNil(filemanger.homeDirectoryForCurrentUser)
+        let filemanager = FileManager.default
+        XCTAssertNil(filemanager.homeDirectory(forUser: "someuser"))
+        XCTAssertNil(filemanager.homeDirectory(forUser: ""))
+        XCTAssertNotNil(filemanager.homeDirectoryForCurrentUser)
     }
     
     func test_temporaryDirectoryForUser() {
-        let filemanger = FileManager.default
-        let tmpDir = filemanger.temporaryDirectory
+        let filemanager = FileManager.default
+        let tmpDir = filemanager.temporaryDirectory
         let tmpFileUrl = tmpDir.appendingPathComponent("test.bin")
         let tmpFilePath = tmpFileUrl.path
         
         do {
-            if filemanger.fileExists(atPath: tmpFilePath) {
-                try filemanger.removeItem(at: tmpFileUrl)
+            if filemanager.fileExists(atPath: tmpFilePath) {
+                try filemanager.removeItem(at: tmpFileUrl)
             }
             
             try "hello world".write(to: tmpFileUrl, atomically: false, encoding: .utf8)
-            XCTAssert(filemanger.fileExists(atPath: tmpFilePath))
+            XCTAssert(filemanager.fileExists(atPath: tmpFilePath))
 
-            try filemanger.removeItem(at: tmpFileUrl)
+            try filemanager.removeItem(at: tmpFileUrl)
         } catch {
             XCTFail("Unable to write a file to the temporary directory: \(tmpDir), err: \(error)")
         }
@@ -994,7 +994,7 @@ class TestFileManager : XCTestCase {
 
         func testFileURL(_ name: String, _ ext: String) -> URL? {
             guard let url = testBundle().url(forResource: name, withExtension: ext) else {
-                XCTFail("Cant open \(name).\(ext)")
+                XCTFail("Can't open \(name).\(ext)")
                 return nil
             }
             return url
@@ -1174,7 +1174,7 @@ class TestFileManager : XCTestCase {
                 let destPerms = (try fm.attributesOfItem(atPath: destFile.path)[.posixPermissions] as? NSNumber)?.intValue {
                 XCTAssertEqual(srcPerms, destPerms)
             } else {
-                XCTFail("Cant get file permissions")
+                XCTFail("Can't get file permissions")
             }
         }
 

--- a/Tests/Foundation/TestHTTPURLResponse.swift
+++ b/Tests/Foundation/TestHTTPURLResponse.swift
@@ -187,7 +187,7 @@ class TestHTTPURLResponse: XCTestCase {
 
         ]
         guard let sut = HTTPURLResponse(url: url, statusCode: 302, httpVersion: "HTTP/1.1", headerFields: f) else {
-            XCTFail("Cant create HTTPURLResponse")
+            XCTFail("Can't create HTTPURLResponse")
             return
         }
         XCTAssertEqual(sut.statusCode, 302)
@@ -196,7 +196,7 @@ class TestHTTPURLResponse: XCTestCase {
         XCTAssertEqual(sut.textEncodingName, "iso-8891-1")
 
         guard let ahf = sut.allHeaderFields as? [String: String] else {
-            XCTFail("Cant read .allheaderFields")
+            XCTFail("Can't read .allheaderFields")
             return
         }
 

--- a/Tests/Foundation/TestJSONEncoder.swift
+++ b/Tests/Foundation/TestJSONEncoder.swift
@@ -907,7 +907,7 @@ class TestJSONEncoder : XCTestCase {
         encoder.dateEncodingStrategy = .iso8601
         let encodedData = try encoder.encode(data)
         guard let jsonObject = try JSONSerialization.jsonObject(with: encodedData) as? [String: Any] else {
-            XCTFail("Cant decode json object")
+            XCTFail("Can't decode json object")
             return
         }
         XCTAssertEqual(jsonObject["this_is_a_string"] as? String, "Hello")
@@ -956,7 +956,7 @@ class TestJSONEncoder : XCTestCase {
         let camelCaseDictionary = ["camelCaseKey": ["nested_dictionary": 1]]
         let encodedData = try encoder.encode(camelCaseDictionary)
         guard let jsonObject = try JSONSerialization.jsonObject(with: encodedData) as? [String: [String: Int]] else {
-            XCTFail("Cant decode json object")
+            XCTFail("Can't decode json object")
             return
         }
         XCTAssertEqual(jsonObject, camelCaseDictionary)

--- a/Tests/Foundation/TestJSONSerialization.swift
+++ b/Tests/Foundation/TestJSONSerialization.swift
@@ -1025,8 +1025,8 @@ extension TestJSONSerialization {
                 XCTAssertEqual(str!, "{\"\(param.0)\":\(param.1)}", "serialized value should  have a decimal places and leading zero")
             }
         }
-        //test serialize values grater than 1 with maxFractionDigits = 15
-        func execute_testSetGraterThanOne() {
+        //test serialize values greater than 1 with maxFractionDigits = 15
+        func execute_testSetGreaterThanOne() {
             let paramsBove1 = [
                 ("1.1",1.1),
                 ("1.2",1.2),
@@ -1066,7 +1066,7 @@ extension TestJSONSerialization {
             }
         }
         execute_testSetLessThanOne()
-        execute_testSetGraterThanOne()
+        execute_testSetGreaterThanOne()
         execute_testWholeNumbersWithDoubleAsInput()
         execute_testWholeNumbersWithIntInput()
     }

--- a/Tests/Foundation/TestNSData.swift
+++ b/Tests/Foundation/TestNSData.swift
@@ -466,13 +466,13 @@ class TestNSData: XCTestCase {
         XCTAssertEqual(
             Data(repeating: 0, count: 48).base64EncodedString(options: .lineLength64Characters),
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-            "each 3 byte is converted into 4 characterss. 48 / 3 * 4 <= 64, therefore result should not have line separator."
+            "each 3 byte is converted into 4 characters. 48 / 3 * 4 <= 64, therefore result should not have line separator."
         )
         
         XCTAssertEqual(
             Data(repeating: 0, count: 57).base64EncodedString(options: .lineLength76Characters),
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-            "each 3 byte is converted into 4 characterss. 57 / 3 * 4 <= 76, therefore result should not have line separator."
+            "each 3 byte is converted into 4 characters. 57 / 3 * 4 <= 76, therefore result should not have line separator."
         )
     }
     
@@ -481,13 +481,13 @@ class TestNSData: XCTestCase {
         XCTAssertEqual(
             Data(repeating: 0, count: 49).base64EncodedString(options: .lineLength64Characters),
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\r\nAA==",
-            "each 3 byte is converted into 4 characterss. 49 / 3 * 4 > 64, therefore result should have lines with separator."
+            "each 3 byte is converted into 4 characters. 49 / 3 * 4 > 64, therefore result should have lines with separator."
         )
         
         XCTAssertEqual(
             Data(repeating: 0, count: 58).base64EncodedString(options: .lineLength76Characters),
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\r\nAA==",
-            "each 3 byte is converted into 4 characterss. 58 / 3 * 4 > 76, therefore result should have lines with separator."
+            "each 3 byte is converted into 4 characters. 58 / 3 * 4 > 76, therefore result should have lines with separator."
         )
     }
     
@@ -743,7 +743,7 @@ class TestNSData: XCTestCase {
             if let txt = String(data: Data(referencing: mData), encoding: .ascii) {
                 XCTAssertEqual(txt, "swift-corelibs-foundation")
             } else {
-                XCTFail("Cant convert to string")
+                XCTFail("Can't convert to string")
             }
         }
 
@@ -812,7 +812,7 @@ class TestNSData: XCTestCase {
         }
 
         guard let mData = NSMutableData(length: 5) else {
-            XCTFail("Cant create NSMutableData")
+            XCTFail("Can't create NSMutableData")
             return
         }
 
@@ -1365,7 +1365,7 @@ extension TestNSData {
                 if let str = String(bytesNoCopy: ptr, length: zeroIdx, encoding: .ascii, freeWhenDone: false) {
                     XCTAssertTrue(str.hasSuffix(".xctest"))
                 } else {
-                    XCTFail("Cant create String")
+                    XCTFail("Can't create String")
                 }
             }
         }
@@ -1386,7 +1386,7 @@ extension TestNSData {
         }
         // Some files in /sys report a non-zero st_size often bigger than the contents
         guard let data = NSData.init(contentsOfFile: "/sys/kernel/profiling") else {
-            XCTFail("Cant read /sys/kernel/profiling")
+            XCTFail("Can't read /sys/kernel/profiling")
             return
         }
         XCTAssert(data.length > 0)

--- a/Tests/Foundation/TestNSLock.swift
+++ b/Tests/Foundation/TestNSLock.swift
@@ -127,7 +127,7 @@ class TestNSLock: XCTestCase {
             let thread = Thread {
                 
                 // Some dummy work on countdown.
-                // Add/substract operations are balanced to decrease countdown
+                // Add/subtract operations are balanced to decrease countdown
                 // exactly by countdownPerThread
                 
                 for _ in 0..<countdownPerThread {
@@ -175,7 +175,7 @@ class TestNSLock: XCTestCase {
         countdownValueLock.unlock()
         
         XCTAssertEqual(completedThreadCount, threadCount, "Some threads are still not finished, could be hung")
-        XCTAssertEqual(resultCountdownValue, 0, "Wrong coundtdown means unresolved race conditions, locks broken")
+        XCTAssertEqual(resultCountdownValue, 0, "Wrong countdown means unresolved race conditions, locks broken")
         
         threadCompletedCondition.unlock()
     }

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -36,7 +36,7 @@ class TestNSString: LoopbackServerTest {
                 XCTAssertEqual(text1.length, data.count)
                 XCTAssertEqual(text1, testString as NSString)
             } else {
-                XCTFail("Cant convert Data to NSString")
+                XCTFail("Can't convert Data to NSString")
             }
         }
 
@@ -44,7 +44,7 @@ class TestNSString: LoopbackServerTest {
             XCTAssertEqual(text2.count, data.count)
             XCTAssertEqual(text2, testString)
         } else {
-            XCTFail("Cant convert Data to String")
+            XCTFail("Can't convert Data to String")
         }
 
         // Test multibyte UTF8 and UTF16
@@ -61,7 +61,7 @@ class TestNSString: LoopbackServerTest {
             XCTAssertEqual(kra.utf16.count, 1)
             XCTAssertEqual(kra, utf8kra as String)
         } else {
-            XCTFail("Cant create UTF8 kra")
+            XCTFail("Can't create UTF8 kra")
         }
 
         let utf16KraData = Data([0x1, 0x38])
@@ -73,7 +73,7 @@ class TestNSString: LoopbackServerTest {
             XCTAssertEqual(kra.utf16.count, 1)
             XCTAssertEqual(kra, utf16kra as String)
         } else {
-            XCTFail("Cant create UTF16 kra")
+            XCTFail("Can't create UTF16 kra")
         }
 
         // Test a large string > 255 characters
@@ -87,7 +87,7 @@ class TestNSString: LoopbackServerTest {
             XCTAssertEqual(largeText.length, largeData.count)
             XCTAssertEqual(largeString, largeText as String)
         } else {
-            XCTFail("Cant convert large Data string to String")
+            XCTFail("Can't convert large Data string to String")
         }
     }
 
@@ -354,11 +354,11 @@ class TestNSString: LoopbackServerTest {
         }
 
         guard let zeroFileURL = testBundle().url(forResource: "TestFileWithZeros", withExtension: "txt") else {
-            XCTFail("Cant get URL for TestFileWithZeros.txt")
+            XCTFail("Can't get URL for TestFileWithZeros.txt")
            return
         }
         guard let zeroString = try? String(contentsOf: zeroFileURL, encoding: .utf8) else {
-            XCTFail("Cant create string from \(zeroFileURL)")
+            XCTFail("Can't create string from \(zeroFileURL)")
             return
         }
         XCTAssertEqual(zeroString, "Some\u{00}text\u{00}with\u{00}NUL\u{00}bytes\u{00}instead\u{00}of\u{00}spaces.\u{00}\n")
@@ -1161,10 +1161,10 @@ class TestNSString: LoopbackServerTest {
     }
     
     func test_addingPercentEncodingAndBack() {
-        let latingString = "a b"
-        let escapedLatingString = latingString.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
-        let returnedLatingString = escapedLatingString?.removingPercentEncoding
-        XCTAssertEqual(returnedLatingString, latingString)
+        let latinString = "a b"
+        let escapedLatinString = latinString.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
+        let returnedLatinString = escapedLatinString?.removingPercentEncoding
+        XCTAssertEqual(returnedLatinString, latinString)
         
         let cyrillicString = "\u{0434}\u{043E}\u{043C}"
         let escapedCyrillicString = cyrillicString.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
@@ -1569,8 +1569,8 @@ class TestNSString: LoopbackServerTest {
         // Simplest check. Whole string is one or more
         // paragraphs, so result range should cover it completely.
         let wholeStringRange = NSRange(location: 0, length: nsText.length)
-        let allParagrapsRange = nsText.paragraphRange(for: wholeStringRange)
-        XCTAssertEqual(wholeStringRange, allParagrapsRange)
+        let allParagraphsRange = nsText.paragraphRange(for: wholeStringRange)
+        XCTAssertEqual(wholeStringRange, allParagraphsRange)
 
         // Every paragraph is checked against all possible subranges in it.
         for expectedRange in paragraphRanges {

--- a/Tests/Foundation/TestNotificationQueue.swift
+++ b/Tests/Foundation/TestNotificationQueue.swift
@@ -184,7 +184,7 @@ class TestNotificationQueue : XCTestCase {
     }
 
     func test_notificationQueueLifecycle() {
-        // check that notificationqueue is associated with current thread. when the thread is destroyed, the queue should be deallocated as well
+        // check that notificationQueue is associated with current thread. when the thread is destroyed, the queue should be deallocated as well
         nonisolated(unsafe) weak var notificationQueue: NotificationQueue?
 
         self.executeInBackgroundThread() {

--- a/Tests/Foundation/TestProcess.swift
+++ b/Tests/Foundation/TestProcess.swift
@@ -91,7 +91,7 @@ class TestProcess : XCTestCase {
         do {
             try inputPipe.fileHandleForWriting.write(contentsOf: msg)
         } catch {
-            XCTFail("Cant write to pipe: \(error)")
+            XCTFail("Can't write to pipe: \(error)")
             return
         }
 
@@ -380,11 +380,11 @@ class TestProcess : XCTestCase {
         do {
             try helper.start()
         }  catch {
-            XCTFail("Cant run xdgTestHelper: \(error)")
+            XCTFail("Can't run xdgTestHelper: \(error)")
             return
         }
         if !helper.waitForReady() {
-            XCTFail("Didnt receive Ready from sub-process")
+            XCTFail("Didn't receive Ready from sub-process")
             return
         }
 
@@ -434,11 +434,11 @@ class TestProcess : XCTestCase {
         do {
             try helper.start()
         }  catch {
-            XCTFail("Cant run xdgTestHelper: \(error)")
+            XCTFail("Can't run xdgTestHelper: \(error)")
             return
         }
         if !helper.waitForReady() {
-            XCTFail("Didnt receive Ready from sub-process")
+            XCTFail("Didn't receive Ready from sub-process")
             return
         }
         let now = DispatchTime.now().uptimeNanoseconds

--- a/Tests/Foundation/TestProgress.swift
+++ b/Tests/Foundation/TestProgress.swift
@@ -274,7 +274,7 @@ class TestProgress : XCTestCase {
         child2.completedUnitCount = 5
         XCTAssertEqual(parent.fractionCompleted, ((1.0 / 3.0) / 2.0) * 2.0, accuracy: 0.01)
         
-        // add an implict child
+        // add an implicit child
         parent.becomeCurrent(withPendingUnitCount: 1)
         let child3 = Progress(totalUnitCount: 10)
         parent.resignCurrent()

--- a/Tests/Foundation/TestScanner.swift
+++ b/Tests/Foundation/TestScanner.swift
@@ -139,7 +139,7 @@ class TestScanner : XCTestCase {
             expectEqual($0.scanString("x"), "x", "Consume non-hex-digit")
             expectEqual($0.scanDouble(representation: .hexadecimal), 0x1E00, "E is not for exponent")
             expectEqual($0.scanDouble(), nil, "Dont parse '.' as a Double")
-            expectEqual($0.scanString("."), ".", "Consue '.'")
+            expectEqual($0.scanString("."), ".", "Consume '.'")
             expectEqual($0.scanDouble(representation: .hexadecimal), -11259375.0078125, "negative decimal")
         }
     }
@@ -195,7 +195,7 @@ class TestScanner : XCTestCase {
             expectEqual($0.scanInt32(), -1 as Int32, "Minus one")
             expectEqual($0.scanInt32(), -1 as Int32, "Minus one after whitespace")
             expectEqual($0.scanInt32(), Int32.min, "Min")
-            expectEqual($0.scanInt32(), Int32.max, "Max again after min (no joining it with preceding min even with ignroed whitespace)")
+            expectEqual($0.scanInt32(), Int32.max, "Max again after min (no joining it with preceding min even with ignored whitespace)")
         }
         
         // Overflow:

--- a/Tests/Foundation/TestStream.swift
+++ b/Tests/Foundation/TestStream.swift
@@ -257,7 +257,7 @@ class TestStream : XCTestCase {
         XCTAssertFalse(outputStream.hasSpaceAvailable)
     }
     
-    func test_ouputStreamWithInvalidPath(){
+    func test_outputStreamWithInvalidPath(){
         let outputStream = OutputStream(toFileAtPath: "http:///home/sdsfsdfd", append: true)
         XCTAssertEqual(.notOpen, outputStream!.streamStatus)
         outputStream?.open()

--- a/Tests/Foundation/TestTimeZone.swift
+++ b/Tests/Foundation/TestTimeZone.swift
@@ -188,7 +188,7 @@ class TestTimeZone: XCTestCase {
         let timeZones = TimeZone.knownTimeZoneIdentifiers.sorted()
         XCTAssertTrue(timeZones.count > 0, "No known timezones")
         for tz in timeZones {
-            XCTAssertNotNil(TimeZone(identifier: tz), "Cant instantiate valid timeZone: \(tz)")
+            XCTAssertNotNil(TimeZone(identifier: tz), "Can't instantiate valid timeZone: \(tz)")
         }
     }
 

--- a/Tests/Foundation/TestURL.swift
+++ b/Tests/Foundation/TestURL.swift
@@ -296,7 +296,7 @@ class TestURL : XCTestCase {
             }
 
 #if os(Windows)
-            // On Windows, pipes are valid charcters which can be used
+            // On Windows, pipes are valid characters which can be used
             // to replace a ':'. See RFC 8089 Section E.2.2 for
             // details.
             //

--- a/Tests/Foundation/TestURLCredentialStorage.swift
+++ b/Tests/Foundation/TestURLCredentialStorage.swift
@@ -276,7 +276,7 @@ class TestURLCredentialStorage : XCTestCase {
         let storage = URLCredentialStorage.shared
 
         let credential1 = URLCredential(user: "user1", password: "password1", persistence: .forSession)
-        let credential2 = URLCredential(user: "user1", password: "password1", persistence: .forSession) // intentially equal
+        let credential2 = URLCredential(user: "user1", password: "password1", persistence: .forSession) // intentionally equal
         let space = URLProtectionSpace(host: "example.com", port: 0, protocol: NSURLProtectionSpaceHTTP, realm: nil, authenticationMethod: NSURLAuthenticationMethodDefault)
 
         storage.set(credential1, for: space)

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -531,9 +531,9 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         XCTAssertEqual(task.state, .suspended)
 
         task.resume()                           // 2
-        XCTAssertEqual(task.state, .suspended)  // Darwin reports this as .running even though the task hasnt actually resumed
+        XCTAssertEqual(task.state, .suspended)  // Darwin reports this as .running even though the task hasn't actually resumed
         task.resume()                           // 1
-        XCTAssertEqual(task.state, .suspended)  // Darwin reports this as .running even though the task hasnt actually resumed
+        XCTAssertEqual(task.state, .suspended)  // Darwin reports this as .running even though the task hasn't actually resumed
 
         task.resume()                           // 0 - Task can run
         XCTAssertEqual(task.state, .running)
@@ -572,7 +572,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
     }
     
     // Verify httpAdditionalHeaders from session configuration are added to the request
-    // and whether it is overriden by Request.allHTTPHeaderFields.
+    // and whether it is overridden by Request.allHTTPHeaderFields.
     
     func test_verifyHttpAdditionalHeaders() async {
         let config = URLSessionConfiguration.default
@@ -730,7 +730,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         for method in httpMethods {
             let testMethod = "\(method) request with statusCode \(statusCode)"
             let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/\(statusCode)?location=jsonBody"
-            let url = try XCTUnwrap(URL(string: urlString), "Cant create URL for \(testMethod)")
+            let url = try XCTUnwrap(URL(string: urlString), "Can't create URL for \(testMethod)")
             var request = URLRequest(url: url)
             request.httpMethod = method
             let d = HTTPRedirectionDataTask(with: expectation(description: "\(method) \(urlString): with HTTP redirection"))
@@ -772,7 +772,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
             for method in httpMethods {
                 let testMethod = "\(method) request with statusCode \(statusCode)"
                 let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/\(statusCode)?location=jsonBody"
-                let url = try XCTUnwrap(URL(string: urlString), "Cant create URL for \(testMethod)")
+                let url = try XCTUnwrap(URL(string: urlString), "Can't create URL for \(testMethod)")
                 var request = URLRequest(url: url)
                 request.httpMethod = method
                 let d = HTTPRedirectionDataTask(with: expectation(description: "\(method) \(urlString): with HTTP redirection"))
@@ -819,7 +819,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         for method in httpMethods {
             let testMethod = "\(method) request with statusCode \(statusCode)"
             let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/\(statusCode)?location=jsonBody"
-            let url = try XCTUnwrap(URL(string: urlString), "Cant create URL for \(testMethod)")
+            let url = try XCTUnwrap(URL(string: urlString), "Can't create URL for \(testMethod)")
             var request = URLRequest(url: url)
             request.httpMethod = method
             let d = HTTPRedirectionDataTask(with: expectation(description: "\(method) \(urlString): with HTTP redirection"))
@@ -853,7 +853,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         for method in httpMethods {
             let testMethod = "\(method) request with statusCode \(statusCode)"
             let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/\(statusCode)?location=jsonBody"
-            let url = try XCTUnwrap(URL(string: urlString), "Cant create URL for \(testMethod)")
+            let url = try XCTUnwrap(URL(string: urlString), "Can't create URL for \(testMethod)")
             var request = URLRequest(url: url)
             request.httpMethod = method
             let d = HTTPRedirectionDataTask(with: expectation(description: "\(method) \(urlString): with HTTP redirection"))
@@ -883,7 +883,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
             for method in httpMethods {
                 let testMethod = "\(method) request with statusCode \(statusCode)"
                 let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/\(statusCode)?location=jsonBody"
-                let url = try XCTUnwrap(URL(string: urlString), "Cant create URL for \(testMethod)")
+                let url = try XCTUnwrap(URL(string: urlString), "Can't create URL for \(testMethod)")
                 var request = URLRequest(url: url)
                 request.httpMethod = method
                 let d = HTTPRedirectionDataTask(with: expectation(description: "\(method) \(urlString): with HTTP redirection"))
@@ -928,7 +928,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         for method in httpMethods {
             let testMethod = "\(method) request with statusCode \(statusCode)"
             let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/\(statusCode)?location=jsonBody"
-            let url = try XCTUnwrap(URL(string: urlString), "Cant create URL for \(testMethod)")
+            let url = try XCTUnwrap(URL(string: urlString), "Can't create URL for \(testMethod)")
             var request = URLRequest(url: url)
             request.httpMethod = method
             let delegate = SessionDelegate(with: expectation(description: "\(method) \(urlString): with HTTP redirection"))
@@ -987,7 +987,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         for method in httpMethods {
             let testMethod = "\(method) request with statusCode \(statusCode)"
             let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/\(statusCode)?location=jsonBody"
-            let url = try XCTUnwrap(URL(string: urlString), "Cant create URL for \(testMethod)")
+            let url = try XCTUnwrap(URL(string: urlString), "Can't create URL for \(testMethod)")
             var request = URLRequest(url: url)
             request.httpMethod = method
             let expect = expectation(description: "\(method) \(urlString): with HTTP redirection")

--- a/Tests/Foundation/TestXMLDocument.swift
+++ b/Tests/Foundation/TestXMLDocument.swift
@@ -280,14 +280,14 @@ class TestXMLDocument : LoopbackServerTest {
             XCTAssertEqual(element.attribute(forName: "name")?.stringValue, "John", "name==John")
             XCTAssertEqual(element.attribute(forName: "ns1:name")?.stringValue, "Tom", "ns1:name==Tom")
             XCTAssertEqual(element.attribute(forName: "ns1:age")?.stringValue, "44", "ns1:age==44")
-            XCTAssertEqual(element.attribute(forName: "ns2:address")?.stringValue, "Foobar City", "ns2:addresss==Foobar City")
+            XCTAssertEqual(element.attribute(forName: "ns2:address")?.stringValue, "Foobar City", "ns2:address==Foobar City")
 
             // Retrieve attributes with URI
             XCTAssertEqual(element.attribute(forLocalName: "name", uri: nil)?.stringValue, "John", "name==John")
             XCTAssertEqual(element.attribute(forLocalName: "name", uri: uriNs1)?.stringValue, "Tom", "name==Tom")
             XCTAssertEqual(element.attribute(forLocalName: "age", uri: uriNs1)?.stringValue, "44", "age==44")
             XCTAssertNil(element.attribute(forLocalName: "address", uri: uriNs1), "address==nil")
-            XCTAssertEqual(element.attribute(forLocalName: "address", uri: uriNs2)?.stringValue, "Foobar City", "addresss==Foobar City")
+            XCTAssertEqual(element.attribute(forLocalName: "address", uri: uriNs2)?.stringValue, "Foobar City", "address==Foobar City")
 
             // Overwrite attributes
             element.addAttribute(XMLNode.attribute(withName: "ns1:age", stringValue: "33") as! XMLNode)


### PR DESCRIPTION
This is the promised follow up of #5075.
This is an exhaustive review.

`__CFCheckForExapendedSet` was renamed to `__CFDebugExpandedSet` because the symbol `__CFCheckForExpandedSet` already exists for something else.