### PR TITLE
[wasm] Include `_CFIsMainThread` for WASI platform

### DIFF
--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -306,9 +306,9 @@ const char *_CFProcessPath(void) {
 #endif
 }
 
-#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_BSD
+#if TARGET_OS_MAC || TARGET_OS_WIN32 || TARGET_OS_BSD || TARGET_OS_WASI
 CF_CROSS_PLATFORM_EXPORT Boolean _CFIsMainThread(void) {
-#if defined(__OpenBSD__) || defined(__FreeBSD__)
+#if defined(__OpenBSD__) || defined(__FreeBSD__) || TARGET_OS_WASI
     return pthread_equal(pthread_self(), _CFMainPThread) != 0;
 #else
     return pthread_main_np() == 1;

--- a/Sources/CoreFoundation/CFRuntime.c
+++ b/Sources/CoreFoundation/CFRuntime.c
@@ -1195,8 +1195,6 @@ void __CFInitialize(void) {
 #elif _POSIX_THREADS
         // move this next line up into the #if above after Foundation gets off this symbol. Also: <rdar://problem/39622745> Stop using _CFMainPThread
         _CFMainPThread = pthread_self();
-#elif TARGET_OS_WASI
-        _CFMainPThread = kNilPthreadT;
 #else
 #error Dont know how to get the main thread on this platform
 #endif


### PR DESCRIPTION
Recent wasi-libc versions include pthreads support for both wasm32-wasip1 and wasm32-wasip1-threads targets.