### PR TITLE
[6.3][cherrypick] Ensure strsep operates on a copy of PATH. (#5289)

### DIFF
--- a/Sources/CoreFoundation/CFPlatform.c
+++ b/Sources/CoreFoundation/CFPlatform.c
@@ -266,10 +266,12 @@ const char *_CFProcessPath(void) {
     }
 
     // Search PATH.
-    if (argv0) {
-        char *paths = getenv("PATH");
+    char *path = getenv("PATH");
+    if (argv0 && path) {
+        char *paths = strdup(path);
+        char *remaining = paths;
         char *p = NULL;
-        while ((p = strsep(&paths, ":")) != NULL) {
+        while ((p = strsep(&remaining, ":")) != NULL) {
             char pp[PATH_MAX];
             int l = snprintf(pp, PATH_MAX, "%s/%s", p, argv0);
             if (l >= PATH_MAX) {
@@ -283,11 +285,13 @@ const char *_CFProcessPath(void) {
                 _CFSetProgramNameFromPath(res);
                 free(argv0);
                 free(res);
+                free(paths);
                 return __CFProcessPath;
             }
             free(res);
         }
         free(argv0);
+        free(paths);
     }
 
     // See if the shell will help.


### PR DESCRIPTION
- **Explanation**:

Fix a PATH processing bug when the toolchain is installed on the BSDs.

- **Scope**:

Changes are scoped only to the BSDs, and the bug is only triggered when the program name, i.e., argv[0], is not an absolute or relative path.

- **Issues**:

No issues, but is of relevance to the OpenBSD port in swiftlang/swift#78437

- **Original PRs**:

#5289 

- **Risk**:

Low, this is a bugfix and it is scoped only for the BSDs.

- **Testing**:

Original commit passed CI and original commit tested locally.

- **Reviewers**:

@parkera 
