### PR TITLE
FileHandle: include userInfo in NSFileHandleConnectionAccepted notification

### DIFF
--- a/Sources/Foundation/FileHandle.swift
+++ b/Sources/Foundation/FileHandle.swift
@@ -998,7 +998,6 @@ extension FileHandle {
         NSUnsupported()
 #else
         let owner = monitor(forReading: true, resumed: false) { (handle, source) in
-            var notification = Notification(name: .NSFileHandleConnectionAccepted, object: handle, userInfo: [:])
             let userInfo: [AnyHashable : Any]
             
             let acceptedFD = accept(handle.fileDescriptor, nil, nil)
@@ -1007,14 +1006,14 @@ extension FileHandle {
             } else {
                 userInfo = ["NSFileHandleError": NSNumber(value: errno)]
             }
-            notification.userInfo = userInfo
+            let notification = Notification(name: .NSFileHandleConnectionAccepted, object: handle, userInfo: userInfo)
             
             DispatchQueue.main.async {
                 handle.privateAsyncVariablesLock.lock()
                 handle.currentBackgroundActivityOwner = nil
                 handle.privateAsyncVariablesLock.unlock()
                 
-                NotificationQueue.default.enqueue(Notification(name: .NSFileHandleConnectionAccepted, object: handle, userInfo: [:]), postingStyle: .asap, coalesceMask: .none, forModes: modes)
+                NotificationQueue.default.enqueue(notification, postingStyle: .asap, coalesceMask: .none, forModes: modes)
             }
         }
         


### PR DESCRIPTION
Forward the computed userInfo so that observers receive the payload instead of an empty dictionary.