### PR TITLE
Fix socket lifecycle management

### DIFF
--- a/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
@@ -203,16 +203,11 @@ private extension URLSession._MultiHandle {
             // we should cancel pending work when unregister action is requested.
             precondition(!socketReference.shouldClose, "Socket close was scheduled, but there is some pending work left")
             workItem.perform()
+
+            /// Marks this reference to close socket on deinit. This allows us
+            /// to extend socket lifecycle by keeping the reference alive.
+            socketReference.shouldClose = true
         }
-
-        self.scheduleClose(for: socketReference.socket)
-    }
-
-    /// Marks this reference to close socket on deinit. This allows us
-    /// to extend socket lifecycle by keeping the reference alive.
-    func scheduleClose(for socket: CFURLSession_socket_t) {
-        let reference = socketReferences[socket] ?? _SocketReference(socket: socket)
-        reference.shouldClose = true
     }
 
     /// Schedules work to be performed when an operation ends for the socket,


### PR DESCRIPTION
Motivation:

When an `easy_handle` is added to a `multi_handle`, the callback set for `CURLOPT_CLOSESOCKETFUNCTION` constructs a `_MultiHandle` from an unretained reference to `self`. This could cause a crash in `URLSession` if the `_MultiHandle`'s `self` is deinitialised before the callback is called, and the socket will never be closed.

_Partially resolves #3813_

Modifications:

- Set the `CURLOPT_CLOSESOCKETFUNCTION` callback to do nothing, deferring closing the socket.
- Schedule a socket for closure in the cancellation handler of its dispatch sources.

Result:

Better management of socket lifecycle.

Testing:

Passing existing tests is sufficient.