### PR TITLE
CFTreeRemoveAllChildren should not be guarded for macOS alone

### DIFF
--- a/Sources/CoreFoundation/CFTree.c
+++ b/Sources/CoreFoundation/CFTree.c
@@ -88,9 +88,7 @@ static CFStringRef __CFTreeCopyDescription(CFTypeRef cf) {
 static void __CFTreeDeallocate(CFTypeRef cf) {
     CFTreeRef tree = (CFTreeRef)cf;
     const struct __CFTreeCallBacks *cb;
-#if TARGET_OS_OSX
     CFTreeRemoveAllChildren(tree);
-#endif
     cb = __CFTreeGetCallBacks(tree);
     if (NULL != cb->release) {
         INVOKE_CALLBACK1(cb->release, tree->_info);


### PR DESCRIPTION
Note: Perhaps the corefoundation engineers at Apple Inc should check that this isn't a bug on their other non-macOS platforms as well.