### PR TITLE
Update automergers to 6.3

### DIFF
--- a/.github/workflows/automerge_to_main.yml
+++ b/.github/workflows/automerge_to_main.yml
@@ -13,7 +13,7 @@ jobs:
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
     with:
       base_branch: main
-      head_branch: release/6.2
+      head_branch: release/6.3
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/automerge_to_release.yml
+++ b/.github/workflows/automerge_to_release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Create PR to merge main into release branch
     uses: swiftlang/github-workflows/.github/workflows/create_automerge_pr.yml@main
     with:
-      base_branch: release/6.2
+      base_branch: release/6.3
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Updates the auto mergers to merge to/from `release/6.3` instead of `release/6.2`. Equivalent to this swift-foundation change: https://github.com/swiftlang/swift-foundation/pull/1596