### PR TITLE
Serialize `curl_multi_cleanup` calls for OpenSSL <1.1.0

### DIFF
--- a/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/MultiHandle.swift
@@ -50,11 +50,9 @@ extension URLSession {
         
         // Only use serialization for OpenSSL < 1.1.0 which has race conditions during cleanup
         private static let _needsCleanupSerialization: Bool = {
-            guard let version = CFURLSessionOpenSSLVersionInfo()?.pointee else {
-                // Not OpenSSL, assume thread-safe
-                return false
-            }
-            return version.major < 1 || (version.major == 1 && version.minor < 1)
+            let version = CFURLSessionSSLVersionInfo();
+            let versionNotThreadSafe = version.major < 1 || (version.major == 1 && version.minor < 1)
+            return version.isOpenSSL && versionNotThreadSafe
         }()
 
         // Process-wide cleanup lock

--- a/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
+++ b/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
@@ -676,21 +676,20 @@ CFURLSessionCurlVersion CFURLSessionCurlVersionInfo(void) {
     return v;
 }
 
-// Get version info for OpenSSL (not other SSL libraries.)
-CFURLSessionOpenSSLVersion * _Nullable CFURLSessionOpenSSLVersionInfo(void) {
+CFURLSessionSSLVersion CFURLSessionSSLVersionInfo(void) {
+    CFURLSessionSSLVersion version = {.major = 0, .minor = 0, .patch = 0, .isOpenSSL = false};
     curl_version_info_data *info = curl_version_info(CURLVERSION_NOW);
     if (info && info->ssl_version) {
+        // Parse OpenSSL version string like "OpenSSL/1.0.2k-fips" or "OpenSSL/1.1.1"
         const char *ssl_str = info->ssl_version;
         if (strncmp(ssl_str, "OpenSSL/", 8) == 0) {
-            // Parse OpenSSL version string like "OpenSSL/1.0.2k-fips" or "OpenSSL/1.1.1"
-            static CFURLSessionOpenSSLVersion version = {0, 0, 0};
+            version.isOpenSSL = true;
             ssl_str += 8;  // Skip "OpenSSL/"
             sscanf(ssl_str, "%d.%d.%d", &version.major, &version.minor, &version.patch);
-            return &version;
         }
     }
 
-    return NULL;
+    return version;
 }
 
 

--- a/Sources/_CFURLSessionInterface/include/CFURLSessionInterface.h
+++ b/Sources/_CFURLSessionInterface/include/CFURLSessionInterface.h
@@ -580,12 +580,14 @@ typedef struct CFURLSessionCurlVersion {
 } CFURLSessionCurlVersion;
 CF_EXPORT CFURLSessionCurlVersion CFURLSessionCurlVersionInfo(void);
 
-typedef struct CFURLSessionOpenSSLVersion {
+typedef struct CFURLSessionSSLVersion {
     int major;
     int minor;
     int patch;
-} CFURLSessionOpenSSLVersion;
-CF_EXPORT CFURLSessionOpenSSLVersion * _Nullable CFURLSessionOpenSSLVersionInfo(void);
+    bool isOpenSSL;
+} CFURLSessionSSLVersion;
+
+CF_EXPORT CFURLSessionSSLVersion CFURLSessionSSLVersionInfo(void);
 
 
 CF_EXPORT int const CFURLSessionWriteFuncPause;


### PR DESCRIPTION
Motivation:

`URLSession` elusively crashes due to race conditions in OpenSSL <1.1.0 when calling `curl_multi_cleanup` concurrently on different threads.

Modifications:

- Add `CFURLSessionSSLVersion CFURLSessionSSLVersionInfo(void)` for detecting the OpenSSL version in use.
- Adjust `_MultiHandle.deinit` to use a process-wide lock to serialize `curl_multi_cleanup` calls for environments with OpenSSL <1.1.0.

Result:

Prevents the crash while avoiding unnecessary performance overhead for newer OpenSSL versions which are thread-safe.

Testing:

Passing existing tests is sufficient. However, without this patch, the code snippet below crashes about once in 20 runs on Amazon Linux 2
> $ curl --version
> _curl 8.3.0 (aarch64-koji-linux-gnu) libcurl/8.3.0 OpenSSL/1.0.2k-fips zlib/1.2.7 libidn2/2.3.0 libpsl/0.21.5 (+libidn2/2.3.0) libssh2/1.4.3 nghttp2/1.41.0 OpenLDAP/2.4.44_
> _Release-Date: 2023-09-13_
...
```
DispatchQueue.concurrentPerform(iterations: 100) { _ in
    let session: URLSession = URLSession(configuration: URLSessionConfiguration.default)
    DispatchQueue.concurrentPerform(iterations: 100) { _ in
        _ = session
    }
}
```