### PR TITLE
Check if length is greater than the buffer size, not if it is greater than count.

### DIFF
--- a/Sources/CoreFoundation/CFListFormatter.c
+++ b/Sources/CoreFoundation/CFListFormatter.c
@@ -139,7 +139,7 @@ CFStringRef _CFListFormatterCreateStringByJoiningStrings(CFAllocatorRef allocato
     int32_t length = __cficu_ulistfmt_format(fmt, (const UChar **)ucharStrings, uStringLengths, count, resultBuffer, RESULT_BUFFER_SIZE, &status);
     if (U_SUCCESS(status)) {
         result = CFStringCreateWithCharacters(allocator, resultBuffer, length);
-    } else if (status == U_BUFFER_OVERFLOW_ERROR || length > count) {
+    } else if (status == U_BUFFER_OVERFLOW_ERROR || length > RESULT_BUFFER_SIZE) {
         status = U_ZERO_ERROR;
         UChar *largeBuffer = malloc(sizeof(UChar) * (length + 1));
         length = __cficu_ulistfmt_format(fmt, (const UChar **)ucharStrings, uStringLengths, count, largeBuffer, length + 1, &status);


### PR DESCRIPTION
The ICU function ulistfmt_format returns the required buffer length.
If the required length is greater than the buffer we provided (RESULT_BUFFER_SIZE, which is 768), then truncation occurred (or would occur).

Therefore, the check must be length > RESULT_BUFFER_SIZE.
