### PR TITLE
Use the new count rather than the array itself to determine the new length

### DIFF
--- a/Sources/CoreFoundation/CFApplicationPreferences.c
+++ b/Sources/CoreFoundation/CFApplicationPreferences.c
@@ -664,7 +664,7 @@ void _CFApplicationPreferencesRemoveDomain(_CFApplicationPreferences *self, CFPr
     while ((idx = CFArrayGetFirstIndexOfValue(self->_search, range, domain)) != kCFNotFound) {
         CFArrayRemoveValueAtIndex(self->_search, idx);
         range.location = idx;
-        range.length  = range.length - idx - 1;
+        range.length = CFArrayGetCount(self->_search) - idx;
     }
     updateDictRep(self);
     __CFUnlock(&__CFApplicationPreferencesLock);


### PR DESCRIPTION
If the middle array element is remove for example, this code is wrong.

range.length = range.length - (idx - range.location) - 1; before updating range.location to idx is also a way to do this.