### PR TITLE
[6.3] Fix out-of-bounds access in CFStringGetMostCompatibleMacStringEncoding

### DIFF
--- a/Sources/CoreFoundation/CFStringEncodingDatabase.c
+++ b/Sources/CoreFoundation/CFStringEncodingDatabase.c
@@ -787,7 +787,11 @@ CF_PRIVATE CFStringEncoding __CFStringEncodingGetMostCompatibleMacScript(CFStrin
         case 0x0100: return kCFStringEncodingUnicode; break; // Unicode
 
         case 0x200: // ISO 8859
-            return (((encoding & 0xFF) <= (sizeof(__CFISO8859SimilarScriptList) / sizeof(*__CFISO8859SimilarScriptList))) ? __CFISO8859SimilarScriptList[(encoding & 0xFF) - 1] : kCFStringEncodingInvalidId);
+            encoding &= 0xFF;
+
+            if ((encoding > 0) && (encoding <= (sizeof(__CFISO8859SimilarScriptList) / sizeof(*__CFISO8859SimilarScriptList)))) {
+                return __CFISO8859SimilarScriptList[encoding - 1];
+            }
             break;
 
         default: {
@@ -799,7 +803,7 @@ CF_PRIVATE CFStringEncoding __CFStringEncodingGetMostCompatibleMacScript(CFStrin
             }
         }
     }
-#endif /* TARGET_OS_OSX */
+#endif /* TARGET_OS_OSX || TARGET_OS_LINUX */
 
     return kCFStringEncodingInvalidId;
 }
@@ -821,7 +825,9 @@ CF_PRIVATE const char *__CFStringEncodingGetName(CFStringEncoding encoding) {
     if (0x0200 == (encoding & 0x0F00)) {
         encoding &= 0x00FF;
 
-        if (encoding <= (sizeof(__CFISONameList) / sizeof(*__CFISONameList))) return __CFISONameList[encoding - 1];
+        if ((encoding > 0) && (encoding <= (sizeof(__CFISONameList) / sizeof(*__CFISONameList)))) {
+            return __CFISONameList[encoding - 1];
+        }
     } else {
         CFIndex index = __CFGetEncodingIndex(encoding);
 

--- a/Tests/Foundation/TestCFStringEncoding.swift
+++ b/Tests/Foundation/TestCFStringEncoding.swift
@@ -1,0 +1,27 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2026 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+
+import CoreFoundation
+
+class TestCFStringEncoding: XCTestCase {
+
+    func test_mostCompatibleMacStringEncoding_0x200() {
+        // Regression Test: 0x200 caused buffer underflow and crashed
+        let encoding: CFStringEncoding = 0x0200
+        let result = CFStringGetMostCompatibleMacStringEncoding(encoding) // Do not crash
+        XCTAssertEqual(result, kCFStringEncodingInvalidId)
+    }
+
+    func test_getNameOfEncoding_0x200() {
+        // Regression Test: 0x200 caused buffer underflow
+        let encoding: CFStringEncoding = 0x0200
+        let name = CFStringGetNameOfEncoding(encoding) // Do not crash
+        XCTAssertNil(name)
+    }
+}


### PR DESCRIPTION
Cherry-pick [#5354](https://github.com/swiftlang/swift-corelibs-foundation/pull/5354)

**Explanation**:
Prevent crash when calling CFStringGetMostCompatibleMacStringEncoding with 0x200

This should just return invalidID, but instead indexes at -1.

`__CFStringEncodingGetName` had a similar issue.

**Testing**: New test cases added.

**Author**: @AZero13 

**Reviewed by**: @glessard 
