### PR TITLE
Use correct accessor when accessing bits

### DIFF
--- a/Sources/CoreFoundation/CFCharacterSet.c
+++ b/Sources/CoreFoundation/CFCharacterSet.c
@@ -1822,7 +1822,7 @@ Boolean CFCharacterSetIsCharacterMember(CFCharacterSetRef theSet, UniChar theCha
             break;
             
         case __kCFCharSetClassBitmap:
-            result = (__CFCSetCompactBitmapBits(theSet) ? (__CFCSetIsMemberBitmap(__CFCSetBitmapBits(theSet), theChar) ? true : false) : isInverted);
+            result = (__CFCSetBitmapBits(theSet) ? (__CFCSetIsMemberBitmap(__CFCSetBitmapBits(theSet), theChar) ? true : false) : isInverted);
             break;
             
         case __kCFCharSetClassCompactBitmap:
@@ -1885,7 +1885,7 @@ CF_CROSS_PLATFORM_EXPORT Boolean _CFCharacterSetIsLongCharacterMember(CFCharacte
             break;
 
         case __kCFCharSetClassBitmap:
-            result = (__CFCSetCompactBitmapBits(theSet) ? (__CFCSetIsMemberBitmap(__CFCSetBitmapBits(theSet), theChar) ? true : false) : isInverted);
+            result = (__CFCSetBitmapBits(theSet) ? (__CFCSetIsMemberBitmap(__CFCSetBitmapBits(theSet), theChar) ? true : false) : isInverted);
             break;
 
         case __kCFCharSetClassCompactBitmap:


### PR DESCRIPTION
__kCFCharSetClassBitmap uses the __CFCSetCompactBitmapBits accessor when it should use the __CFCSetBitmapBits accessor.