### PR TITLE
__CFStringEncodingGetMostCompatibleMacScript is mistakenly not allowed on Windows or OpenBSD

### DIFF
--- a/Sources/CoreFoundation/CFStringEncodingDatabase.c
+++ b/Sources/CoreFoundation/CFStringEncodingDatabase.c
@@ -780,7 +780,7 @@ static const char * const __CFOtherNameList[] = {
 #endif /* TARGET_OS_OSX || TARGET_OS_LINUX || TARGET_OS_WIN32 || TARGET_OS_BSD */
 
 CF_PRIVATE CFStringEncoding __CFStringEncodingGetMostCompatibleMacScript(CFStringEncoding encoding) {
-#if TARGET_OS_OSX || TARGET_OS_LINUX
+#if TARGET_OS_OSX || TARGET_OS_LINUX || TARGET_OS_WIN32 || TARGET_OS_BSD
     switch (encoding & 0x0F00) {
         case 0: return encoding & 0xFF; break; // Mac scripts
 
@@ -803,7 +803,7 @@ CF_PRIVATE CFStringEncoding __CFStringEncodingGetMostCompatibleMacScript(CFStrin
             }
         }
     }
-#endif /* TARGET_OS_OSX || TARGET_OS_LINUX */
+#endif /* TARGET_OS_OSX || TARGET_OS_LINUX || TARGET_OS_WIN32 || TARGET_OS_BSD */
 
     return kCFStringEncodingInvalidId;
 }


### PR DESCRIPTION
This is despite __CFStringEncodingGetName being compatible for those platforms too and compiled for it.