### PR TITLE
Move reclaim until after the exchange, not before

### DIFF
--- a/Sources/CoreFoundation/CFRuntime.c
+++ b/Sources/CoreFoundation/CFRuntime.c
@@ -1588,12 +1588,12 @@ static void _CFRelease(CFTypeRef CF_RELEASES_ARGUMENT cf) {
             }
             if (1 == rc) {
                 CFRuntimeClass const *cfClass = __CFRuntimeClassTable[typeID];
-                if ((cfClass->version & _kCFRuntimeResourcefulObject) && cfClass->reclaim != NULL) {
-                    cfClass->reclaim(cf);
-                }
                 newInfo = info | RC_DEALLOCATING_BIT;
                 if (!atomic_compare_exchange_strong(&(((CFRuntimeBase *)cf)->_cfinfoa), &info, newInfo)) {
                     goto again;
+                }
+                if ((cfClass->version & _kCFRuntimeResourcefulObject) && cfClass->reclaim != NULL) {
+                    cfClass->reclaim(cf);
                 }
                 void (*func)(CFTypeRef) = __CFRuntimeClassTable[typeID]->finalize;
                 if (NULL != func) {


### PR DESCRIPTION
The original implementation had a race condition. It called cfClass->reclaim(cf) before atomically setting the RC_DEALLOCATING_BIT.

If another thread retained the object (resurrecting it) while reclaim was running, the reclaim function might destroy internal resources (like file descriptors or auxiliary memory) even though the object survived (its retain count went back up). This would leave the resurrected object in a broken state.

By moving the reclaim call after the atomic_compare_exchange_strong that sets RC_DEALLOCATING_BIT, we ensure that the object is officially transitioning to deallocation before we destroy its resources.