### PR TITLE
Remove dead code in 64-bit overflow protection

### DIFF
--- a/Sources/CoreFoundation/CFRuntime.c
+++ b/Sources/CoreFoundation/CFRuntime.c
@@ -1460,11 +1460,6 @@ static CFTypeRef _CFRetain(CFTypeRef cf, Boolean tryR) {
                 return cf;
             }
             
-            if (__builtin_expect(__CFHighRCFromInfo(info) == ~0U, false)) {
-                // Overflow will occur upon add. Turn into constant CFTypeRef (rc == 0). Retain will do nothing, but neither will release.
-                __CFBitfield64SetValue(newInfo, HIGH_RC_END, HIGH_RC_START, 0);
-            }
-            
             // Increment the retain count and swap into place
             newInfo = info + RC_INCREMENT;
         } while (!atomic_compare_exchange_strong(&(((CFRuntimeBase *)cf)->_cfinfoa), &info, newInfo));


### PR DESCRIPTION
Swap into place if overflow doesn't happen.

__CFBitfield64SetValue call operated on newInfo from a previous loop iteration (or uninitialized on first iteration), not the current info.

Plus, newInfo = info + RC_INCREMENT; was executed unconditionally after the overflow check, overwriting any value set by __CFBitfield64SetValue.