### PR TITLE
Check should be for *bytes, not bytes

### DIFF
--- a/Sources/CoreFoundation/CFFileUtilities.c
+++ b/Sources/CoreFoundation/CFFileUtilities.c
@@ -127,7 +127,7 @@ static Boolean _CFReadBytesFromPathAndGetFD(CFAllocatorRef alloc, const char *pa
             desiredLength = maxLength;
         }
         *bytes = CFAllocatorAllocate(alloc, desiredLength, 0);
-        if (!bytes) {
+        if (!*bytes) {
             close(*fd);
             *fd = -1;
             closeAutoFSNoWait(no_hang_fd);


### PR DESCRIPTION
We need to check if the CFAllocator failed