### PR TITLE
Free stringsPInfo.error

### DIFF
--- a/Sources/CoreFoundation/CFOldStylePList.c
+++ b/Sources/CoreFoundation/CFOldStylePList.c
@@ -754,6 +754,7 @@ CF_PRIVATE CFTypeRef __CFCreateOldStylePropertyListOrStringsFile(CFAllocatorRef 
         CFRelease(plistString);
     }
     if (stringsPInfo.stringSet) { CFRelease(stringsPInfo.stringSet); }
+    if (stringsPInfo.error) { CFRelease(stringsPInfo.error); }
     return result;
 }
 


### PR DESCRIPTION
stringsPInfo.error is leaked. So we should release it.