### PR TITLE
Change MaxCharSize to 4 for Windows

### DIFF
--- a/Sources/CoreFoundation/CFPlatformConverters.c
+++ b/Sources/CoreFoundation/CFPlatformConverters.c
@@ -187,7 +187,7 @@ CF_PRIVATE CFIndex __CFStringEncodingPlatformBytesToUnicode(uint32_t encoding, u
             CPINFO cpInfo;
 
             if (!GetCPInfo(CFStringConvertEncodingToWindowsCodepage(encoding), &cpInfo)) {
-                cpInfo.MaxCharSize = 1; // Is this right ???
+                cpInfo.MaxCharSize = 4; // Is this right ???
             }
             if (cpInfo.MaxCharSize == 1) {
                 numBytes = maxCharLen;


### PR DESCRIPTION
4 is the biggest reasonable size for a string encoding, and is a safer guess.