### PR TITLE
Remove redundant OSMemoryBarrier from CFBundle.c

### DIFF
--- a/Sources/CoreFoundation/CFBundle.c
+++ b/Sources/CoreFoundation/CFBundle.c
@@ -861,12 +861,6 @@ static CFBundleRef _CFBundleCreate(CFAllocatorRef allocator, CFURLRef bundleURL,
     CFDictionaryRef infoDict = CFBundleGetInfoDictionary(bundle);
     CFStringRef bundleID = CFBundleGetIdentifier(bundle);
 
-    // Do this so that we can use the dispatch_once on the ivar of this bundle safely
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
-    OSMemoryBarrier();
-#pragma GCC diagnostic pop
-
     // We cannot add to tables for unique bundles. Return unique bundle results here without heading into the section below where we take a lock.
     if (unique) {
         assert(!addToTables);


### PR DESCRIPTION
When a bundle is unique, it is allocated and initialized on the current thread and returned to the same thread.

Since the pointer isn't published to any other thread, no memory barrier is needed to ensure initialization visibility.

If the bundle is not unique, the code immediately acquires CFBundleGlobalDataLock.

If a user passes the bundle pointer to another thread in a way that leads to races, that is a bug with the user, and their problem.