### PR TITLE
[6.3] Add Android certificate paths to CURL_CA_PATH (#5283)

### DIFF
--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -220,6 +220,25 @@ extension _EasyHandle {
                 try! CFURLSession_easy_setopt_ptr(rawHandle, CFURLSessionOptionCAINFO, caInfo).asError()
             }
             return
+        } else {
+            // default to the standard Android folders, like how it is done at:
+            // https://github.com/apple/swift-nio-ssl/blob/main/Sources/NIOSSL/AndroidCABundle.swift
+            let paths = [
+                "/apex/com.android.conscrypt/cacerts",  // >= Android14
+                "/system/etc/security/cacerts",  // < Android14
+            ]
+
+            for path in paths {
+                var isDirectory: ObjCBool = false
+                if FileManager.default.fileExists(atPath: path,
+                                                  isDirectory: &isDirectory)
+                        && isDirectory.boolValue {
+                    path.withCString { pathPtr in
+                        try! CFURLSession_easy_setopt_ptr(rawHandle, CFURLSessionOptionCAPATH, UnsafeMutablePointer(mutating: pathPtr)).asError()
+                    }
+                    return
+                }
+            }
         }
 #endif
 


### PR DESCRIPTION
Cherry-pick https://github.com/swiftlang/swift-corelibs-foundation/pull/5283

* Add Android certificate paths to CURL_CA_PATH

* Update Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift



---------


(cherry picked from commit 0d60cfae8ff1f55f7bc840be31fd60a33bc76a42)
