### PR TITLE
Revert "Serialize `curl_multi_cleanup` calls for OpenSSL <1.1.0"

### DIFF
--- a/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
+++ b/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
@@ -676,22 +676,6 @@ CFURLSessionCurlVersion CFURLSessionCurlVersionInfo(void) {
     return v;
 }
 
-CFURLSessionSSLVersion CFURLSessionSSLVersionInfo(void) {
-    CFURLSessionSSLVersion version = {.major = 0, .minor = 0, .patch = 0, .isOpenSSL = false};
-    curl_version_info_data *info = curl_version_info(CURLVERSION_NOW);
-    if (info && info->ssl_version) {
-        // Parse OpenSSL version string like "OpenSSL/1.0.2k-fips" or "OpenSSL/1.1.1"
-        const char *ssl_str = info->ssl_version;
-        if (strncmp(ssl_str, "OpenSSL/", 8) == 0) {
-            version.isOpenSSL = true;
-            ssl_str += 8;  // Skip "OpenSSL/"
-            sscanf(ssl_str, "%d.%d.%d", &version.major, &version.minor, &version.patch);
-        }
-    }
-
-    return version;
-}
-
 
 int const CFURLSessionWriteFuncPause = CURL_WRITEFUNC_PAUSE;
 int const CFURLSessionReadFuncPause = CURL_READFUNC_PAUSE;

--- a/Sources/_CFURLSessionInterface/include/CFURLSessionInterface.h
+++ b/Sources/_CFURLSessionInterface/include/CFURLSessionInterface.h
@@ -580,15 +580,6 @@ typedef struct CFURLSessionCurlVersion {
 } CFURLSessionCurlVersion;
 CF_EXPORT CFURLSessionCurlVersion CFURLSessionCurlVersionInfo(void);
 
-typedef struct CFURLSessionSSLVersion {
-    int major;
-    int minor;
-    int patch;
-    bool isOpenSSL;
-} CFURLSessionSSLVersion;
-
-CF_EXPORT CFURLSessionSSLVersion CFURLSessionSSLVersionInfo(void);
-
 
 CF_EXPORT int const CFURLSessionWriteFuncPause;
 CF_EXPORT int const CFURLSessionReadFuncPause;


### PR DESCRIPTION
Reverts swiftlang/swift-corelibs-foundation#5321

This *may* have impacted SwiftPM tests, which is preventing toolchain delivery.

I'm running cross-repo testing in https://github.com/swiftlang/swift-package-manager/pull/9605