### PR TITLE
Check that CFAllocatorAllocate works before operating on bytes

### DIFF
--- a/Sources/CoreFoundation/CFData.c
+++ b/Sources/CoreFoundation/CFData.c
@@ -282,7 +282,7 @@ static void *__CFDataAllocate(CFDataRef data, CFIndex size, Boolean clear) {
     if (__CFDataUseAllocator(data)) {
 	CFAllocatorRef allocator = __CFGetAllocator(data);
 	bytes = CFAllocatorAllocate(allocator, size, 0);
-	if (clear) memset((uint8_t *)bytes, 0, size);
+	if (clear && bytes != NULL) memset(bytes, 0, size);
     } else {
         if (clear) {
             bytes = calloc(1, size);


### PR DESCRIPTION
Otherwise we get a NULL deref