### PR TITLE
Fix file descriptor check in fileFinalize

### DIFF
--- a/Sources/CoreFoundation/CFBundle.c
+++ b/Sources/CoreFoundation/CFBundle.c
@@ -234,7 +234,7 @@ CF_PRIVATE CFURLRef _CFURLCreateResolvedDirectoryWithString(CFAllocatorRef alloc
     CFRelease(absolutePath);
     if (success) {
         int fd = open(absolutePathCString, O_RDONLY);
-        if (fd > 0) {
+        if (fd >= 0) {
             char resolvedPathCString[PATH_MAX];
             if (_CFGetPathFromFileDescriptor(fd, resolvedPathCString)) {
                 os_log_error(_CFBundleResourceLogger(), "Unable to resolve directory (%d)", errno);
@@ -735,7 +735,7 @@ static Boolean _CFBundlesHaveEquivalentURL(CFBundleRef b1, CFBundleRef b2) {
         int fd1 = open(path1CString, O_RDONLY);
         int fd2 = open(path2CString, O_RDONLY);
 
-        if (fd1 > 0 && fd2 > 0) {
+        if (fd1 >= 0 && fd2 >= 0) {
             struct stat statbuf1;
             struct stat statbuf2;
             
@@ -748,8 +748,8 @@ static Boolean _CFBundlesHaveEquivalentURL(CFBundleRef b1, CFBundleRef b2) {
             }
         }
         
-        if (fd1 > 0) close(fd1);
-        if (fd2 > 0) close(fd2);
+        if (fd1 >= 0) close(fd1);
+        if (fd2 >= 0) close(fd2);
     }
     
     return result;

--- a/Sources/CoreFoundation/CFBundle_Resources.c
+++ b/Sources/CoreFoundation/CFBundle_Resources.c
@@ -405,7 +405,7 @@ CF_PRIVATE _CFBundleVersion _CFBundleGetBundleVersionForURL(CFURLRef url) {
                 int resolvedBundlePathFd = open(bundlePathCString, O_RDONLY);
 #endif
                 
-                if (resolvedWrappedBundleFd > 0 && resolvedBundlePathFd > 0) {
+                if (resolvedWrappedBundleFd >= 0 && resolvedBundlePathFd >= 0) {
                     char resolvedWrappedBundlePath[PATH_MAX];
                     char resolvedBundlePath[PATH_MAX];
                     
@@ -420,8 +420,8 @@ CF_PRIVATE _CFBundleVersion _CFBundleGetBundleVersionForURL(CFURLRef url) {
                     
                 }
                 
-                if (resolvedWrappedBundleFd > 0) close(resolvedWrappedBundleFd);
-                if (resolvedBundlePathFd > 0) close(resolvedBundlePathFd);
+                if (resolvedWrappedBundleFd >= 0) close(resolvedWrappedBundleFd);
+                if (resolvedBundlePathFd >= 0) close(resolvedBundlePathFd);
                 
                 if (!subdirectoryCheckOk) {
                     os_log_error(_CFBundleResourceLogger(), "`WrappedBundle` link invalid or pointed outside bundle at %{public}@", url);

--- a/Sources/CoreFoundation/CFConcreteStreams.c
+++ b/Sources/CoreFoundation/CFConcreteStreams.c
@@ -42,7 +42,7 @@ typedef struct {
     union {
         CFFileDescriptorRef cffd;	// ref created once we open and have an fd
         CFMutableArrayRef rlArray;	// scheduling information prior to open
-    } rlInfo; // If fd > 0, cffd exists.  Otherwise, rlArray.
+    } rlInfo; // If fd >= 0, cffd exists.  Otherwise, rlArray.
 #else
     uint16_t scheduled;	// ref count of how many times we've been scheduled
 #endif
@@ -387,7 +387,7 @@ static void fileSchedule(struct _CFStream *stream, CFRunLoopRef runLoop, CFStrin
     }
 #else
     fileStream->scheduled++;
-    if (fileStream->scheduled == 1 && fileStream->fd > 0 && status == kCFStreamStatusOpen) {
+    if (fileStream->scheduled == 1 && fileStream->fd >= 0 && status == kCFStreamStatusOpen) {
         if (isReadStream)
             CFReadStreamSignalEvent((CFReadStreamRef)stream, kCFStreamEventHasBytesAvailable, NULL);
         else
@@ -520,7 +520,7 @@ static void *fileCreate(struct _CFStream *stream, void *info) {
 
 static void	fileFinalize(struct _CFStream *stream, void *info) {
     _CFFileStreamContext *ctxt = (_CFFileStreamContext *)info;
-    if (ctxt->fd > 0) {
+    if (ctxt->fd >= 0) {
 #ifdef REAL_FILE_SCHEDULING
         if (ctxt->rlInfo.cffd) {
             CFFileDescriptorInvalidate(ctxt->rlInfo.cffd); 

--- a/Sources/CoreFoundation/CFString.c
+++ b/Sources/CoreFoundation/CFString.c
@@ -93,7 +93,7 @@ static void __CFRecordStringAllocationEvent(const char *encoding, const char *by
         } else {
             snprintf(path, sizeof(path), "%s/CFSharedStringInstrumentation_%s_%d.txt", temp_dir, name, getpid());
             fd = open(path, O_WRONLY | O_APPEND | O_CREAT, 0666);
-            if (fd <= 0) {
+            if (fd < 0) {
                 int error = errno;
                 const char *errString = strerror(error);
                 fprintf(stderr, "open() failed with error %d (%s)\n", error, errString);
@@ -101,7 +101,7 @@ static void __CFRecordStringAllocationEvent(const char *encoding, const char *by
         }
     });
 
-    if (fd > 0) {
+    if (fd >= 0) {
 	char *buffer = NULL;
 	char formatString[256];
 	snprintf(formatString, sizeof(formatString), "%%-8d\t%%-16s\t%%.%lds\n", byteCount);


### PR DESCRIPTION
Change file descriptor check from 'fd > 0' to 'fd >= 0' in fileFinalize to ensure file descriptors with value 0 are also properly handled.