### PR TITLE
Check that bytes is not null before memset

### DIFF
--- a/Sources/CoreFoundation/CFData.c
+++ b/Sources/CoreFoundation/CFData.c
@@ -282,7 +282,7 @@ static void *__CFDataAllocate(CFDataRef data, CFIndex size, Boolean clear) {
     if (__CFDataUseAllocator(data)) {
 	CFAllocatorRef allocator = __CFGetAllocator(data);
 	bytes = CFAllocatorAllocate(allocator, size, 0);
-	if (clear) memset((uint8_t *)bytes, 0, size);
+	if (bytes && clear) memset(bytes, 0, size);
     } else {
         if (clear) {
             bytes = calloc(1, size);


### PR DESCRIPTION
Otherwise, we get NULL deref