### PR TITLE
[CMake] Remove override of CMAKE_C_COMPILER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,6 @@ if(POLICY CMP0157)
     endif()
 endif()
 
-if (NOT DEFINED CMAKE_C_COMPILER)
-    set(CMAKE_C_COMPILER clang)
-endif()
-
 project(Foundation
     LANGUAGES C Swift)
 


### PR DESCRIPTION
CMake is supposed to determine the value of `CMAKE_<LANG>_Compiler` when a `project` requires the given language. It is a this point that CMake loads `CMAKE_TOOLCHAIN_FILE` (if provided) which is supposed to set `CMAKE_<LANG>_COMPILER`. Otherwise CMake will try to determine the compiler depending on the system. Overriding `CMAKE_C_COMPILER` before `project` is invoked, and giving it a value of `clang` would not allow setups that try to use `CMAKE_TOOLCHAIN_FILE` to work, and will always use `clang` from the `$PATH`, which in some environments might not exist when doing hermetic builds.

The problem was introduced in #4959 a couple of years ago, but it did not exist in the previous CMake file used before `swift-foundation` was integrated.