### PR TITLE
`NSStringFromClass` optimized: replaced `String(reflecting:)` with `_typeName`

### DIFF
--- a/Sources/Foundation/NSObjCRuntime.swift
+++ b/Sources/Foundation/NSObjCRuntime.swift
@@ -355,7 +355,7 @@ fileprivate let mapFromObjCNameToClass: [String: AnyClass] = {
 fileprivate let mapFromSwiftClassNameToObjCName: [String: String] = {
     var map: [String: String] = [:]
     for entry in _NSClassesRenamedByObjCAPINotes {
-        map[String(reflecting: entry.class)] = entry.objCName
+        map[_typeName(entry.class, qualified: true)] = entry.objCName
     }
     return map
 }()
@@ -378,7 +378,7 @@ internal let _SwiftFoundationXMLModuleName = _SwiftFoundationModuleName + "XML"
     neither stable nor human-readable.
  */
 public func NSStringFromClass(_ aClass: AnyClass) -> String {
-    let classNameString = String(reflecting: aClass)
+    let classNameString = _typeName(aClass, qualified: true)
     if let renamed = mapFromSwiftClassNameToObjCName[classNameString] {
         return renamed
     }


### PR DESCRIPTION
`NSStringFromClass` optimized by replacing `String(reflecting:)` with `_typeName`

### Motivation:

Optimizing `NSStringFromClass`.

### Modifications:

I've replaced heavy `String(reflecting:)` call with `_typeName` function. It's valid because `String(reflecting:)` eventually calls `_typeName` function

### Result:

`NSStringFromClass` will work much faster.

### Testing:

Tested locally. Basically, testing is not needed because calls are equivalent and there are unit-tests in `TestObjCRuntime.swift`. The same change was made here: https://github.com/swiftlang/swift/pull/77369
