### PR TITLE
Add UnitFrequency.framesPerSecond

### DIFF
--- a/Sources/Foundation/Unit.swift
+++ b/Sources/Foundation/Unit.swift
@@ -1091,25 +1091,27 @@ public final class UnitFrequency : Dimension, @unchecked Sendable {
      */
     
     private struct Symbol {
-        static let terahertz    = "THz"
-        static let gigahertz    = "GHz"
-        static let megahertz    = "MHz"
-        static let kilohertz    = "kHz"
-        static let hertz        = "Hz"
-        static let millihertz   = "mHz"
-        static let microhertz   = "µHz"
-        static let nanohertz    = "nHz"
+        static let terahertz       = "THz"
+        static let gigahertz       = "GHz"
+        static let megahertz       = "MHz"
+        static let kilohertz       = "kHz"
+        static let hertz           = "Hz"
+        static let millihertz      = "mHz"
+        static let microhertz      = "µHz"
+        static let nanohertz       = "nHz"
+        static let framesPerSecond = "fps"
     }
     
     private struct Coefficient {
-        static let terahertz    = 1e12
-        static let gigahertz    = 1e9
-        static let megahertz    = 1e6
-        static let kilohertz    = 1e3
-        static let hertz        = 1.0
-        static let millihertz   = 1e-3
-        static let microhertz   = 1e-6
-        static let nanohertz    = 1e-9
+        static let terahertz       = 1e12
+        static let gigahertz       = 1e9
+        static let megahertz       = 1e6
+        static let kilohertz       = 1e3
+        static let hertz           = 1.0
+        static let millihertz      = 1e-3
+        static let microhertz      = 1e-6
+        static let nanohertz       = 1e-9
+        static let framesPerSecond = 1.0
     }
     
     private convenience init(symbol: String, coefficient: Double) {
@@ -1163,7 +1165,13 @@ public final class UnitFrequency : Dimension, @unchecked Sendable {
             return UnitFrequency(symbol: Symbol.nanohertz, coefficient: Coefficient.nanohertz)
         }
     }
-    
+
+    public class var framesPerSecond: UnitFrequency {
+        get {
+            return UnitFrequency(symbol: Symbol.framesPerSecond, coefficient: Coefficient.framesPerSecond)
+        }
+    }
+
     public override class func baseUnit() -> UnitFrequency {
         return .hertz
     }

--- a/Tests/Foundation/TestUnitConverter.swift
+++ b/Tests/Foundation/TestUnitConverter.swift
@@ -142,7 +142,8 @@ class TestUnitConverter: XCTestCase {
         XCTAssertEqual(testIdentity(UnitFrequency.millihertz), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitFrequency.microhertz), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitFrequency.nanohertz), 1, accuracy: delta)
-        
+        XCTAssertEqual(testIdentity(UnitFrequency.framesPerSecond), 1, accuracy: delta)
+
         XCTAssertEqual(testIdentity(UnitFuelEfficiency.litersPer100Kilometers), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitFuelEfficiency.milesPerImperialGallon), 1, accuracy: delta)
         XCTAssertEqual(testIdentity(UnitFuelEfficiency.milesPerGallon), 1, accuracy: delta)


### PR DESCRIPTION
_Add `UnitFrequency.framesPerSecond` class property to match Apple's Foundation_

### Motivation:

`UnitFrequency.framesPerSecond` was introduced in Apple's Foundation in iOS 13 / macOS 10.15 but is missing from swift-corelibs-foundation. This is the last remaining gap from the WWDC19 unit additions. ref: #4619.

[UnitFrequency.framesPerSecond](https://developer.apple.com/documentation/foundation/unitfrequency/framespersecond)

### Modifications:

- Added `framesPerSecond` symbol (`"fps"`) and coefficient (`1.0`) to the private `Symbol` and `Coefficient` structs in `UnitFrequency`
- Added `public class var framesPerSecond: UnitFrequency` property
- Added bijectivity test in `TestUnitConverter`

### Result:

`UnitFrequency.framesPerSecond` is now available in swift-corelibs-foundation, matching the Apple Foundation API.

### Testing:

- Added `testIdentity(UnitFrequency.framesPerSecond)` assertion in `TestUnitConverter`