### PR TITLE
Fix deadlock with URLSessionTask cancellation

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -379,7 +379,10 @@ open class URLSessionTask : NSObject, NSCopying, @unchecked Sendable {
      * cancellation.  -cancel may be sent to a task that has been suspended.
      */
     open func cancel() {
-        workQueue.sync {
+        // We must asynchronously perform the cancellation on the dispatch
+        // queue to avoid a deadlock. See the full explanation for why in
+        // https://github.com/swiftlang/swift-corelibs-foundation/issues/5412
+        workQueue.async {
             let canceled = self.syncQ.sync { () -> Bool in
                 guard self._state == .running || self._state == .suspended else { return true }
                 self._state = .canceling


### PR DESCRIPTION
Fix a deadlock that occurs between a thread cancelling a `URLSession.data()` task and a network thread processing the task completion.

### Motivation:

As described in issue #5412, running `URLSession.data()` on a non-existent URL in a task and then canceling that task shortly after may cause a deadlock.

The deadlock is due to a lock-ordering inversion problem:
* The thread processing the cancellation holds an internal task lock and then tries to lock on the WorkQueue (to mark the task as cancelled).
* The thread processing the socket failure locks on the WorkQueue and then tries to acquire the internal task lock (to schedule the task to run).

<details>
<summary>More explanation</summary>

For a thread A and B, the deadlock occurs with the following sequence of events:

`requestTask` -> the task awaiting on `URLSession.data(..)`

Thread A
```
1. cancel requestTask
2. withStatusRecordLock(requestTask) <---- Lock 1
3. run the requestTask cancellation handler
4. URLSessionTask.cancel()
5. workQueue.sync { ... } <---- Lock 2
```

Thread B
```
1. <socket failure>
2. workQueue executes socket handler <---- Lock 2
3. process socket failure
4. unblock requestTask via continuation.resume
5. schedule requestTask on executor
6. withStatusRecordLock(requestTask) <---- Lock 1
```

</details>

### Modifications:

To break this deadlock, the cancellation handler should not lock on the work queue via `workQueue.sync { ... }`.

Acquiring a lock from within a cancellation handler is a delicate operation that can cause deadlocks. The documentation of [withTaskCancellationHandler](https://developer.apple.com/documentation/swift/withtaskcancellationhandler(operation:oncancel:isolation:)#Cancellation-handlers-and-locks) has more to say about this.

To fix this issue, we change the `workQueue.sync { ... }` call to `workQueue.async { ... }` in `URLSessionTask.cancel()`.

### Result:

This PR fixes #5412 . This change will make the cancellation of the task an asynchronous operation that will be scheduled in the future by the dispatch executor, hence avoiding the deadlock.

### Testing:

The repro program described in issue #5412 no longer fails after this fix.