### PR TITLE
[6.3] [wasm] Enable `NSURLDirectoryEnumerator` on WASI

### DIFF
--- a/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
@@ -37,7 +37,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define _CRT_NONSTDC_NO_DEPRECATE
 #include <Windows.h>
-#elif !TARGET_OS_WASI
+#else
 #include <fts.h>
 #endif
 #if __has_include(<unistd.h>)

--- a/Sources/Foundation/FileManager+POSIX.swift
+++ b/Sources/Foundation/FileManager+POSIX.swift
@@ -311,26 +311,6 @@ extension FileManager {
         return temp._bridgeToObjectiveC().appendingPathComponent(dest)
     }
 
-    #if os(WASI)
-    // For platforms that don't support FTS, we just throw an error for now.
-    // TODO: Provide readdir(2) based implementation here or FTS in wasi-libc?
-    internal class NSURLDirectoryEnumerator : DirectoryEnumerator {
-        var _url : URL
-        var _errorHandler : ((URL, Error) -> Bool)?
-
-        init(url: URL, options: FileManager.DirectoryEnumerationOptions, errorHandler: ((URL, Error) -> Bool)?) {
-            _url = url
-            _errorHandler = errorHandler
-        }
-
-        override func nextObject() -> Any? {
-            if let handler = _errorHandler {
-                _ = handler(_url, _NSErrorWithErrno(ENOTSUP, reading: true, url: _url))
-            }
-            return nil
-        }
-    }
-    #else
     internal class NSURLDirectoryEnumerator : DirectoryEnumerator {
         var _url : URL
         var _options : FileManager.DirectoryEnumerationOptions
@@ -464,7 +444,6 @@ extension FileManager {
             return nil
         }
     }
-    #endif
 
     internal func _updateTimes(atPath path: String, withFileSystemRepresentation fsr: UnsafePointer<Int8>, creationTime: Date? = nil, accessTime: Date? = nil, modificationTime: Date? = nil) throws {
         let stat = try _lstatFile(atPath: path, withFileSystemRepresentation: fsr)


### PR DESCRIPTION
- **Explanation**:
  FTS has been supported since wasi-libc 25, and swiftlang/swift release/6.3 branch already uses the greater version of wasi-libc than 25. So we can use the proper `NSURLDirectoryEnumerator` on WASI as well.
- **Scope**:
  Only affects WASI.
- **Issues**:
  - https://github.com/swiftlang/swift-corelibs-foundation/issues/5420
- **Original PRs**:
  - swiftlang/swift-corelibs-foundation#5418
- **Risk**:
  Low because this only affects WASI.
- **Testing**:
  Same as swiftlang/swift-corelibs-foundation#5418's testing.
- **Reviewers**:
  @kateinoigakukun, @MaxDesiatov