### PR TITLE
build: support building for Windows with the GNU driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,21 +193,21 @@ list(APPEND _Foundation_common_build_flags
     "-Wno-switch"
     "-fblocks")
 
-if(NOT "${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC")
-    list(APPEND _Foundation_common_build_flags
-        "-fconstant-cfstrings"
-        "-fdollars-in-identifiers"
-        "-fno-common"
-        "-fcf-runtime-abi=swift")
-
-    if(NOT CMAKE_SYSTEM_NAME STREQUAL OpenBSD)
-        list(APPEND _Foundation_common_build_flags
-            "-fexceptions")
-    endif()
+if(MSVC)
+  list(APPEND _Foundation_common_build_flags
+      "/EHsc"
+      "/clang:-fcf-runtime-abi=swift")
 else()
-    list(APPEND _Foundation_common_build_flags
-        "/EHsc"
-        "/clang:-fcf-runtime-abi=swift")
+  list(APPEND _Foundation_common_build_flags
+      "-fconstant-cfstrings"
+      "-fdollars-in-identifiers"
+      "-fno-common"
+      "-fcf-runtime-abi=swift")
+
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL OpenBSD)
+      list(APPEND _Foundation_common_build_flags
+          "-fexceptions")
+  endif()
 endif()
 
 set(CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH ON)


### PR DESCRIPTION
Adjust the flag handling to accommodate the GNU driver and the cl driver on Windows. This unblocks work towards supporting the LLVM CAS on Windows.