### PR TITLE
build: add a shim for WASI detection on older CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,13 @@ endif()
 project(Foundation
     LANGUAGES C Swift)
 
+if(CMAKE_VERSION VERSION_LESS 3.31)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Generic" AND CMAKE_SYSTEM_PROCESSOR MATCHES "wasm32")
+    set(CMAKE_SYSTEM_NAME WASI)
+    set(WASI 1)
+  endif()
+endif()
+
 option(FOUNDATION_SWIFTPM_DEPS "build Windows SwiftPM dependencies via CMake" NO)
 if(FOUNDATION_SWIFTPM_DEPS)
     include(WindowsSwiftPMDependencies)
@@ -75,7 +82,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 set(FOUNDATION_BUILD_NETWORKING_default ON)
-if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
+if(WASI)
     # Networking is not supported on WASI
     set(FOUNDATION_BUILD_NETWORKING_default OFF)
 endif()
@@ -150,7 +157,7 @@ endif()
 # System dependencies
 
 # We know libdispatch is always unavailable on WASI
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "WASI")
+if(NOT WASI)
     find_package(LibRT)
     find_package(dispatch CONFIG)
     if(NOT dispatch_FOUND)
@@ -229,7 +236,7 @@ list(APPEND _Foundation_swift_build_flags
     "-Xfrontend"
     "-require-explicit-sendable")
 
-if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
+  if(WASI)
     # Enable wasi-libc emulation features
     set(WASI_EMULATION_DEFS _WASI_EMULATED_MMAN _WASI_EMULATED_SIGNAL _WASI_EMULATED_PROCESS_CLOCKS)
     foreach(def ${WASI_EMULATION_DEFS})

--- a/Sources/CoreFoundation/CMakeLists.txt
+++ b/Sources/CoreFoundation/CMakeLists.txt
@@ -120,7 +120,7 @@ target_link_libraries(CoreFoundation
         _FoundationICU
         dispatch)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
+if(WASI)
     # On WASI, we use vendored BlocksRuntime instead of the one from libdispatch
     add_subdirectory(BlockRuntime)
     # Add BlocksRuntime object library to CoreFoundation static archive

--- a/Sources/_CFXMLInterface/CMakeLists.txt
+++ b/Sources/_CFXMLInterface/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(_CFXMLInterface PRIVATE
     dispatch
     LibXml2::LibXml2)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
+if(WASI)
     target_link_libraries(_CFXMLInterface PRIVATE BlocksRuntime)
 endif()
 


### PR DESCRIPTION
WASI was introduced into CMake as a platform in 3.31. For older CMake versions, we add a shim to allow cleanly supporting this platform.