### PR TITLE
use default CURL_BUFFERSIZE (CURL_MAX_READ_SIZE typically 10MB).

### DIFF
--- a/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
@@ -70,7 +70,6 @@ internal class _FTPURLProtocol: _NativeProtocol {
             failWith(error: nsError, request: request)
             return
         }
-        easyHandle.set(preferredReceiveBufferSize: Int.max)
         do {
             switch (body, try body.getBodyLength()) {
             case (.none, _):

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -329,7 +329,6 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         let _config = session._configuration
         easyHandle.set(sessionConfig: _config)
         easyHandle.setAllowedProtocolsToHTTPAndHTTPS()
-        easyHandle.set(preferredReceiveBufferSize: Int.max)
         do {
             switch (body, try body.getBodyLength()) {
             case (.none, _):


### PR DESCRIPTION
stop explicitly setting the receive buffer size so we get the default value which is safe and won't crash.

closes #5445


### Motivation:

The current code uses `Int.max` which is out of bounds for what libcurl allows so this call always crashes.

### Modifications:

Removed the calls to set the size.

### Result:

The default buffer size will be used (typically 10MB, but can be changed at configure time of building libcurl)

### Testing:

None yet, I need a refresher on how to test foundation networking builds.
