### PR TITLE
Actually use renameat2 for renaming when it's available

### DIFF
--- a/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
+++ b/Sources/CoreFoundation/include/ForSwiftFoundationOnly.h
@@ -90,10 +90,12 @@
 #include <termios.h>
 #include <fcntl.h>
 
+// Required for statx + renameat2 wrappers
+#include <sys/syscall.h>
+
 #ifdef __GLIBC_PREREQ
 #if __GLIBC_PREREQ(2, 28) == 0
 // required for statx() system call, glibc >=2.28 wraps the kernel function
-#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <linux/stat.h>
@@ -536,7 +538,7 @@ static inline unsigned int _dev_minor(dev_t rdev) {
 
 
 #if TARGET_OS_LINUX
-#ifdef __NR_statx
+#if defined(__NR_statx) && defined(_GNU_SOURCE)
 
 // There is no glibc statx() function, it must be called using syscall().
 


### PR DESCRIPTION
Correct definition if `_CFHasRenameat2` to actually detect the presence of renameat2 on Ubuntu, among others.

As discussed on https://github.com/swiftlang/swift-corelibs-foundation/pull/5443.

I figured this is a good fix without opening the bucket of worms which is defining `_GNU_SOURCE` for everything and fixing all the STATX issues.

My only real question about this code: is there CI coverage for both these paths or are all the CI runners Linux-with-sufficiently-new-kernel to use renameat2?

### Motivation:

As discussed in this comment thread ( https://github.com/swiftlang/swift-corelibs-foundation/pull/5443#discussion_r3012721709 ) renameat2 + `RENAME_EXCHANGE` gives us atomic file replacement, which is definitely nice to have.

### Modifications:

- Move `<sys/syscall.h>` include.
  - renameat2 support was all wired up, but we weren't using this code path on Ubuntu (at least) because `<sys/syscall.h>` wasn't included before the test for `SYS_renameat2`, causing `_CFHasRenameat2` to always be false. 
  - Fixing this causes some other STATX code to compile which didn't before. That code needs `_GNU_SOURCE` defined, so I've tweaked the compilation condition on that to specify the `_GNU_SOURCE` requirement.

### Result:

We now use renameat2 for atomic file replacement on Linux kernels where renameat2 is supported.

fixes https://github.com/swiftlang/swift-corelibs-foundation/issues/5451

### Testing:

I have tested this commit on top of #5443 before rebasing onto main using the `swift:6.3.0-noble` docker image. Unfortunately I haven't been able to test since rebasing because that Docker image can't build main anymore & neither can `swiftlang/swift:nightly-noble`.