### PR TITLE
Fix URLSessionTask hanging on 401 when no credentials are available

### DIFF
--- a/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
+++ b/Sources/FoundationNetworking/URLSession/URLSessionTask.swift
@@ -1139,6 +1139,10 @@ extension _ProtocolClient : URLProtocolClient {
             }
         }
         
+        completeTask(urlProtocol: urlProtocol, task: task, session: session)
+    }
+
+    private func completeTask(urlProtocol: URLProtocol, task: URLSessionTask, session: URLSession) {
         if let storage = session.configuration.urlCredentialStorage,
            let last = task._protocolLock.performLocked({ task._lastCredentialUsedFromStorageDuringAuthentication }) {
             storage.set(last.credential, for: last.protectionSpace, task: task)
@@ -1264,6 +1268,7 @@ extension _ProtocolClient : URLProtocolClient {
             task.resume()
         }
         
+        nonisolated(unsafe) let nonisolatedURLProtocol = `protocol`
         @Sendable func attemptProceedingWithDefaultCredential() {
             if let credential = challenge.proposedCredential {
                 let last = task._protocolLock.performLocked { task._lastCredentialUsedFromStorageDuringAuthentication }
@@ -1271,8 +1276,10 @@ extension _ProtocolClient : URLProtocolClient {
                 if last?.credential != credential {
                     proceed(using: credential)
                 } else {
-                    task.cancel()
+                    self.completeTask(urlProtocol: nonisolatedURLProtocol, task: task, session: session)
                 }
+            } else {
+                self.completeTask(urlProtocol: nonisolatedURLProtocol, task: task, session: session)
             }
         }
         

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -1781,6 +1781,25 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         waitForExpectations(timeout: 12, handler: nil)
     }
 
+    // Regression test: when a server returns 401 with a WWW-Authenticate challenge header and
+    // the client has no credentials to offer, the task should complete with the 401 response
+    // rather than hanging indefinitely.
+    func test_basicAuthChallenge_whenNoCredentialsAvailable_completesWithResponse() async {
+        let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/auth/basic"
+        let url = URL(string: urlString)!
+        let config = URLSessionConfiguration.default
+        config.urlCredentialStorage = nil
+        let expect = expectation(description: "GET \(urlString): 401 with no credentials should complete")
+        let session = URLSession(configuration: config)
+        let task = session.dataTask(with: url) { _, response, error in
+            defer { expect.fulfill() }
+            XCTAssertNil(error)
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 401)
+        }
+        task.resume()
+        waitForExpectations(timeout: 12, handler: nil)
+    }
+
     func test_checkErrorTypeAfterInvalidateAndCancel() async throws {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/country.txt"
         let url = try XCTUnwrap(URL(string: urlString))


### PR DESCRIPTION
<Backporting  #5457 to swift 6.3>

When a server returns a 401 with a WWW-Authenticate header and the client has no credentials to offer, `attemptProceedingWithDefaultCredential` would do nothing, leaving the task suspended indefinitely. Pass the 401 response through as a normal completion instead. This produces an error that matches what macOS produces when making a request under the same conditions.

Also add a regression test covering this scenario.

Issue: #5456
