### PR TITLE
Fix NSRange to Range<String.Index> conversion for misaligned UTF-16 i…

### DIFF
--- a/Sources/Foundation/NSRange.swift
+++ b/Sources/Foundation/NSRange.swift
@@ -292,7 +292,14 @@ extension Range where Bound == String.Index {
             let lowerBound = String.Index(start, within: string),
             let upperBound = String.Index(end, within: string)
             else { return nil }
-        
+
+        // Verify the bounds were not snapped or transcoded to a different
+        // position. If either UTF-16 offset fell mid-scalar or mid-grapheme
+        // (e.g. inside a surrogate pair or combining sequence), the round-trip
+        // produces a different index and we must reject the range. (rdar://112643333)
+        guard start == lowerBound, end == upperBound
+            else { return nil }
+
         self = lowerBound..<upperBound
     }
 }

--- a/Tests/Foundation/TestNSRange.swift
+++ b/Tests/Foundation/TestNSRange.swift
@@ -162,6 +162,62 @@ class TestNSRange : XCTestCase {
         _assertNSRangeInit(..<unicodeSubstring.firstIndex(of: "╯")!, in: unicodeString, is: "{0, 31}")
     }
 
+    func test_init_range_stringIndex_misaligned_utf16() {
+        // rdar://112643333: Range<String.Index>(NSRange, in:) should return nil
+        // when the NSRange points to misaligned UTF-16 offsets (e.g. mid-surrogate).
+
+        // "😀" is U+1F600, encoded as a surrogate pair (2 UTF-16 code units).
+        // UTF-16 offsets: 0=D83D(hi), 1=DE00(lo), 2='a', 3='b', 4='c'
+        let emoji = "😀abc"
+
+        // Mid-surrogate start: location 1 is the low surrogate — not a character boundary
+        XCTAssertNil(Range<String.Index>(NSRange(location: 1, length: 1), in: emoji),
+                     "NSRange starting mid-surrogate should return nil")
+
+        // Mid-surrogate end: length 1 from start lands on low surrogate
+        XCTAssertNil(Range<String.Index>(NSRange(location: 0, length: 1), in: emoji),
+                     "NSRange ending mid-surrogate should return nil")
+
+        // Valid: full surrogate pair
+        XCTAssertNotNil(Range<String.Index>(NSRange(location: 0, length: 2), in: emoji),
+                        "NSRange covering full surrogate pair should succeed")
+
+        // Valid: full string
+        XCTAssertNotNil(Range<String.Index>(NSRange(location: 0, length: 5), in: emoji),
+                        "NSRange covering full string should succeed")
+
+        // "𓀀" is U+13000, also a surrogate pair in UTF-16.
+        // UTF-16 offsets: 0='a', 1='b', 2=D80C(hi), 3=DC00(lo), 4='c', 5='d'
+        let hieroglyph = "ab𓀀cd"
+
+        // Mid-surrogate: location 3 is the low surrogate
+        XCTAssertNil(Range<String.Index>(NSRange(location: 3, length: 1), in: hieroglyph),
+                     "NSRange starting at low surrogate should return nil")
+
+        // Ends mid-surrogate: location 1, length 2 ends at offset 3 (low surrogate)
+        XCTAssertNil(Range<String.Index>(NSRange(location: 1, length: 2), in: hieroglyph),
+                     "NSRange ending mid-surrogate should return nil")
+
+        // Valid: covers full surrogate pair
+        XCTAssertNotNil(Range<String.Index>(NSRange(location: 2, length: 2), in: hieroglyph),
+                        "NSRange covering full surrogate pair should succeed")
+
+        // Pure ASCII: all offsets are valid character boundaries
+        let ascii = "abcdef"
+        XCTAssertNotNil(Range<String.Index>(NSRange(location: 1, length: 3), in: ascii),
+                        "NSRange in ASCII string should always succeed")
+        XCTAssertNotNil(Range<String.Index>(NSRange(location: 0, length: 6), in: ascii),
+                        "NSRange covering full ASCII string should succeed")
+
+        // Out of bounds should return nil
+        XCTAssertNil(Range<String.Index>(NSRange(location: 0, length: 10), in: ascii),
+                     "NSRange beyond string length should return nil")
+
+        // NSNotFound should return nil
+        XCTAssertNil(Range<String.Index>(NSRange(location: NSNotFound, length: 0), in: ascii),
+                     "NSRange with NSNotFound location should return nil")
+    }
+
     func test_hashing() {
         let large = Int.max >> 2
         let samples: [NSRange] = [


### PR DESCRIPTION
…ndices

Range<String.Index>.init?(_:in:) was silently accepting misaligned UTF-16 offsets (e.g. mid-surrogate pair). When an NSRange pointed into the middle of a surrogate pair, String.Index(_:within:) would round the index to the nearest character boundary via _characterAligned, and the conversion would return a non-nil range pointing to the wrong characters.

Root cause: String.Index(_:within:) (StringIndexConversions.swift:61) applies _characterAligned for backward compatibility with legacy code. This is intentional behavior in the stdlib, but callers that need precise UTF-16 boundary validation must verify the result wasn't silently adjusted.

Fix: After resolving lowerBound and upperBound via String.Index(_:within:), verify they equal the original UTF-16 indices (start == lowerBound, end == upperBound). If the index was snapped, the equality fails and we return nil. This is an O(1) struct comparison.

Compatibility note: This is a behavior change to a public API — code that previously received a non-nil range for misaligned NSRanges will now receive nil. The old behavior was incorrect (returning ranges pointing to wrong characters), so this is a correctness fix, not a regression.

Known limitation: Other callers of String.Index(_:within:) (e.g. AttributedString index conversion) may have the same silent-rounding issue. This fix addresses only the NSRange conversion path.

rdar://112643333

_[One line description of your change]_

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve. References to issues the changes resolve, if any.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_

### Testing:

_[The specific testing that has been done or needs to be done to further
  validate any impact of the changes.]_
