### PR TITLE
Process.run() on Linux crashes intermittently — buffer over-read in findMaximumOpenFromProcSelfFD()

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -83,10 +83,21 @@ private func findMaximumOpenFromProcSelfFD() -> CInt? {
     var highestFDSoFar = CInt(0)
 
     while let dirEntPtr = readdir(dirPtr) {
-        var entryName = dirEntPtr.pointee.d_name
-        let thisFD = withUnsafeBytes(of: &entryName) { entryNamePtr -> CInt? in
-            CInt(String(decoding: entryNamePtr.prefix(while: { $0 != 0 }), as: Unicode.UTF8.self))
-        }
+        // Read d_name via the bounded `_direntName` / `_direntNameLength`
+        // helpers rather than `dirEntPtr.pointee.d_name`. The latter
+        // performs a 256-byte struct copy of the declared
+        // `char d_name[256]` field, but glibc's `readdir(3)` returns
+        // dirent records sized to `d_reclen` (typically 24-32 bytes
+        // for short filenames like /proc/self/fd entries). When a
+        // record sits near the end of glibc's internal read buffer
+        // and the following page is unmapped, the bulk copy faults
+        // with SIGSEGV. PR #4892 already converted the
+        // `FileManager+POSIX` dirent walks for the same reason; this
+        // was the last remaining instance of the antipattern.
+        let length = Int(_direntNameLength(dirEntPtr))
+        let namePtr = UnsafeRawPointer(_direntName(dirEntPtr)).assumingMemoryBound(to: UInt8.self)
+        let nameBuffer = UnsafeBufferPointer(start: namePtr, count: length)
+        let thisFD = CInt(String(decoding: nameBuffer, as: Unicode.UTF8.self))
         highestFDSoFar = max(thisFD ?? -1, highestFDSoFar)
     }
 

--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -83,17 +83,10 @@ private func findMaximumOpenFromProcSelfFD() -> CInt? {
     var highestFDSoFar = CInt(0)
 
     while let dirEntPtr = readdir(dirPtr) {
-        // Read d_name via the bounded `_direntName` / `_direntNameLength`
-        // helpers rather than `dirEntPtr.pointee.d_name`. The latter
-        // performs a 256-byte struct copy of the declared
-        // `char d_name[256]` field, but glibc's `readdir(3)` returns
-        // dirent records sized to `d_reclen` (typically 24-32 bytes
-        // for short filenames like /proc/self/fd entries). When a
-        // record sits near the end of glibc's internal read buffer
-        // and the following page is unmapped, the bulk copy faults
-        // with SIGSEGV. PR #4892 already converted the
-        // `FileManager+POSIX` dirent walks for the same reason; this
-        // was the last remaining instance of the antipattern.
+        // Don't bulk-copy `pointee.d_name`: `readdir(3)` returns dirent
+        // records sized to `d_reclen`, not the declared 256 bytes, so
+        // a struct copy can read past the end of glibc's readdir
+        // buffer and SIGSEGV on the next page.
         let length = Int(_direntNameLength(dirEntPtr))
         let namePtr = UnsafeRawPointer(_direntName(dirEntPtr)).assumingMemoryBound(to: UInt8.self)
         let nameBuffer = UnsafeBufferPointer(start: namePtr, count: length)


### PR DESCRIPTION
### Description

`Process.run()` on Linux SIGSEGVs intermittently from a 256-byte over-read in `findMaximumOpenFromProcSelfFD()` (`Sources/Foundation/Process.swift:86`). The line

```swift
var entryName = dirEntPtr.pointee.d_name
```

copies the entire 256-byte `char d_name[256]` field of glibc's `struct dirent`. But `readdir(3)` returns dirent records sized to `d_reclen` — typically 24-32 bytes for short filenames like the small integers under `/proc/self/fd`. When a record sits at the tail of glibc's internal read buffer and the subsequent page is unmapped, the bulk memcpy reads past the buffer end and the program crashes.

This is **the only remaining instance of the `pointee.d_name` antipattern** in the repo (`grep -rn "pointee\.d_name" Sources/`); PR #4892 already converted `FileManager+POSIX.swift` to the safer `_direntName` / `_direntNameLength` helpers in Feb 2024.

The bug has been latent since the function was introduced in 077775eed (2019-12-12).

### Reproduction

Tested on Ubuntu 24.04, Swift 6.3.1. Reproduces about **1 in 5 runs** of a moderate test suite that spawns child processes, **1 in 20 runs** in GitHub-hosted CI.

Minimal reproducer (Linux only) — pre-fills `/proc/self/fd` so glibc's readdir buffer fills with dirents that have a chance of sitting near a page boundary, then hammers `Process.run()` from concurrent tasks:

```swift
import Foundation

@main
struct Reprex {
    static func main() async {
        // Open many fds first so /proc/self/fd has enough entries to span
        // glibc's readdir buffer (a few hundred entries).
        var dummy: [FileHandle] = []
        for _ in 0..<500 {
            if let f = FileHandle(forReadingAtPath: "/dev/null") { dummy.append(f) }
        }

        // Hammer Process.run() concurrently. The number of cooperative
        // workers and per-worker iterations are tuned to make a crash
        // probable within ~30 seconds; adjust if needed.
        await withTaskGroup(of: Void.self) { group in
            for _ in 0..<50 {
                group.addTask {
                    for _ in 0..<200 {
                        let p = Process()
                        p.executableURL = URL(fileURLWithPath: "/bin/true")
                        try? p.run()
                        p.waitUntilExit()
                    }
                }
            }
        }
        _ = dummy  // keep alive
    }
}
```

Run with `SWIFT_BACKTRACE=enable=no` under `gdb --batch` to see the actual stack instead of Swift's signal handler:

```bash
SWIFT_BACKTRACE=enable=no gdb --batch \
  -ex "handle SIGSEGV stop print nopass" \
  -ex "run" \
  -ex "bt 30" \
  ./reprex
```

### Captured stack trace

```
Thread 6 "...default-qos" received signal SIGSEGV, Segmentation fault.
__memcpy_avx_unaligned_erms () at .../memmove-vec-unaligned-erms.S:401

#0  __memcpy_avx_unaligned_erms ()
#1  Foundation.findMaximumOpenFromProcSelfFD()         libFoundation.so
#2  Foundation.Process.run()                           libFoundation.so
#3  <caller's Process.run() invocation>
#4  swift::runJobInEstablishedExecutorContext          libswift_Concurrency.so
#5  swift_job_run                                      libswift_Concurrency.so
#6  _dispatch_continuation_pop                         libdispatch.so
#7  _dispatch_async_redirect_invoke                    libdispatch.so
#8  _dispatch_worker_thread                            libdispatch.so
```

Faulting registers (`rdx = 0x100` confirms the 256-byte memcpy):

```
rdi 0x7ffff15fa4c0   (destination — stack)
rsi 0x7fffe004af13   (source — heap, near page boundary)
rdx 0x100            (length: 256 bytes)
rip 0x7ffff6188b6e   (__memcpy_avx_unaligned_erms+238)
```

Faulting instruction (AVX-2 unaligned vmovdqu reading past mapped memory):

```
=> 0x7ffff6188b6e <__memcpy_avx_unaligned_erms+238>: vmovdqu -0x20(%rsi,%rdx,1),%ymm4
```

`rsi + rdx - 0x20 = 0x7fffe004afF3`, which crosses the `0x7fffe004b000` page boundary into unmapped memory.

### Proposed fix

Already implemented and pushed to a fork — happy to send a PR if the approach looks right:

https://github.com/billdenney/swift-corelibs-foundation/tree/fix/process-d_name-buffer-overrun

The fix uses the existing `_direntName` / `_direntNameLength` C helpers in `Sources/CoreFoundation/include/ForSwiftFoundationOnly.h` — same pattern PR #4892 already applied elsewhere in the repo. Three lines changed:

```diff
     while let dirEntPtr = readdir(dirPtr) {
-        var entryName = dirEntPtr.pointee.d_name
-        let thisFD = withUnsafeBytes(of: &entryName) { entryNamePtr -> CInt? in
-            CInt(String(decoding: entryNamePtr.prefix(while: { $0 != 0 }), as: Unicode.UTF8.self))
-        }
+        let length = Int(_direntNameLength(dirEntPtr))
+        let namePtr = UnsafeRawPointer(_direntName(dirEntPtr)).assumingMemoryBound(to: UInt8.self)
+        let nameBuffer = UnsafeBufferPointer(start: namePtr, count: length)
+        let thisFD = CInt(String(decoding: nameBuffer, as: Unicode.UTF8.self))
         highestFDSoFar = max(thisFD ?? -1, highestFDSoFar)
     }
```

### Severity

Crashes are **process-fatal and silent** on the application side — `Process.run()` doesn't throw; the cooperative worker dies under SIGSEGV and unwinds the whole process. In CI it manifests as flaky test-process exits with signal 11. In production it would crash any long-running Swift server that spawns child processes under load.

### Environment

- Swift 6.3.1 on Ubuntu 24.04 (`swift:6.3.1-noble` Docker image and direct `swiftly` install)
- glibc 2.39
- Reproduces on `swift-6.3.1-RELEASE`; identical code is on `main` HEAD (commit 30e3497d, 2026-04-20).