### PR TITLE
Disable OpenSSL atexit handler before CURL init

### DIFF
--- a/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
+++ b/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
@@ -22,6 +22,7 @@
 #include "CFURLSessionInterface.h"
 #include "CFString.h"
 #include <curl/curl.h>
+#include <dlfcn.h>
 
 #if !defined(LIBCURL_VERSION_MAJOR)
 #error "LIBCURL_VERSION_MAJOR not defined, missing curlver.h"
@@ -166,6 +167,25 @@ CFURLSessionMultiCode CFURLSession_multi_setopt_tf(CFURLSessionMultiHandle _Nonn
 }
 
 CFURLSessionEasyCode CFURLSessionInit(void) {
+    // Call OPENSSL_init_crypto with OPENSSL_INIT_NO_ATEXIT (0x00080000) before
+    // libcurl does, preventing OpenSSL from registering an atexit handler.
+    //
+    // We do not want an atexit handler, because that races with Swift's object
+    // cleanup on libdispatch threads, leading to a situation where OpenSSL could
+    // have been cleaned up before Swift cleaned up CURL handles, causing a
+    // double-free crash.
+    //
+    // This issue has been documented in:
+    // * https://github.com/swiftlang/swift-corelibs-foundation/issues/5469
+    // * https://github.com/swiftlang/swift-package-manager/issues/8171
+    //
+    // OpenSSL is in the process of disabling the atexit handler by default from
+    // version 4.0 onwards: https://openssl-library.org/post/2026-03-10-remove-atexit/
+    typedef int (*openssl_init_crypto_fn)(uint64_t, const void *);
+    openssl_init_crypto_fn openssl_init_crypto = (openssl_init_crypto_fn)dlsym(RTLD_DEFAULT, "OPENSSL_init_crypto");
+    if (openssl_init_crypto != NULL) {
+        openssl_init_crypto(0x00080000L, NULL);
+    }
     return MakeEasyCode(curl_global_init(CURL_GLOBAL_SSL));
 }
 

--- a/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
+++ b/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
@@ -22,7 +22,10 @@
 #include "CFURLSessionInterface.h"
 #include "CFString.h"
 #include <curl/curl.h>
+
+#if !defined(_WIN32)
 #include <dlfcn.h>
+#endif
 
 #if !defined(LIBCURL_VERSION_MAJOR)
 #error "LIBCURL_VERSION_MAJOR not defined, missing curlver.h"
@@ -167,6 +170,7 @@ CFURLSessionMultiCode CFURLSession_multi_setopt_tf(CFURLSessionMultiHandle _Nonn
 }
 
 CFURLSessionEasyCode CFURLSessionInit(void) {
+    #if !defined(_WIN32)
     // Call OPENSSL_init_crypto with OPENSSL_INIT_NO_ATEXIT (0x00080000) before
     // libcurl does, preventing OpenSSL from registering an atexit handler.
     //
@@ -181,11 +185,14 @@ CFURLSessionEasyCode CFURLSessionInit(void) {
     //
     // OpenSSL is in the process of disabling the atexit handler by default from
     // version 4.0 onwards: https://openssl-library.org/post/2026-03-10-remove-atexit/
+    //
+    // TODO: This works for Linux. Investigate how to achieve parity with Windows.
     typedef int (*openssl_init_crypto_fn)(uint64_t, const void *);
     openssl_init_crypto_fn openssl_init_crypto = (openssl_init_crypto_fn)dlsym(RTLD_DEFAULT, "OPENSSL_init_crypto");
     if (openssl_init_crypto != NULL) {
         openssl_init_crypto(0x00080000L, NULL);
     }
+    #endif
     return MakeEasyCode(curl_global_init(CURL_GLOBAL_SSL));
 }
 

--- a/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
+++ b/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
@@ -170,7 +170,7 @@ CFURLSessionMultiCode CFURLSession_multi_setopt_tf(CFURLSessionMultiHandle _Nonn
 }
 
 CFURLSessionEasyCode CFURLSessionInit(void) {
-    #if !defined(_WIN32)
+#if !defined(_WIN32)
     // Call OPENSSL_init_crypto with OPENSSL_INIT_NO_ATEXIT (0x00080000) before
     // libcurl does, preventing OpenSSL from registering an atexit handler.
     //
@@ -192,7 +192,7 @@ CFURLSessionEasyCode CFURLSessionInit(void) {
     if (openssl_init_crypto != NULL) {
         openssl_init_crypto(0x00080000L, NULL);
     }
-    #endif
+#endif
     return MakeEasyCode(curl_global_init(CURL_GLOBAL_SSL));
 }
 


### PR DESCRIPTION
Attempt to dynamically link `OPENSSL_init_crypto` and invoke it with `OPENSSL_INIT_NO_ATEXIT` before libcurl init, preventing OpenSSL from registering an atexit handler.

### Motivation:

URLSession may flakily cause crashes at program exit, which has been recorded in these issues:
* https://github.com/swiftlang/swift-corelibs-foundation/issues/5469
* https://github.com/swiftlang/swift-package-manager/issues/8171

This happens because OpenSSL's atexit handler races with Swift's object cleanup on libdispatch threads. It is possible that OpenSSL could have been cleaned up before Swift cleaned up CURL handles, causing a double-free of SSL objects, leading to a crash.

**Note**: OpenSSL is already in the process of disabling the atexit handler by default from version 4.0 onwards: https://openssl-library.org/post/2026-03-10-remove-atexit/

### Modifications:

`CFURLSessionInit` will first attempt to dynamically link the symbol `OPENSSL_init_crypto` and invoke it with `OPENSSL_INIT_NO_ATEXIT`. Then it will call `curl_global_init(CURL_GLOBAL_SSL)`.

### Result:

This change will ensure that OpenSSL's atexit handler is never installed, so there is no race at program exit.

**Note**: Disabling OpenSSL cleanup on program exit will cause memory leak checks to fail. OpenSSL also acknowledges this, but says that those warnings should be suppressed because the memory that would have been cleaned up was only allocated by OpenSSL once, so it is not strictly speaking a leak.

### Testing:

Confirmed with this sample program running in a loop that the spurious crash no longer occurs after the fix:

```
import Foundation
import FoundationNetworking

@main
struct Example {
    static func main() async throws {
        let session = URLSession(configuration: .default)
        try await session.data(from: .init(string: "https://swift.org/index.html")!)
        session.finishTasksAndInvalidate()
    }
}
```
