### PR TITLE
[6.4.x] [wasm] Fix unavailable calls in NSString write methods on WASI

### DIFF
--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1283,14 +1283,22 @@ extension NSString {
     @available(*, unavailable, message: "WASI does not support atomic file-writing as it does not have temporary directories")
     #endif
     public func write(to url: URL, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {
+        #if os(WASI)
+        throw CocoaError(.featureUnsupported)
+        #else
         try _writeTo(url, useAuxiliaryFile, enc)
+        #endif
     }
-    
+
     #if os(WASI)
     @available(*, unavailable, message: "WASI does not support atomic file-writing as it does not have temporary directories")
     #endif
     public func write(toFile path: String, atomically useAuxiliaryFile: Bool, encoding enc: UInt) throws {
+        #if os(WASI)
+        throw CocoaError(.featureUnsupported)
+        #else
         try _writeTo(URL(fileURLWithPath: path), useAuxiliaryFile, enc)
+        #endif
     }
     
     public convenience init(charactersNoCopy characters: UnsafeMutablePointer<unichar>, length: Int, freeWhenDone freeBuffer: Bool) /* "NoCopy" is a hint */ {


### PR DESCRIPTION
Cherry-pick of https://github.com/swiftlang/swift-corelibs-foundation/pull/5475.

Apply the same `#if os(WASI)` guard that was already applied to `_writeTo`'s body to `write(to:)` and `write(toFile:)`.

### Motivation:

`write(to:)` and `write(toFile:)` call `_writeTo`, which is marked `@available(*, unavailable)` on WASI. An upcoming Swift compiler fix (https://github.com/swiftlang/swift/pull/88942) corrects handling of calls to universally unavailable members of extensions, so these now need the same `#if os(WASI)` guard that was already applied to `_writeTo`'s body.

### Modifications:

Throw `.featureUnsupported` errors directly from `write(to:)` and `write(toFile:)` on WASI.

### Result:

The package builds with a Swift compiler that has https://github.com/swiftlang/swift/pull/88942.

### Testing:

Cross repo testing initiated from https://github.com/swiftlang/swift.
