### PR TITLE
Fix potential oob read in sendWebSocketsData

### DIFF
--- a/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
+++ b/Sources/FoundationNetworking/URLSession/libcurl/EasyHandle.swift
@@ -426,7 +426,7 @@ extension _EasyHandle {
                 var offset = 0
                 repeat {
                     var amountWritten = 0
-                    try CFURLSessionEasyHandleWebSocketsSend(rawHandle, bytesPtr.advanced(by: offset), data.count, &amountWritten, 0, cfurlSessionFlags).asError()
+                    try CFURLSessionEasyHandleWebSocketsSend(rawHandle, bytesPtr.advanced(by: offset), data.count - offset, &amountWritten, 0, cfurlSessionFlags).asError()
                     offset += amountWritten
                 } while offset < data.count
             }


### PR DESCRIPTION
Underneath this calls `curl_ws_send` and from the documentation:

> sent is set to the number of payload bytes actually sent. If the return value is [CURLE_OK](https://curl.se/libcurl/c/libcurl-errors.html#CURLEOK) but sent is less than the given buflen, libcurl was unable to consume the complete payload in a single call. In this case the application must call this function again until all payload is processed. buffer and buflen must be updated on every following invocation to only point to the remaining piece of the payload.

But in this loop, the `buflen` isn't updated and this can result in an out of bounds read if curl wasn't able to consume the whole payload in a single call.