### PR TITLE
Remove explicit `Connection: keep-alive` header set

### DIFF
--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -662,9 +662,7 @@ internal class _HTTPURLProtocol: _NativeProtocol {
     /// These will only be set if not already part of the request.
     /// - SeeAlso: https://curl.haxx.se/libcurl/c/CURLOPT_HTTPHEADER.html
     var curlHeadersToSet: [(String,String)] {
-        var result = [("Connection", "keep-alive"),
-                      ("User-Agent", userAgentString),
-                      ]
+        var result = [("User-Agent", userAgentString)]
         if let language = NSLocale.current.languageCode {
             result.append(("Accept-Language", language))
         }


### PR DESCRIPTION
Setting this header explicitly causes issues for WebSockets which need `Connection: upgrade`.

curl is capable of managing the `Connection` header by itself and we don't need to specify this header, which is implicitly assumed for HTTP/1.1 and not needed for HTTP/2 or HTTP/3

Tested that new versions of curl which support websockets don't fail the URLSession websocket tests with this change.