### PR TITLE
Fix CFRunLoop timeouts breaking under coarse-resolution CLOCK_MONOTONIC

### DIFF
--- a/Sources/CoreFoundation/CFDate.c
+++ b/Sources/CoreFoundation/CFDate.c
@@ -168,11 +168,15 @@ CF_PRIVATE void __CFDateInitialize(void) {
     __CFTSRRate = 1.0e7;
     __CF1_TSRRate = 1.0 / __CFTSRRate;
 #elif TARGET_OS_LINUX || TARGET_OS_BSD || TARGET_OS_WASI
-    struct timespec res;
-    if (clock_getres(CLOCK_MONOTONIC, &res) != 0) {
-        HALT;
-    }
-    __CFTSRRate = res.tv_sec + (1000000000 * res.tv_nsec);
+    // On these platforms the monotonic time source is
+    // clock_gettime(CLOCK_MONOTONIC), which always reports nanoseconds, so
+    // __CFTSRRate (TSR-units per second) is fixed at NSEC_PER_SEC regardless
+    // of the clock's reported resolution. The previous `clock_getres`-based
+    // formula coincidentally produced 1e9 only when tv_nsec==1; on hosts
+    // where CLOCK_MONOTONIC resolution is coarser (e.g. 1ms under some
+    // virtualized kernels) it produced wildly wrong values, breaking every
+    // CFRunLoop timeout.
+    __CFTSRRate = (double)NSEC_PER_SEC;
     __CF1_TSRRate = 1.0 / __CFTSRRate;
 #else
 #error Unable to initialize date


### PR DESCRIPTION
This fixes an issue affecting Linux/BSD/WASI where the [TSR rate in `CFDate.c`](https://github.com/swiftlang/swift-corelibs-foundation/blob/aba41180f22dfe732a6096ad4a6a4fdb8a1af38f/Sources/CoreFoundation/CFDate.c#L175) may be incorrect. This rate is derived from the resolution of `CLOCK_MONOTONIC`, but on some systems this clock has coarser resolution. It's used by a [shim of `mach_absolute_time()`](https://github.com/swiftlang/swift-corelibs-foundation/blob/aba41180f22dfe732a6096ad4a6a4fdb8a1af38f/Sources/CoreFoundation/internalInclude/CoreFoundation_Prefix.h#L263) and multiplied by a constant factor that assumes a more granular resolution, so on systems with coarser resolution the times will be incorrect.

Fixes rdar://139710145

### Motivation:

The practical scenario where this bug has been observed most often is when running XCTests in Linux via Docker on macOS. Linux Docker uses a clock with a coarser-resolution `CLOCK_MONOTONIC` than "bare metal" Linux. This leads to timeout calculation errors in Foundation's `RunLoop`, which XCTest relies on heavily for many features including handling `async` test methods. The end result is that trivial XCTest suites involving `async` methods can hang in this environment once every 1-4 attempts.

### Modifications:

Stop using `clock_getres(CLOCK_MONOTONIC, ...)` to determine TSR rate on Linux (and the other affected platforms in this `#if` branch) and instead hardcode the same rate that is used in the `mach_absolute_time()` shim above, `NSEC_PER_SEC`.

### Result:

The XCTest hang no longer reproduces after many thousands of attempts in a loop, after reliably reproducing after 1-4 attempts previously.

### Testing:

Verified via testing above.