### PR TITLE
NSNull: fix === returning false when both operands are nil

### DIFF
--- a/Sources/Foundation/NSNull.swift
+++ b/Sources/Foundation/NSNull.swift
@@ -44,6 +44,16 @@ open class NSNull : NSObject, NSCopying, NSSecureCoding, @unchecked Sendable {
 }
 
 public func ===(lhs: NSNull?, rhs: NSNull?) -> Bool {
-    guard let _ = lhs, let _ = rhs else { return false }
-    return true
+    switch (lhs, rhs) {
+    case (nil, nil):
+        return true
+    case (nil, _), (_, nil):
+        return false
+    default:
+        return true
+    }
+}
+
+public func !==(lhs: NSNull?, rhs: NSNull?) -> Bool {
+    return !(lhs === rhs)
 }

--- a/Tests/Foundation/TestNSNull.swift
+++ b/Tests/Foundation/TestNSNull.swift
@@ -11,23 +11,44 @@ class TestNSNull : XCTestCase {
     func test_alwaysEqual() {
         let null_1 = NSNull()
         let null_2 = NSNull()
-        
+
         let null_3: NSNull? = NSNull()
         let null_4: NSNull? = nil
-        
+
         //Check that any two NSNull's are ==
         XCTAssertEqual(null_1, null_2)
 
         //Check that any two NSNull's are ===, preserving the singleton behavior
         XCTAssertTrue(null_1 === null_2)
-        
+        XCTAssertFalse(null_1 !== null_2)
+
         //Check that NSNull() == .Some(NSNull)
         XCTAssertEqual(null_1, null_3)
-        
+
         //Make sure that NSNull() != .None
-        XCTAssertNotEqual(null_1, null_4)        
+        XCTAssertNotEqual(null_1, null_4)
     }
-    
+
+    func test_identityOperator() {
+        let null_1: NSNull? = NSNull()
+        let null_2: NSNull? = NSNull()
+        let null_nil: NSNull? = nil
+
+        //Check that two non-nil NSNull values are ===
+        XCTAssertTrue(null_1 === null_2)
+        XCTAssertFalse(null_1 !== null_2)
+
+        //Check that nil === nil for the NSNull? overload
+        XCTAssertTrue(null_nil === null_nil)
+        XCTAssertFalse(null_nil !== null_nil)
+
+        //Check that a non-nil NSNull is not === to nil in either order
+        XCTAssertFalse(null_1 === null_nil)
+        XCTAssertFalse(null_nil === null_1)
+        XCTAssertTrue(null_1 !== null_nil)
+        XCTAssertTrue(null_nil !== null_1)
+    }
+
     func test_description() {
         XCTAssertEqual(NSNull().description, "<null>")
     }


### PR DESCRIPTION
Fixes #5248.

The hack in `===(NSNull?, NSNull?)` returns false when either operand is nil, so `nil === nil` returns false. Replace the guard with an explicit switch on the optional pair: `(nil, nil)` is true, mixed-nil is false, and two non-nil NSNull instances remain identical (preserving the singleton behavior).

Also add a matching `!==` overload so the symmetric operator agrees with `===` for this signature. Without it, Swift's default `!==` for `AnyObject?` returns true for two distinct NSNull instances even though the custom `===` says they are identical.

The new operator is a small public-API addition. Happy to drop it and land only the bug fix if a swift-evolution discussion is preferred.

### Tests

Added `test_identityOperator()` covering the full truth table (nil/nil, mixed, non-nil/non-nil for both `===` and `!==`). Existing `test_alwaysEqual()` still passes; added one supplemental `!==` assertion to it.

Verified on Linux via `swiftlang/swift:nightly-main-jammy`:

```
Test Suite 'TestNSNull' passed
   Executed 3 tests, with 0 failures (0 unexpected) in 0.106s
```