### PR TITLE
Make NSAttributedString conform to CVarArg

### DIFF
--- a/Sources/Foundation/NSAttributedString.swift
+++ b/Sources/Foundation/NSAttributedString.swift
@@ -422,6 +422,13 @@ extension NSAttributedString {
     internal var _cfObject: CFAttributedString { return unsafeBitCast(self, to: CFAttributedString.self) }
 }
 
+extension NSAttributedString : CVarArg {
+    @inlinable // c-abi
+    public var _cVarArgEncoding: [Int] {
+        return _encodeBitsAsWords(self)
+    }
+}
+
 extension NSAttributedString {
 
     public struct EnumerationOptions: OptionSet, Sendable {

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -862,6 +862,13 @@ class TestNSString: LoopbackServerTest {
         }
     }
 
+    func test_initializeWithFormatNSAttributedStringCVarArg() {
+        let value = NSAttributedString(string: "hello")
+        let result = NSString(format: "%@", value)
+        XCTAssertTrue(result.hasPrefix("hello "))
+        XCTAssertTrue(result.hasSuffix("{} Len 5\n"))
+    }
+
     func test_appendingPathComponent() {
         do {
             let path: NSString = "/tmp"


### PR DESCRIPTION
### Motivation:

Related to #5487.

`NSAttributedString` is CF-backed in swift-corelibs-foundation, but it does not currently conform to `CVarArg` on non-Darwin platforms. That prevents it from being passed to `%@` formatting APIs.

For example:

```swift
let value = NSAttributedString(string: "hello")
let result = NSString(format: "%@", value)
```

### Modifications:

Make `NSAttributedString` conform to `CVarArg` using the same object word encoding used by other Foundation object varargs. This keeps the conformance scoped to a CF-compatible Foundation type instead of applying it to all `NSObject` subclasses.

### Result:

The example above compiles on non-Darwin platforms and formats through the existing CFAttributedString description path.

### Testing:

- Added `test_initializeWithFormatNSAttributedStringCVarArg`
- Verified a Linux overlay of the same conformance formats `NSAttributedString` through `%@`
- Verified a plain Swift `NSObject` subclass remains rejected as `CVarArg`