### PR TITLE
Reduce Unsafe Pointer Usage in Process argv and envp

### DIFF
--- a/Sources/Foundation/Process.swift
+++ b/Sources/Foundation/Process.swift
@@ -744,45 +744,19 @@ open class Process: NSObject, @unchecked Sendable {
                 throw _NSErrorWithErrno(errno, reading: true, path: launchPath)
             }
         })
+
         // Convert the arguments array into a posix_spawn-friendly format
-        
-        var args = [launchPath]
-        if let arguments = self.arguments {
-            args.append(contentsOf: arguments)
-        }
-        
-        let argv : UnsafeMutablePointer<UnsafeMutablePointer<Int8>?> = args.withUnsafeBufferPointer {
-            let array : UnsafeBufferPointer<String> = $0
-            let buffer = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: array.count + 1)
-            buffer.initialize(from: array.map { $0.withCString(strdup) }, count: array.count)
-            buffer[array.count] = nil
-            return buffer
-        }
-        
-        defer {
-            for arg in argv ..< argv + args.count {
-                free(UnsafeMutableRawPointer(arg.pointee))
-            }
-            argv.deallocate()
-        }
+        let args: [String] = [launchPath] + (self.arguments ?? [])
+        var argv: [UnsafeMutablePointer<Int8>?] = args.map { strdup($0) }
+        argv.append(nil)
 
-        var env: [String: String]
-        if let e = environment {
-            env = e
-        } else {
-            env = ProcessInfo.processInfo.environment
-        }
-
-        let nenv = env.count
-        let envp = UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>.allocate(capacity: 1 + nenv)
-        envp.initialize(from: env.map { strdup("\($0)=\($1)") }, count: nenv)
-        envp[env.count] = nil
+        let env: [String: String] = self.environment ?? ProcessInfo.processInfo.environment
+        var envp: [UnsafeMutablePointer<Int8>?] = env.map { strdup("\($0)=\($1)") }
+        envp.append(nil)
 
         defer {
-            for pair in envp ..< envp + env.count {
-                free(UnsafeMutableRawPointer(pair.pointee))
-            }
-            envp.deallocate()
+            argv.dropLast().forEach { free($0) }
+            envp.dropLast().forEach { free($0) }
         }
 
         var taskSocketPair : [Int32] = [0, 0]


### PR DESCRIPTION
Modified the implementation of constructing argv and envp arrays for `posix_spawn`, to be more readable and use less unsafe pointers.

### Motivation:

Recently published [swift-foundation Contribution Guidelines](https://github.com/swiftlang/swift-foundation/blob/3019981601232666270dd250f2a1f4e496d6dec7/CONTRIBUTION_GUIDELINE.md) suggest avoiding unsafe APIs.

### Modifications:

`posix_spawn` needs an array of C-strings. We can't avoid using unsafe APIs for the C-strings themselves, but the array can be a regular Swift array, and Swift supports passing that into C. We just have to make sure our array ends with a null-pointer.

### Result:

No functional changes.

### Testing:

I've run the tests on Ubuntu 24.04 arm64.

It would be good to also run the tests on Android (I don't have one).
