### PR TITLE
Make NSObject conform to CVarArg

### DIFF
--- a/Sources/Foundation/NSAttributedString.swift
+++ b/Sources/Foundation/NSAttributedString.swift
@@ -422,13 +422,6 @@ extension NSAttributedString {
     internal var _cfObject: CFAttributedString { return unsafeBitCast(self, to: CFAttributedString.self) }
 }
 
-extension NSAttributedString : CVarArg {
-    @inlinable // c-abi
-    public var _cVarArgEncoding: [Int] {
-        return _encodeBitsAsWords(self)
-    }
-}
-
 extension NSAttributedString {
 
     public struct EnumerationOptions: OptionSet, Sendable {

--- a/Sources/Foundation/NSAttributedString.swift
+++ b/Sources/Foundation/NSAttributedString.swift
@@ -422,6 +422,13 @@ extension NSAttributedString {
     internal var _cfObject: CFAttributedString { return unsafeBitCast(self, to: CFAttributedString.self) }
 }
 
+extension NSAttributedString : CVarArg {
+    @inlinable // c-abi
+    public var _cVarArgEncoding: [Int] {
+        return _encodeBitsAsWords(self)
+    }
+}
+
 extension NSAttributedString {
 
     public struct EnumerationOptions: OptionSet, Sendable {

--- a/Sources/Foundation/NSObject.swift
+++ b/Sources/Foundation/NSObject.swift
@@ -410,3 +410,10 @@ extension NSObject : CustomDebugStringConvertible {
 
 extension NSObject : CustomStringConvertible {
 }
+
+extension NSObject : CVarArg {
+    @inlinable // c-abi
+    public var _cVarArgEncoding: [Int] {
+        return _encodeBitsAsWords(self)
+    }
+}

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1315,32 +1315,18 @@ extension NSString {
     }
     
     public convenience init(format: String, arguments argList: CVaListPointer) {
-        let str = CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, nil, format._cfObject, argList)!
+        let str = _NSCreateStringWithFormatAndArguments(format._cfObject, nil, argList)
         self.init(str._swiftObject)
     }
     
     public convenience init(format: String, locale: AnyObject?, arguments argList: CVaListPointer) {
-        let str: CFString
-        if let loc = locale {
-            if type(of: loc) === NSLocale.self {
-                // Create a CFLocaleRef
-                let cf = (loc as! NSLocale)._cfObject
-                str = CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, unsafeBitCast(cf, to: CFDictionary.self), format._cfObject, argList)
-            } else if type(of: loc) === NSDictionary.self {
-                let dict = (loc as! NSDictionary)._cfObject
-                str = CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, dict, format._cfObject, argList)
-            } else {
-                fatalError("locale parameter must be a NSLocale or a NSDictionary")
-            }
-        } else {
-            str = CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, nil, format._cfObject, argList)
-        }
+        let str = _NSCreateStringWithFormatAndArguments(format._cfObject, locale, argList)
         self.init(str._swiftObject)
     }
-    
+
     public convenience init(format: NSString, _ args: CVarArg...) {
         let str = withVaList(args) { (vaPtr) -> CFString? in
-            CFStringCreateWithFormatAndArguments(kCFAllocatorSystemDefault, nil, format._cfObject, vaPtr)
+            _NSCreateStringWithFormatAndArguments(format._cfObject, nil, vaPtr)
         }!
         self.init(str._swiftObject)
     }
@@ -1475,6 +1461,66 @@ extension NSString {
     
     public convenience init(contentsOfFile path: String, usedEncoding enc: UnsafeMutablePointer<UInt>?) throws {
         try self.init(contentsOf: URL(fileURLWithPath: path), usedEncoding: enc)
+    }
+}
+
+private func _NSCreateStringWithFormatAndArguments(_ format: CFString, _ locale: AnyObject?, _ arguments: CVaListPointer) -> CFString {
+    let formatOptions: CFDictionary?
+    if let loc = locale {
+        if type(of: loc) === NSLocale.self {
+            let cf = (loc as! NSLocale)._cfObject
+            formatOptions = unsafeBitCast(cf, to: CFDictionary.self)
+        } else if type(of: loc) === NSDictionary.self {
+            formatOptions = (loc as! NSDictionary)._cfObject
+        } else {
+            fatalError("locale parameter must be a NSLocale or a NSDictionary")
+        }
+    } else {
+        formatOptions = nil
+    }
+
+    return _CFStringCreateWithFormatAndArgumentsAux(kCFAllocatorSystemDefault, _NSCopyFormattingDescription, formatOptions, format, arguments)
+}
+
+private func _NSCopyFormattingDescription(_ object: UnsafeMutableRawPointer, _ formatOptions: UnsafeRawPointer) -> Unmanaged<CFString> {
+    let value = Unmanaged<AnyObject>.fromOpaque(object).takeUnretainedValue()
+    if let nsObject = value as? NSObject {
+        return Unmanaged.passRetained(_NSFormattingDescription(nsObject, locale: _NSFormattingLocale(formatOptions))._cfObject)
+    }
+
+    let cfObject = unsafeBitCast(object, to: CFTypeRef.self)
+    return Unmanaged.passRetained(CFCopyDescription(cfObject))
+}
+
+private func _NSFormattingLocale(_ formatOptions: UnsafeRawPointer) -> Locale? {
+    guard Int(bitPattern: formatOptions) != 0 else {
+        return nil
+    }
+
+    let cfObject = unsafeBitCast(formatOptions, to: CFTypeRef.self)
+    guard CFGetTypeID(cfObject) == CFLocaleGetTypeID() else {
+        return nil
+    }
+
+    return unsafeBitCast(cfObject, to: CFLocale.self)._swiftObject
+}
+
+private func _NSFormattingDescription(_ object: NSObject, locale: Locale?) -> String {
+    switch object {
+    case let array as NSArray:
+        return array.description(withLocale: locale)
+    case let dictionary as NSDictionary:
+        return dictionary.description(withLocale: locale)
+    case let orderedSet as NSOrderedSet:
+        return orderedSet.description(withLocale: locale)
+    case let set as NSSet:
+        return set.description(withLocale: locale)
+    case let number as NSNumber:
+        return number.description(withLocale: locale)
+    case let date as NSDate:
+        return date.description(with: locale)
+    default:
+        return object.description
     }
 }
 
@@ -1675,13 +1721,6 @@ extension NSString : _StructTypeBridgeable {
     
     public func _bridgeToSwift() -> _StructType {
         return _StructType._unconditionallyBridgeFromObjectiveC(self)
-    }
-}
-
-extension NSString : CVarArg {
-    @inlinable // c-abi
-    public var _cVarArgEncoding: [Int] {
-        return _encodeBitsAsWords(unsafeBitCast(self, to: AnyObject.self))
     }
 }
 

--- a/Sources/Foundation/NSString.swift
+++ b/Sources/Foundation/NSString.swift
@@ -1483,13 +1483,8 @@ private func _NSCreateStringWithFormatAndArguments(_ format: CFString, _ locale:
 }
 
 private func _NSCopyFormattingDescription(_ object: UnsafeMutableRawPointer, _ formatOptions: UnsafeRawPointer) -> Unmanaged<CFString> {
-    let value = Unmanaged<AnyObject>.fromOpaque(object).takeUnretainedValue()
-    if let nsObject = value as? NSObject {
-        return Unmanaged.passRetained(_NSFormattingDescription(nsObject, locale: _NSFormattingLocale(formatOptions))._cfObject)
-    }
-
-    let cfObject = unsafeBitCast(object, to: CFTypeRef.self)
-    return Unmanaged.passRetained(CFCopyDescription(cfObject))
+    let nsObject = Unmanaged<NSObject>.fromOpaque(UnsafeRawPointer(object)).takeUnretainedValue()
+    return Unmanaged.passRetained(_NSFormattingDescription(nsObject, locale: _NSFormattingLocale(formatOptions))._cfObject)
 }
 
 private func _NSFormattingLocale(_ formatOptions: UnsafeRawPointer) -> Locale? {

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -879,12 +879,6 @@ class TestNSString: LoopbackServerTest {
         XCTAssertEqual(result, "custom object description")
     }
 
-    func test_initializeWithFormatNilObjectCVarArg() {
-        let value = unsafeBitCast(0, to: NSObject.self)
-        let result = NSString(format: "%@", value)
-        XCTAssertEqual(result, "(null)")
-    }
-
     func test_initializeWithFormatNSObjectCVarArgWithLocale() {
         let argument: [CVarArg] = [NSNumber(value: 1000)]
         withVaList(argument) { pointer in

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -862,6 +862,13 @@ class TestNSString: LoopbackServerTest {
         }
     }
 
+    func test_initializeWithFormatNSAttributedStringCVarArg() {
+        let value = NSAttributedString(string: "hello")
+        let result = NSString(format: "%@", value)
+        XCTAssertTrue(result.hasPrefix("hello "))
+        XCTAssertTrue(result.hasSuffix("{} Len 5\n"))
+    }
+
     func test_appendingPathComponent() {
         do {
             let path: NSString = "/tmp"

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -24,6 +24,11 @@ internal let kCFStringEncodingUTF32BE =  CFStringBuiltInEncodings.UTF32BE.rawVal
 internal let kCFStringEncodingUTF32LE =  CFStringBuiltInEncodings.UTF32LE.rawValue
 #endif
 
+private final class NSObjectWithCustomDescription: NSObject {
+    override var description: String {
+        return "custom object description"
+    }
+}
 
 class TestNSString: LoopbackServerTest {
 
@@ -865,8 +870,21 @@ class TestNSString: LoopbackServerTest {
     func test_initializeWithFormatNSAttributedStringCVarArg() {
         let value = NSAttributedString(string: "hello")
         let result = NSString(format: "%@", value)
-        XCTAssertTrue(result.hasPrefix("hello "))
-        XCTAssertTrue(result.hasSuffix("{} Len 5\n"))
+        XCTAssertEqual(result, "hello{\n}")
+    }
+
+    func test_initializeWithFormatNSObjectCVarArg() {
+        let value = NSObjectWithCustomDescription()
+        let result = NSString(format: "%@", value)
+        XCTAssertEqual(result, "custom object description")
+    }
+
+    func test_initializeWithFormatNSObjectCVarArgWithLocale() {
+        let argument: [CVarArg] = [NSNumber(value: 1000)]
+        withVaList(argument) { pointer in
+            let string = NSString(format: "%@", locale: Locale(identifier: "en_GB") as AnyObject, arguments: pointer)
+            XCTAssertEqual(string, "1,000")
+        }
     }
 
     func test_appendingPathComponent() {

--- a/Tests/Foundation/TestNSString.swift
+++ b/Tests/Foundation/TestNSString.swift
@@ -879,6 +879,12 @@ class TestNSString: LoopbackServerTest {
         XCTAssertEqual(result, "custom object description")
     }
 
+    func test_initializeWithFormatNilObjectCVarArg() {
+        let value = unsafeBitCast(0, to: NSObject.self)
+        let result = NSString(format: "%@", value)
+        XCTAssertEqual(result, "(null)")
+    }
+
     func test_initializeWithFormatNSObjectCVarArgWithLocale() {
         let argument: [CVarArg] = [NSNumber(value: 1000)]
         withVaList(argument) { pointer in


### PR DESCRIPTION
## Summary

- Make `NSObject` conform to `CVarArg` so Foundation objects can be passed to `%@` formatting on non-Darwin platforms.
- Route `NSString(format:)` through `_CFStringCreateWithFormatAndArgumentsAux` with a Foundation description callback, matching the CoreFoundation hook intended for `descriptionWithLocale:` / `description`.
- Remove the narrower `NSAttributedString`-only conformance and cover ordinary `NSObject`, `NSAttributedString`, and locale-aware formatting in `TestNSString`.

## Details

`NSObject: CVarArg` only supplies the object pointer to the varargs list. The important behavioral change is that `NSString(format:)` now provides CoreFoundation with a `copyDescFunc`, so `%@` formatting asks Foundation for an object description instead of falling back to treating every object pointer as a CF runtime object.

For known Foundation collection/number/date types, the callback uses the existing locale-aware description entry points. Other `NSObject` subclasses use `object.description`.