### PR TITLE
[URLSession] bugfix for IPv6 hard coded addresses

### DIFF
--- a/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
+++ b/Sources/_CFURLSessionInterface/CFURLSessionInterface.c
@@ -742,15 +742,27 @@ bool CFURLSessionCurlHostIsEqual(const char *_Nonnull url, const char *_Nonnull 
 #if LIBCURL_VERSION_MAJOR > 7 || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR >= 62)
     bool isEqual = false;
     CURLU *h = curl_url();
+    if (h == NULL) {
+        return false;
+    }
     if (0 == curl_url_set(h, CURLUPART_URL, url, 0)) {
         char *curlHost = NULL;
         if (0 == curl_url_get(h, CURLUPART_HOST, &curlHost, 0)) {
-            isEqual = (strlen(curlHost) == strlen(expectedHost) &&
-                       strncmp(curlHost, expectedHost, strlen(curlHost)) == 0);
+            // libcurl leaves IPv6 literal hostnames in brackets (e.g. "[::1]"), but
+            // URL.host strips them — so we strip brackets from hostname returned by libcurl
+            // if needed before comparing.
+            const char *host = curlHost;
+            size_t hostLen = strlen(curlHost);
+            if (hostLen >= 2 && host[0] == '[' && host[hostLen - 1] == ']') {
+                host += 1;
+                hostLen -= 2;
+            }
+            isEqual = (hostLen == strlen(expectedHost) &&
+                       strncmp(host, expectedHost, hostLen) == 0);
             curl_free(curlHost);
         }
-        curl_free(h);
     }
+    curl_url_cleanup(h);
     return isEqual;
 #else
     return true;

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -311,7 +311,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
                     XCTAssert(error is URLError)
                     if let urlError = error as? URLError {
                         let code = URLError.Code(rawValue: urlError.errorCode)
-                        XCTAssertEqual(code, .cannotConnectToHost)
+                        XCTAssertEqual(code, .cannotConnectToHost, "unexpected error: \(urlError.errorCode)")
                     }
             })
         }

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -298,6 +298,21 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         d.run(with: urlRequest)
         waitForExpectations(timeout: 12)
     }
+
+    func test_downloadTaskWithIPv6URLRequest() async {
+        let urlString = "http://[::1]:\(TestURLSession.serverPort)/country.txt"
+        let urlRequest = URLRequest(url: URL(string: urlString)!, timeoutInterval: 2)
+        let d = DownloadTask(testCase: self, description: "Download GET \(urlString): with a delegate")
+        d.run(with: urlRequest)
+        // { (session) -> DownloadTask.Configuration in
+        //     return DownloadTask.Configuration(errorExpectation:
+        //         { (error) in
+        //             XCTAssert(error is URLError)
+        //             XCTAssertEqual((error as? URLError)?.errorCode, URLError.unsupportedURL.rawValue)
+        //     })
+        // }
+        waitForExpectations(timeout: 4)
+    }
     
     func test_downloadTaskWithRequestAndHandler() async {
         //shared session

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -303,7 +303,9 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         let urlString = "http://[::1]:\(TestURLSession.serverPort)/country.txt"
         let urlRequest = URLRequest(url: URL(string: urlString)!, timeoutInterval: 2)
         let d = DownloadTask(testCase: self, description: "Download GET \(urlString): with a delegate")
-        d.run { (session) -> DownloadTask.Configuration in
+        // Check that literal IPv6 addresses pass without throwing a .badURL error
+        // which happened on Linux/Windows (see GitHub issue #5496).
+        d.run(requestTimeout: 2) { (session) -> DownloadTask.Configuration in
             return DownloadTask.Configuration(
                 task: session.downloadTask(with: urlRequest),
                 errorExpectation:
@@ -315,7 +317,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
                     }
             })
         }
-        waitForExpectations(timeout: 4)
+        waitForExpectations(timeout: 5)
     }
     
     func test_downloadTaskWithRequestAndHandler() async {
@@ -2847,9 +2849,9 @@ class DownloadTask : NSObject, @unchecked Sendable {
         var errorExpectation: ((Error) -> Void)?
     }
     
-    func run(configuration: (URLSession) -> Configuration) {
+    func run(requestTimeout: TimeInterval = 8, configuration: (URLSession) -> Configuration) {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 8
+        config.timeoutIntervalForRequest = requestTimeout
         session = URLSession(configuration: config, delegate: self, delegateQueue: nil)
         let taskConfiguration = configuration(session)
         

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -303,14 +303,18 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         let urlString = "http://[::1]:\(TestURLSession.serverPort)/country.txt"
         let urlRequest = URLRequest(url: URL(string: urlString)!, timeoutInterval: 2)
         let d = DownloadTask(testCase: self, description: "Download GET \(urlString): with a delegate")
-        d.run(with: urlRequest)
-        // { (session) -> DownloadTask.Configuration in
-        //     return DownloadTask.Configuration(errorExpectation:
-        //         { (error) in
-        //             XCTAssert(error is URLError)
-        //             XCTAssertEqual((error as? URLError)?.errorCode, URLError.unsupportedURL.rawValue)
-        //     })
-        // }
+        d.run { (session) -> DownloadTask.Configuration in
+            return DownloadTask.Configuration(
+                task: session.downloadTask(with: urlRequest),
+                errorExpectation:
+                { (error) in
+                    XCTAssert(error is URLError)
+                    if let urlError = error as? URLError {
+                        let code = URLError.Code(rawValue: urlError.errorCode)
+                        XCTAssertEqual(code, .cannotConnectToHost)
+                    }
+            })
+        }
         waitForExpectations(timeout: 4)
     }
     

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -311,7 +311,7 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
                     XCTAssert(error is URLError)
                     if let urlError = error as? URLError {
                         let code = URLError.Code(rawValue: urlError.errorCode)
-                        XCTAssertEqual(code, .cannotConnectToHost, "unexpected error: \(urlError.errorCode)")
+                        XCTAssertNotEqual(code, .badURL)
                     }
             })
         }


### PR DESCRIPTION
fixes #5496

Fix connecting to hard coded IPv6 address URLs.

### Motivation:

Currently on Windows and Linux, URLSession.download(for: ) and I suspect any other similar API seems to fail with error -1000 (NSURLErrorBadURL) for URLs with hard coded IPv6 addresses, such as "http://[2a01:b740:1f:1325:b6:983c:840f:c2f3]:8080/build/1". cURL works on those platforms on the command line with the same URL, indicating it's not a network failure or bad URL per se. Also the same code works fine on Darwin Foundation.

It seems the check in EasyHandle for a matching hostname between lib curl and FoundationEssentials.URL.host is not fully respecting brackets.

### Modifications:

Added in code to match the form of the hostname returned by lib curl to match the form of FoundationEssentials.URL.host (i.e. with brackets removed).

### Result:

No functional change, just a bug fix to allow these URLs to work on Windows/Linux.

### Testing:

Manually tested on Windows, and this seemed to fix the issue. This needs a suitable unit test.
