### PR TITLE
Prefer fstatat + dirfd to cf_strlcat and then stat

### DIFF
--- a/Sources/CoreFoundation/CFFileUtilities.c
+++ b/Sources/CoreFoundation/CFFileUtilities.c
@@ -455,15 +455,24 @@ CF_PRIVATE CFMutableArrayRef _CFCreateContentsOfDirectory(CFAllocatorRef alloc, 
 #endif
             Boolean isDir = (dp->d_type == DT_DIR);
             if (!isDir) {
-                // Ugh; must stat.
-                char subdirPath[CFMaxPathLength];
                 struct statinfo statBuf;
-                cf_strlcpy(subdirPath, dirPath, sizeof(subdirPath));
-                cf_strlcat(subdirPath, "/", sizeof(subdirPath));
-                cf_strlcat(subdirPath, dp->d_name, sizeof(subdirPath));
-                if (stat(subdirPath, &statBuf) == 0) {
+#if TARGET_OS_WASI
+                // WASI doesn't support dirfd/fstatat, fall back to stat
+                if (pathLength + 1 + namelen < CFMaxPathLength) {
+                    char subdirPath[CFMaxPathLength];
+                    cf_strlcpy(subdirPath, dirPath, sizeof(subdirPath));
+                    cf_strlcat(subdirPath, "/", sizeof(subdirPath));
+                    cf_strlcat(subdirPath, dp->d_name, sizeof(subdirPath));
+                    if (stat(subdirPath, &statBuf) == 0) {
+                        isDir = ((statBuf.st_mode & S_IFMT) == S_IFDIR);
+                    }
+                }
+#else
+                int dirfd_fd = dirfd(dirp);
+                if (dirfd_fd >= 0 && fstatat(dirfd_fd, dp->d_name, &statBuf, 0) == 0) {
                     isDir = ((statBuf.st_mode & S_IFMT) == S_IFDIR);
                 }
+#endif
             }
 #if TARGET_OS_LINUX || TARGET_OS_WASI
             fileURL = CFURLCreateFromFileSystemRepresentationRelativeToBase(alloc, (uint8_t *)dp->d_name, namelen, isDir, dirURL);


### PR DESCRIPTION
Motivation:
When checking if a filesystem entry is a directory (handling DT_UNKNOWN or similar), the existing code relied on copying and concatenating strings into a fixed-size CFMaxPathLength buffer using cf_strlcpy and cf_strlcat. If the combined length of the directory path and filename exceeded the buffer size, cf_strlcat would silently truncate the path. This resulted in passing a corrupted path to stat(), causing it to fail and silently misclassify deeply nested directories as standard files. Furthermore, absolute path construction is generally less efficient and more vulnerable to Time-of-Check to Time-of-Use (TOCTOU) race conditions.

Modifications:
Replaced the manual absolute path construction and stat() call with fstatat() and dirfd() on supported platforms. This allows the kernel to resolve the path relative to the already-open directory descriptor, bypassing buffer limits entirely.

For platforms that lack dirfd/fstatat (like WASI), wrapped the legacy stat() fallback in an explicit bounds check (if (pathLength + 1 + namelen < CFMaxPathLength)) to prevent the silent string truncation bug.

Fixed a pointer arithmetic bug in the file extension matching logic where strchr and wcschr failed to advance past the current dot, causing an infinite loop.
