### PR TITLE
[6.2] Use default libcurl receive buffer size

### DIFF
--- a/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/FTP/FTPURLProtocol.swift
@@ -70,7 +70,6 @@ internal class _FTPURLProtocol: _NativeProtocol {
             failWith(error: nsError, request: request)
             return
         }
-        easyHandle.set(preferredReceiveBufferSize: Int.max)
         do {
             switch (body, try body.getBodyLength()) {
             case (.none, _):

--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPURLProtocol.swift
@@ -329,7 +329,6 @@ internal class _HTTPURLProtocol: _NativeProtocol {
         let _config = session._configuration
         easyHandle.set(sessionConfig: _config)
         easyHandle.setAllowedProtocolsToHTTPAndHTTPS()
-        easyHandle.set(preferredReceiveBufferSize: Int.max)
         do {
             switch (body, try body.getBodyLength()) {
             case (.none, _):


### PR DESCRIPTION
## What changed

This backports #5448 to `release/6.2`.

Foundation Networking no longer overrides libcurl's receive buffer size when configuring web and file-transfer requests. Both protocols now use libcurl's default receive buffer size.

## Why

Swift Package Manager can issue more concurrent registry downloads than the per-host connection limit. Registry archives are served through redirects, so Foundation Networking reuses an existing libcurl handle for the redirected request.

With Swift 6.2 on Linux, that combination can terminate `swift package resolve` with libcurl error 43. The fix is already present on `main`, but Swift 6.2.4 was released before it merged.

## Root cause

The Swift 6.2 implementation reapplies `CURLOPT_BUFFERSIZE` every time `_HTTPURLProtocol` or `_FTPURLProtocol` configures a transfer. curl 8.5.0 can reject that operation with `CURLE_BAD_FUNCTION_ARGUMENT` when the reused handle still owns its receive buffer.

Foundation Networking treats the returned error as a programming error through `try!`, so the package-resolution process traps instead of reporting a recoverable download failure.

## Approach

Remove the explicit buffer-size assignments and let libcurl retain its default. This matches the accepted fix in #5448.

The removed value was capped to `CURL_MAX_WRITE_SIZE`, which is also libcurl's default receive buffer size, so this avoids the unsafe reconfiguration without changing the effective buffer size.

## Impact

Swift Package Manager registry resolution no longer crashes when concurrent package downloads cross redirects on affected Linux distributions. File-transfer requests also stop applying the same unsafe override.

## Reproduction

The failure can be reproduced with Swift Package Manager and the Swift 6.2 container:

```sh
git clone --depth 1 \
  --branch backport/local-package-test-targets-4.197.x \
  https://github.com/tuist/tuist.git
cd tuist

docker run --rm \
  -v "$PWD:/workspace" \
  -w /workspace \
  swift:6.2 \
  swift package resolve --replace-scm-with-registry
```

Before this backport, the command terminates in `_HTTPURLProtocol.configureEasyHandle` during redirect handling:

```text
FoundationNetworking/EasyHandle.swift:293: Fatal error: 'try!' expression unexpectedly raised an error: Error Domain=libcurl.Easy Code=43
```

## Validation

- Reproduced the crash locally with the command above using the stock Swift 6.2.4 Foundation Networking library.
- Built the patched `release/6.2` source with the coordinated Swift 6.2.4 dependency revisions.
- Ran `swift test --filter TestURLSession/test_httpRedirectionWithCode303`. The targeted redirect test passed.
