### PR TITLE
fix(windows): align static Foundation autolinks

### DIFF
--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -58,6 +58,9 @@ target_link_libraries(FoundationNetworking
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationNetworking PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFURLSessionInterface>")
+
+    # The Windows SDK's curl uses Schannel, zlib, and Brotli. The static Linux
+    # SDK's curl uses OpenSSL and zlib, which BUILD_FULLY_STATIC supplies below.
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         target_compile_options(FoundationNetworking PRIVATE
             "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend libcurl>"

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -58,8 +58,16 @@ target_link_libraries(FoundationNetworking
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationNetworking PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFURLSessionInterface>")
-    target_compile_options(FoundationNetworking PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend curl>")
+    if(WIN32)
+        target_compile_options(FoundationNetworking PRIVATE
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend libcurl>"
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend zlibstatic>"
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend brotlicommon>"
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend brotlidec>")
+    else()
+        target_compile_options(FoundationNetworking PRIVATE
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend curl>")
+    endif()
     target_compile_options(FoundationNetworking PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend $<$<PLATFORM_ID:Windows>:${CMAKE_STATIC_LIBRARY_PREFIX_Swift}>swiftSynchronization>")
 

--- a/Sources/FoundationNetworking/CMakeLists.txt
+++ b/Sources/FoundationNetworking/CMakeLists.txt
@@ -58,7 +58,7 @@ target_link_libraries(FoundationNetworking
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationNetworking PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFURLSessionInterface>")
-    if(WIN32)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         target_compile_options(FoundationNetworking PRIVATE
             "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend libcurl>"
             "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend zlibstatic>"

--- a/Sources/FoundationXML/CMakeLists.txt
+++ b/Sources/FoundationXML/CMakeLists.txt
@@ -33,8 +33,13 @@ target_link_libraries(FoundationXML
 if(NOT BUILD_SHARED_LIBS)
     target_compile_options(FoundationXML PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend _CFXMLInterface>")
-    target_compile_options(FoundationXML PRIVATE
-        "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend xml2>")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        target_compile_options(FoundationXML PRIVATE
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend libxml2s>")
+    else()
+        target_compile_options(FoundationXML PRIVATE
+            "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend xml2>")
+    endif()
     target_compile_options(FoundationXML PRIVATE
         "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -public-autolink-library -Xfrontend $<$<PLATFORM_ID:Windows>:${CMAKE_STATIC_LIBRARY_PREFIX_Swift}>swiftSynchronization>")
 


### PR DESCRIPTION
## Summary

- Static CMake builds now autolink the packaged Windows archive names for FoundationNetworking and FoundationXML.
- The Windows networking module propagates the zlib and Brotli archives required by its static curl build.
- Other platforms retain their existing `curl` and `xml2` autolinks.

## Validation

- CMake 4.3.2 emits the expected Windows autolink names for both patched targets.
- The pinned x64 SDK reproduced the original `curl.lib` and `xml2.lib` link failures.
- Rebuilt static modules produced `libcurl.lib` and `libxml2s.lib` directives and linked successfully.
- A static FoundationXML executable parsed an XML document successfully.
- Both x86_64 and ARM64 Windows SDK slices package `libxml2s.lib` and omit `xml2.lib`.
- The Swift 6.3.3 release and 2026-07-11 development static Linux SDKs link unchanged on x86_64 and ARM64.

Related reports are thebrowsercompany/swift-build#351 and thebrowsercompany/swift-build#352.