### PR TITLE
CMake: Enable CMP0157 unconditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,15 +22,8 @@ if(POLICY CMP0156)
 endif()
 
 if(POLICY CMP0157)
-    if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows AND CMAKE_SYSTEM_NAME STREQUAL Android)
-        # CMP0157 causes swift-collections to fail to compile when targetting
-        # Android on Windows due to swift-driver not being present during the
-        # toolchain build. Disable it for now.
-        cmake_policy(SET CMP0157 OLD)
-    else()
-        # New Swift build model: improved incremental build performance and LSP support
-        cmake_policy(SET CMP0157 NEW)
-    endif()
+    # New Swift build model: improved incremental build performance and LSP support
+    cmake_policy(SET CMP0157 NEW)
 endif()
 
 project(Foundation

--- a/Sources/CoreFoundation/CMakeLists.txt
+++ b/Sources/CoreFoundation/CMakeLists.txt
@@ -120,6 +120,11 @@ target_link_libraries(CoreFoundation
         _FoundationICU
         dispatch)
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+    # CFLog calls __android_log_print, which lives in liblog.
+    target_link_libraries(CoreFoundation PRIVATE log)
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL "WASI")
     # On WASI, we use vendored BlocksRuntime instead of the one from libdispatch
     add_subdirectory(BlockRuntime)


### PR DESCRIPTION
The Windows toolchain build now always has a swift-driver build, unblocking enabling CMP0157 on every platform.

### Motivation:

CMP0157 should be enabled as CMake eventually removes old policies support.

### Modifications:

* Always set CMP0157 to NEW.
* Explicitly link `liblog.so`, as is done in the SPM build since #5144. This is necessary because enabling CMP0157 brings linker flags to this build, like `--no-undefined`. Previously, this resulted in `__android_log_print` being carried as `UND` in `libFoundation.so`. This was not a problem at runtime because Android loads `liblog.so` in almost every process but it should be fixed for correctness.

### Result:

* Incremental builds are better supported in this project.
* `libFoundation.so` now explicitly links `liblog.so`.

### Testing:

* Local toolchain build with the changes + toolchain build on CI.