### PR TITLE
Accept HTTP response headers without whitespace after the colon

### DIFF
--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPMessage.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPMessage.swift
@@ -398,14 +398,10 @@ private extension _HTTPURLProtocol._HTTPMessage._Header {
         let name = String(headView[nameRange])
         var value: String?
         let line = headView[headView.index(after: nameRange.upperBound)..<headView.endIndex]
-        if !line.isEmpty {
-            if line.hasSPHTPrefix && line.count == 1 {
-                // to handle empty headers i.e header without value
-                value = ""
-            } else {
-                guard let v = line.trimSPHTPrefix else { return nil }
-                value = String(v)
-            }
+        if line.hasSPHTPrefix {
+            value = line.trimSPHTPrefix.map { String($0) } ?? ""
+        } else {
+            value = String(line)
         }
         do {
             var t = tail

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -772,6 +772,15 @@ public class TestURLSessionServer: CustomStringConvertible {
             return try _HTTPResponse(response: .OK, body: text)
         }
 
+        if uri == "/response-header-without-whitespace" {
+            let body = "Hello, world!"
+            return try _HTTPResponse(
+                response: .OK,
+                headers: "Content-Length:\(body.utf8.count)\r\nContent-Type:text/plain",
+                body: body
+            )
+        }
+
         if uri == "/requestHeaders" {
             let text = request.getCommaSeparatedHeaders()
             return try _HTTPResponse(response: .OK, body: text)

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -58,6 +58,16 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         await dataTaskWithURLCompletionHandler(with: session)
     }
 
+    func test_dataTaskAcceptsResponseHeaderValueWithoutWhitespace() async throws {
+        let url = try XCTUnwrap(URL(string: "http://127.0.0.1:\(TestURLSession.serverPort)/response-header-without-whitespace"))
+        let (data, response) = try await URLSession.shared.data(from: url)
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), "Hello, world!")
+        XCTAssertEqual(httpResponse.value(forHTTPHeaderField: "Content-Length"), "13")
+        XCTAssertEqual(httpResponse.value(forHTTPHeaderField: "Content-Type"), "text/plain")
+    }
+
     func dataTaskWithURLCompletionHandler(with session: URLSession) async {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/USA"
         let url = URL(string: urlString)!


### PR DESCRIPTION
Accept HTTP response header field values that do not begin with whitespace.

### Motivation:

[RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5) defines a field line as:

```
field-name ":" OWS field-value OWS
```

Because OWS may contain zero characters, both `Content-Type: text/plain` and `Content-Type:text/plain` are valid.

FoundationNetworking currently calls `trimSPHTPrefix` unconditionally when parsing a non-empty field value. That helper returns `nil` if the value does not begin with a space or horizontal tab, causing the entire HTTP response parser to abort for valid headers without whitespace after the colon.

On Android, this causes URLSession requests to fail with `NSURLErrorDomain Code=-1` and libcurl's `Failure writing output to destination` when a valid server response contains headers such as `Content-Length:13`.

### Modifications:

- Preserve header values that do not begin with whitespace.
- Continue trimming leading spaces and horizontal tabs when present.
- Add a loopback HTTP response containing `Content-Length:13` and `Content-Type:text/plain`.
- Add a URLSession regression test verifying that the response body and header fields are received successfully.

### Result:

FoundationNetworking accepts valid HTTP response headers regardless of whether optional whitespace is present after the colon.

### Testing:

- Reproduced the failure on aarch64 Android with the Swift 6.3.2 SDK.
- Added `test_dataTaskAcceptsResponseHeaderValueWithoutWhitespace`.
- `git diff --check` passes.
- Test execution is pending upstream Linux CI. A clean `main` checkout currently fails earlier in unrelated CoreFoundation/ICU compilation with the available macOS Swift 6.3.2 toolchains.

### Backport:

This appears to be a good candidate for consideration for the Swift 6.3 release branch:

- The affected parser is used on non-Darwin platforms.
- The behavior reproduces with the Swift 6.3.2 Android SDK.
- The same parser logic remains in the Swift 6.3.3 source tag.
- The fix is narrowly scoped and covered by a regression test.

If the change is accepted on `main`, I would be happy to prepare the `release/6.3` backport PR.
