### PR TITLE
[6.3] Accept HTTP header values without leading whitespace

### DIFF
--- a/Sources/FoundationNetworking/URLSession/HTTP/HTTPMessage.swift
+++ b/Sources/FoundationNetworking/URLSession/HTTP/HTTPMessage.swift
@@ -398,14 +398,10 @@ private extension _HTTPURLProtocol._HTTPMessage._Header {
         let name = String(headView[nameRange])
         var value: String?
         let line = headView[headView.index(after: nameRange.upperBound)..<headView.endIndex]
-        if !line.isEmpty {
-            if line.hasSPHTPrefix && line.count == 1 {
-                // to handle empty headers i.e header without value
-                value = ""
-            } else {
-                guard let v = line.trimSPHTPrefix else { return nil }
-                value = String(v)
-            }
+        if line.hasSPHTPrefix {
+            value = line.trimSPHTPrefix.map { String($0) } ?? ""
+        } else {
+            value = String(line)
         }
         do {
             var t = tail

--- a/Tests/Foundation/HTTPServer.swift
+++ b/Tests/Foundation/HTTPServer.swift
@@ -772,6 +772,15 @@ public class TestURLSessionServer: CustomStringConvertible {
             return try _HTTPResponse(response: .OK, body: text)
         }
 
+        if uri == "/response-header-without-whitespace" {
+            let body = "Hello, world!"
+            return try _HTTPResponse(
+                response: .OK,
+                headers: "Content-Length:\(body.utf8.count)\r\nContent-Type:text/plain",
+                body: body
+            )
+        }
+
         if uri == "/requestHeaders" {
             let text = request.getCommaSeparatedHeaders()
             return try _HTTPResponse(response: .OK, body: text)

--- a/Tests/Foundation/TestURLSession.swift
+++ b/Tests/Foundation/TestURLSession.swift
@@ -58,6 +58,16 @@ final class TestURLSession: LoopbackServerTest, @unchecked Sendable {
         await dataTaskWithURLCompletionHandler(with: session)
     }
 
+    func test_dataTaskAcceptsResponseHeaderValueWithoutWhitespace() async throws {
+        let url = try XCTUnwrap(URL(string: "http://127.0.0.1:\(TestURLSession.serverPort)/response-header-without-whitespace"))
+        let (data, response) = try await URLSession.shared.data(from: url)
+        let httpResponse = try XCTUnwrap(response as? HTTPURLResponse)
+
+        XCTAssertEqual(String(decoding: data, as: UTF8.self), "Hello, world!")
+        XCTAssertEqual(httpResponse.value(forHTTPHeaderField: "Content-Length"), "13")
+        XCTAssertEqual(httpResponse.value(forHTTPHeaderField: "Content-Type"), "text/plain")
+    }
+
     func dataTaskWithURLCompletionHandler(with session: URLSession) async {
         let urlString = "http://127.0.0.1:\(TestURLSession.serverPort)/USA"
         let url = URL(string: urlString)!


### PR DESCRIPTION
- **Explanation**: Backports #5527. `FoundationNetworking` currently rejects valid HTTP response fields when the field value begins immediately after the colon, such as `Content-Type:text/plain`. Accept the value and continue trimming optional leading spaces and tabs when present.
- **Scope**: Non-Darwin `FoundationNetworking` HTTP response parsing. The change also adds a loopback `URLSession` regression test.
- **Issues**: HTTP requests can fail before delivering the response when a server omits optional whitespace after the response-header colon.
- **Original PRs**: #5527
- **Risk**: Low. The parser is relaxed to accept RFC-valid zero whitespace while preserving the existing behavior for spaces, tabs, and empty values.
- **Testing**: The original PR passed upstream CI and includes a focused loopback regression test. The cherry-pick applies cleanly to `release/6.3`. A local macOS run with Swift 6.3.2 was blocked before test execution by the branch's existing `Sources/Testing/Testing.swift` compile error (`cannot find 'exit' in scope`); release-branch CI is requested.
- **Reviewers**: @xbhatnag
